### PR TITLE
feat: dsh 内部偏好实时化

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -37,7 +37,7 @@ DSHana 标签内 dsh 主题与宿主 Hana 联动：
 3. **覆盖范围**：72 个 `--dsw-alias-*` + `--dsw-specific-*` token（bg 层次/遮罩/文字/brand/button/border/interactive/markdown/state/组件专用/滚动条），功能性颜色保留原生（照片查看器黑底、danger·warn 语义色、按钮反白文字、toast·tooltip 深色浮层、工具栏半透明、骨架屏、反白边框）
 4. **分发**：cordis 插件经 dsh-host-webserver `tapIndex` 注入 index 响应；插件本体在安装目录 `dsh-plugin/dsh-hana-theme/`（包名 `dsh-hana-theme` 注册，dsh-run.js 启动前在 `$DSH_HOME/profiles/node_modules` 建 junction 指向安装目录，与四内嵌插件（logger/theme/provider/settings）统一机制）
 
-**生效时机**：宿主切 Hana 主题后，壳页接宿主 `hana.theme.changed` 广播**实时跟随**，无需重开标签页（webui-shell 主题桥按新 cssUrl 换 link 重读变量，宿主新增/修改主题零适配）。用户切 dsh 偏好（`system`/`light`/`dark`）不触发宿主广播，仍在 dsh 侧处理，**重开标签页生效**。
+**生效时机**：宿主切 Hana 主题后，壳页接宿主 `hana.theme.changed` 广播**实时跟随**，无需重开标签页（webui-shell 主题桥按新 cssUrl 换 link 重读变量，宿主新增/修改主题零适配）。用户切 dsh 偏好（`system`/`light`/`dark`）现也**实时生效**——dsh-hana-theme 注入脚本经 `/api/events.host` WebSocket 订阅 dsh 自身 `settings/document-updated` 变更广播（`ui-theme` namespace），偏好一变即回读 `pref` 并重跑 `applyOrRemove()`，无需重开标签页。
 
 ### DSHana 设置分页（v0.9.5 默认模型 → v0.13.0 改名升级）
 
@@ -140,7 +140,7 @@ dsh 的 `/api/events.mux` **要求 WebSocket 升级**：GET 返回 `426 Upgrade 
 ## 已知限制
 
 - **bash 工具在 Windows 上可能 `E_ACCESSDENIED`**（dsh-bash-sandbox 创建 bash 服务实例失败，属 dsh 沙箱环境限制，非本插件问题）。文件系统工具（write/read/edit）在 workspace-write 沙箱下工作正常，Windows 上优先用文件系统工具
-- **主题跟随**：DSHana 标签内，dsh 偏好 `system`（默认）→ 跟随 Hana 当前主题（明暗 + 配色）；`light`/`dark` → dsh 内置原生配色。宿主切 Hana 主题后壳页接 `hana.theme.changed` 广播**实时跟随**（无需重开标签页）；用户切 dsh 偏好仍**重开标签页生效**（主题 CSS 打开时拉取一次）
+- **主题跟随**：DSHana 标签内，dsh 偏好 `system`（默认）→ 跟随 Hana 当前主题（明暗 + 配色）；`light`/`dark` → dsh 内置原生配色。宿主切 Hana 主题后壳页接 `hana.theme.changed` 广播**实时跟随**（无需重开标签页）；用户切 dsh 偏好也**实时生效**（dsh-hana-theme 注入脚本经 `/api/events.host` WebSocket 订阅 `settings/document-updated` 的 `ui-theme` 变更，回读 pref 并重跑 applyOrRemove）
 - 越界权限请求默认走审批自动化：插件捕获 approval/requested → deferred 通知 Agent → `dsh_approve` 应答；无人应答超时自动拒绝，兜底 dsh Web UI 人工审批
 - **同步模式（wait=true）无审批通知**：同步调用时 Agent 在等结果，审批挂起只能靠 dsh Web UI 人工处理（或超时）。长任务建议用异步模式
 - 默认每个任务新建独立 session；传 `sessionId` 可复用已有会话（resume，跨任务继承上下文）

--- a/dsh-plugin/dsh-hana-theme/index.js
+++ b/dsh-plugin/dsh-hana-theme/index.js
@@ -9,8 +9,10 @@
 //     theme.css 变量生效，getComputedStyle 读到当前主题 16 个变量的渲染值。
 //     随宿主更新：宿主切主题 → dataset.theme 变 → 插件 iframe 重载 → 壳桥
 //     回传新值；宿主新增/修改主题无需插件更新（无静态主题表）。
-// 边界：dsh preference 加载时读一次 settings.describe（不轮询）——
-//   system → 覆盖 Hana 配色；light/dark → 完全原生。重开标签页生效。
+// 边界：dsh preference 经 settings.describe 读取一次，并监听 dsh 自身的 settings
+//   变更广播（`settings/document-updated`，经 /api/events.host WebSocket 下发，
+//   参数 [ns, revision]）在偏好变化时实时回读 pref 并重跑 applyOrRemove——
+//   无需重开标签页。system → 覆盖 Hana 配色；light/dark → 完全原生。
 //
 // 机制：经 dsh-host-webserver 的 tapIndex 扩展点，向每个 index 响应注入：
 //   1) 静态 <style>：无脚本/桥失败时的默认主题 fallback
@@ -183,22 +185,58 @@ const BRIDGE = `<script id="dsh-hana-theme-bridge">
       }
     }
   });
