### PR TITLE
fix(lifecycle): place --patch before --profile for dsh 0.1.x launcher flags

### DIFF
--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -557,9 +557,12 @@ export async function ensureWebHost(cfg) {
   const patchArgs = patchFiles.flatMap((p) => ["--patch", p]);
   // 四段 cordis 插件均以包名注册，spawn 前确保 junction 就绪（幂等）
   ensureCordisJunctions(dshHome);
+  // launcher flag（--profile/--patch）必须位于应用参数（--port）之前；且 --patch 是
+  // 顶层 dsh 选项，必须位于 --profile 之前（dsh 0.1.x：--profile 之后的参数视为
+  // web app 参数，--patch 会被 web app 拒为 unknown option）
   const child = spawn(
     ELECTRON_NODE,
-    [cliBin, "--profile", "web", ...patchArgs, "--port", String(port)],
+    [cliBin, ...patchArgs, "--profile", "web", "--port", String(port)],
     {
       cwd: cfg.dataDir,
       stdio: ["ignore", "pipe", "pipe"],


### PR DESCRIPTION
## 问题

在 macOS + dsh 0.1.1-rc.2 环境下，插件拉起 web host 时 `dsh` 报错：

```
error: unknown option '--patch'
```

web host 启动失败，dsh-hana-provider / dsh-hana-settings 等 cordis 插件永远无法加载。

## 根因

`src/lifecycle.js` 里 spawn 命令是：

```js
[cliBin, "--profile", "web", ...patchArgs, "--port", String(port)]
```

即 `--patch` 放在 `--profile web` **之后**。但 dsh 0.1.x 的 CLI 解析中，`--profile` 之后的参数全部视为 **web app 的参数**（顶层 launcher flag 必须在前），所以 `--patch` 被 web app 拒为 unknown option。

## 修复

把 `--patch` 移到 `--profile` 之前：

```js
[cliBin, ...patchArgs, "--profile", "web", "--port", String(port)]
```

## 验证

- 修复前：`dsh --profile web --patch x.yml --port 3080` → `unknown option '--patch'`
- 修复后：`dsh --patch x.yml --profile web --port 3080` → web host 正常启动，patch 生效（5 个 dsh-hana-* 插件全部加载，provider 自动同步成功：`provider push 成功（4 条 routes / 11 个模型）`）

已在本地 macOS (Apple Silicon) + dsh 0.1.1-rc.2 完整验证。