### PR TITLE
fix: web host spawn 注入 --expose-internals，绕开 macOS arm64 原生 addon 崩溃

### DIFF
--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -601,9 +601,16 @@ export async function ensureWebHost(cfg) {
   // launcher flag（--profile/--patch）必须位于应用参数（--port）之前；且 --patch 是
   // 顶层 dsh 选项，必须位于 --profile 之前（dsh 0.1.x：--profile 之后的参数视为
   // web app 参数，--patch 会被 web app 拒为 unknown option）
+  // --expose-internals 是 node 运行时 flag，必须置于 cliBin 之前（node --expose-internals <cliBin> …）。
+  // HMR 服务需要 Node 内部 ESM loader：上游 drop 该 flag 后改走原生 addon 兜底
+  // （require('node-addon-require-builtin')），但该 addon 在 macOS arm64 上加载失败
+  // （node-addon-require-builtin: Unsupported/no-getter (arm64 …)），导致 `dsh web` boot 崩溃。
+  // 显式注入 flag 切到 require('internal/modules/esm/loader') 直连路径，绕开崩溃 addon；
+  // Windows x64 等其余平台走直连同样成立、行为不变（Hana 内置 node 24.15，v2 loader）。
   const child = spawn(
     ELECTRON_NODE,
     [
+      "--expose-internals",
       cliBin,
       ...patchArgs,
       "--profile",


### PR DESCRIPTION
## 背景

deepseek-harness 讨论 #113（macOS arm64 上 \
px/bunx @deepseek-ai/dsh web\ 直接崩溃）：

- HMR 服务需要 Node 内部 ESM loader，只能经 \--expose-internals\ 获得
- 上游 drop 该 flag 后改走原生 addon 兜底（\
ode-addon-require-builtin\），但该 addon 在 macOS arm64 上加载失败（\Unsupported/no-getter (arm64 …)\）
- bun 无 \internal/modules/esm/loader\，bunx 必败

## 改动

在插件拉起 web host 的 spawn 参数里显式注入 \--expose-internals\（置于 cliBin 之前）。

- 切到 \equire('internal/modules/esm/loader')\ 直连路径，绕开崩溃的 arm64 addon
- Windows x64 等其余平台走直连同样成立、行为不变
- Hana 内置 node 24.15（≥22），module loader v2 直连路径成立

无需 bump（纯行为修正，无版本/产物变化）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application startup on macOS arm64 by preventing a native module loading crash.
  * Enabled the appropriate module-loading path across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->