-  fetch("/api/settings.describe", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ type: "client-request", rpcId: "theme-pref-" + Date.now(), method: "settings.describe", payload: {} })
-  })
-    .then(function (r) { return r.json(); })
-    .then(function (d) {
-      var ns = d && d.result && d.result.value && d.result.value.namespaces;
-      if (Array.isArray(ns)) {
-        for (var i = 0; i < ns.length; i++) {
-          if (ns[i] && ns[i].ns === "ui-theme" && ns[i].value) { pref = ns[i].value.preference || "system"; break; }
-        }
-      }
-      applyOrRemove();
+  // 回读一次 preference 并重跑 applyOrRemove（加载时 + 偏好变更时共用）。
+  function refreshPref() {
+    fetch("/api/settings.describe", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type: "client-request", rpcId: "theme-pref-" + Date.now(), method: "settings.describe", payload: {} })
     })
-    .catch(function () {});
+      .then(function (r) { return r.json(); })
+      .then(function (d) {
+        var ns = d && d.result && d.result.value && d.result.value.namespaces;
+        if (Array.isArray(ns)) {
+          for (var i = 0; i < ns.length; i++) {
+            if (ns[i] && ns[i].ns === "ui-theme" && ns[i].value) { pref = ns[i].value.preference || "system"; break; }
+          }
+        }
+        applyOrRemove();
+      })
+      .catch(function () {});
+  }
+  refreshPref();
+  // 偏好实时化：dsh 前端写 settings 后，host 经 /api/events.host WebSocket 下发
+  // 'settings/document-updated' 帧（frame.args = [ns, revision]）。本脚本无法访问
+  // dsh 内部 ctx.remote.$on，故同源再开一条 WebSocket 订阅该下行；收到 ui-theme
+  // 变更即回读 pref 并重跑 applyOrRemove（无需重开标签页）。
+  function connectThemePref() {
+    try {
+      var scheme = window.location.protocol === "https:" ? "wss:" : "ws:";
+      var ws = new WebSocket(scheme + "//" + window.location.host + "/api/events.host");
+      ws.onmessage = function (ev) {
+        try {
+          if (typeof ev.data !== "string") return;
+          var env = JSON.parse(ev.data);
+          var frame = env && env.payload;
+          if (frame && frame.type === "host/remote-event" && frame.event === "settings/document-updated") {
+            var args = frame.args || [];
+            if (args[0] === "ui-theme") refreshPref();
+          }
+        } catch (e) { /* 忽略无法解析的帧 */ }
+      };
+      ws.onclose = function () {
+        // dsh 会自行重建下行；脚本侧温和重连（指数退避封顶），失败过多则安静停住，
+        // 依赖加载时读一次兜底，不阻断主题功能。
+        if (reconnectAttempts < 10) {
+          reconnectAttempts += 1;
+          setTimeout(connectThemePref, Math.min(1000 * Math.pow(2, reconnectAttempts), 30000));
+        }
+      };
+      ws.onerror = function () { /* 后面 onclose 会接手重连 */ };
+    } catch (e) { /* 无 WebSocket/连接失败时维持加载时读一次的语义 */ }
+  }
+  var reconnectAttempts = 0;
+  connectThemePref();
   var mq = window.matchMedia && matchMedia("(prefers-color-scheme: dark)");
   if (mq && mq.addEventListener) mq.addEventListener("change", ask);
   // 竞态修复：壳页（宿主 iframe 外层）主题桥的注册可能与 dsh 页面加载不同步——脚本加载时

--- a/skills/dsh-hanako/SKILL.md
+++ b/skills/dsh-hanako/SKILL.md
@@ -120,7 +120,7 @@ dsh 请求越界权限时任务挂起，插件经 deferred 发 dsh-approval 通�
 
 ## 已知限制
 
-- 主题跟随：system 跟随宿主，light/dark 原生；宿主切 Hana 主题后壳页接 `hana.theme.changed` 广播**实时跟随**（无需重开），切 dsh 偏好仍**重开标签页生效**
+- 主题跟随：system 跟随宿主，light/dark 原生；宿主切 Hana 主题后壳页接 `hana.theme.changed` 广播**实时跟随**（无需重开），切 dsh 偏好也**实时生效**（经 `/api/events.host` WS 订阅 `settings/document-updated` 的 `ui-theme` 变更）
 - bash 在 Windows 可能 E_ACCESSDENIED（dsh 沙箱限制）；文件工具正常，Windows 优先用
 - wait=true 同步模式无审批通知（只能 Web UI 或超时）；长任务建议异步
 - 越界权限默认走审批：deferred 通知 → dsh_approve 应答；30s 超时自动拒绝


### PR DESCRIPTION
feat: dsh 内部偏好实时化——注入脚本经 /api/events.host WS 订阅 settings/document-updated，切偏好免重开标签页；跟注 DESIGN/SKILL