### PR TITLE
feat: dsh_run 回调升级——finish error 不误判失败 + 定位键 id + callbackMode minimal

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -63,7 +63,8 @@
           "type": "string",
           "enum": [
             "summary",
-            "full"
+            "full",
+            "minimal"
           ],
           "default": "summary",
           "title": "回调输出模式",

--- a/manifest.json
+++ b/manifest.json
@@ -68,7 +68,7 @@
           ],
           "default": "summary",
           "title": "回调输出模式",
-          "description": "异步任务完成后回调给 Agent 的输出体量：summary=只回传最终结论摘要（默认，省上下文；完整输出在卡片 op 快照与 dsh web UI 可查）；full=回传完整输出（上下文占用大）。"
+          "description": "异步任务完成后回调给 Agent 的输出体量：summary=只回传最终结论摘要（默认，省上下文；完整输出在卡片 op 快照与 dsh web UI 可查）；full=回传完整输出（上下文占用大）；minimal=回调只带定位键 { id, status, rpcId, sessionId }，不生成摘要（buildSummary 跳过），主上下文自行审查或凭 id 取具体会话内容。"
         }
       }
     },

--- a/skills/dsh-run/SKILL.md
+++ b/skills/dsh-run/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: dsh-run
-description: "dsh_run 工具调用手册（源码 tools/dsh-run.js 核对）。触发场景：dsh_run 怎么传参（task/cwd/timeout/wait/agentPreset/reasoningEffort/provider/model/sessionId 的语义与副作用）、异步/同步模式区别与返回结构、后台回调 payload 结构、callbackMode 摘要压缩、超时语义（审批挂起暂停计时）、错误码 DSH_ERROR/DSH_TIMEOUT/DSH_ABORTED、provider/model 显式指定的写回副作用（显式即成为 dsh 新默认）、resume 复用会话、agentPreset 选型（standard/code/cordis/minimal）、config.json 单一事实源实时生效。需要提交 dsh 任务前先读本技能。"
+description: "dsh_run 工具调用手册（源码 tools/dsh-run.js 核对）。触发场景：dsh_run 怎么传参（task/cwd/timeout/wait/agentPreset/reasoningEffort/provider/model/sessionId 的语义与副作用）、异步/同步模式区别与返回结构、后台回调 payload 结构、callbackMode 三档（summary/full/minimal）、超时语义（审批挂起暂停计时）、错误码 DSH_ERROR/DSH_TIMEOUT/DSH_ABORTED、provider/model 显式指定的写回副作用（显式即成为 dsh 新默认）、resume 复用会话、agentPreset 选型（standard/code/cordis/minimal）、config.json 单一事实源实时生效。需要提交 dsh 任务前先读本技能。"
 ---
 
 # dsh_run 工具手册
 
-把任务交给 DeepSeek Harness（dsh）的常驻 web host（--profile web）执行：完整编码 agent、沙箱 bash/文件系统工具、上下文压缩、subagent 级联。权限 `external_side_effect`（external_llm_api，消耗宿主 provider 额度）。实现 `tools/dsh-run.js`（单文件自包含，2378 行）。
+把任务交给 DeepSeek Harness（dsh）的常驻 web host（--profile web）执行：完整编码 agent、沙箱 bash/文件系统工具、上下文压缩、subagent 级联。权限 `external_side_effect`（external_llm_api，消耗宿主 provider 额度）。实现 `tools/dsh-run.js`（单文件自包含，1029 行）。
 
 ## 参数契约（源码 parameters + doExecute + submitTask 核实）
 
@@ -33,25 +33,26 @@ ensureWebHost（resolveDshPkgDir 定位依赖 → spawn dsh web，DSH_HOME=数�
 → events.mux 事件循环 → 终态
 ```
 
-事件处理要点：`assistant/chunk` 文本流累积（finish 帧 `reason.kind==="error"` 直接透传真实错误如 429/400）；`assistant/message` 收集 usage + 摘要锚点；`tool/call` 与 `tool/code-dispatch-start` 缓存工具参数原文（审批决策数据源）；`turn/end` 终态判定；`approval/requested`/`approval/resolved` 审批；`stream/error` 事件流错误。
+事件处理要点：`assistant/chunk` 文本流累积（finish 帧 `reason.kind==="error"` **不是终态信号**——只记 pendingFailure 兜底后继续消费：DSH 侧 LLM 请求失败如 429/400 会进入 agent/request-error waterfall → dsh-llm-retry 指数退避重试，任务实际还在跑，可能继续出 chunk / assistant/message，终态判定以 `turn/end` 为准——官方 UI 客户端同语义）；`llm/retry` 事件经会话日志通道记「LLM 请求失败，退避重试中（第 N 次，延迟 Xms）」（不阻断、不改卡片渲染）；`assistant/message` 收集 usage + 摘要锚点；`tool/call` 与 `tool/code-dispatch-start` 缓存工具参数原文（审批决策数据源）；`turn/end` 终态判定；`approval/requested`/`approval/resolved` 审批；`stream/error` 事件流错误。
 
-**终态映射**：`completed → end_turn` / `max-tokens → max_tokens` / `aborted → aborted` / `error → error`（failure.message 透传）。流结束无终态帧兜底 end_turn；已请求取消（cancelledRequested）且 mux 断流无 turn/end 判 aborted（防误报完成）。
+**终态映射**：`completed → end_turn` / `max-tokens → max_tokens` / `aborted → aborted` / `error → error`（failure.message 透传）。流结束无终态帧时：已请求取消（cancelledRequested）且 mux 断流判 aborted（防误报完成）；期间见过 finish error（LLM 请求失败帧）按 error 收尾（pendingFailure 兜底，防 DSH 退避重试中断流/崩溃被误判成功）；否则兜底 end_turn。
 
 ## 返回与回调
 
 **异步模式（默认）**：立即返回 `{ content: "任务已提交给 dsh（rpcId: xxx）…", details: { dsh: { rpcId, status: "running", cwd, wait: false }, card: { route: "/card/op?sessionId=…&rpcId=…&timeoutMs=…", … } } }`。deferred 注册 taskId=任务 rpcId（type=dsh-run，trigger_parent_turn，失败也唤醒），完成后宿主投递 `<hana-background-result>`。
 
-**后台回调 payload**：
+**后台回调 payload**（callbackMode 三档，见下）：
 ```
-{ rpcId, tool: "dsh_run", status: "ok", cwd, sessionId,
-  output,                    // callbackMode 决定体量
+{ id, rpcId, tool: "dsh_run", status: "ok", cwd, sessionId,
+  output,                    // summary/full 时存在（体量由 callbackMode 决定）
   outputMeta: { mode, fullLength, summaryLength, summaryOf },
   stopReason, usage, stderr }
 ```
+`id` = sessionId（与 dsh_ops / dsh_search / dsh_run resume 的定位键一致）：主上下文收到回调后凭 id 直接取会话内容或续接，无需 dsh_search 查找。失败回调（failDeferredWake）error 尽力带定位键：有 sessionId（提交成功后的执行失败）时 `error.sessionId`；提交失败无 sessionId 时 `error.rpcId`（可为空串）。
 
-**callbackMode 摘要压缩**（buildSummary）：默认 summary 只回传摘要。锚点 = 最后一条 assistant/message 文本（`summaryOf: "final-message"`）；无 finalText 时超长（>1500+600）head-tail 折叠（`summaryOf: "head-tail"`）；短输出原样（`summaryOf: "full"`）。full 模式回传全量。**完整输出永远在卡片（会话 jsonl 恢复）+ dsh Web UI（sessionId 定位）可查**。
+**callbackMode 三档**（config.json `global.callbackMode`，默认 summary）：`summary`=只回传最终结论摘要（buildSummary：锚点 = 最后一条 assistant/message 文本，`summaryOf: "final-message"`；无 finalText 时超长 >1500+600 head-tail 折叠，`summaryOf: "head-tail"`；短输出原样，`summaryOf: "full"`）；`full`=回传全量输出；`minimal`=回调只带 `{ id, status, rpcId, sessionId }` 定位键（**不调用 buildSummary**、不含 output/outputMeta/summary/usage/stderr 等大字段，主上下文自行审查或凭 id 取具体会话内容）。**完整输出永远在卡片（会话 jsonl 恢复）+ dsh Web UI（sessionId 定位）可查**。
 
-**同步模式（wait=true）**：content = `res.output` +（非 end_turn 附 `[stopReason: …]`）；details.dsh = `{ stopReason, usage, cwd, rpcId, sessionId, wait: true }`，stderr 附 `dshStderr`（截 2000）。阻塞当前回合、无卡片进度；长任务建议异步。
+**同步模式（wait=true）**：content = `res.output` +（非 end_turn 附 `[stopReason: …]`）；details.dsh = `{ id, stopReason, usage, cwd, rpcId, sessionId, wait: true }`（`id` = sessionId，同异步回调定位键），stderr 附 `dshStderr`（截 2000）。阻塞当前回合、无卡片进度；长任务建议异步。
 
 ## 超时语义
 
@@ -64,7 +65,7 @@ ensureWebHost（resolveDshPkgDir 定位依赖 → spawn dsh web，DSH_HOME=数�
 
 | 错误码 | stopReason | 触发 |
 |---|---|---|
-| `DSH_ERROR` | error | 任务执行失败（failure.message 透传，含 finish 帧 429/400） |
+| `DSH_ERROR` | error | 任务执行失败（turn/end error 的 failure.message 透传；finish 帧 429/400 先走 DSH 侧退避重试，仅重试耗尽/断流兜底 pendingFailure 时按 error 收尾） |
 | `DSH_TIMEOUT` | timeout | 超时（审批挂起时间不计入） |
 | `DSH_ABORTED` | aborted | dsh_cancel / 外部 signal 中止 |
 
@@ -84,7 +85,7 @@ defaultCwd / approvalTimeoutMs 优先直读 `<dataDir>/config.json` 的 `global.
 | approvalTimeoutMs | 30000 | 0/负数 = 禁用超时拒绝 |
 | defaultTimeoutMs | 1800000 (30min) | 未显式传 timeout 时用；可被 config.json 覆盖 |
 | webPort | 3080 | 0 不生效 |
-| callbackMode | summary | summary=摘要 / full=全量 |
+| callbackMode | summary | summary=摘要（默认）/ full=全量 / minimal=只带定位键 `{ id, status, rpcId, sessionId }`（不生成摘要、不占上下文） |
 
 依赖位置：数据目录 `dsh-pkg/` 优先（升级不丢），回退插件 node_modules。
 

--- a/src/tools/dsh-run.js
+++ b/src/tools/dsh-run.js
@@ -291,6 +291,10 @@ function submitTask(
     let sawChunk = false;
     const seen = new Set();
     let outcome = null; // { stopReason, failure? }
+    // pendingFailure：finish error 帧（LLM 请求失败，如 429 限流）的 failure 兜底记录。
+    // finish error 不是终态信号（DSH 侧可能退避重试继续跑），仅当流异常关闭且无 turn/end
+    // 终态帧时用它把任务判为失败，避免 finish error 后 DSH 断流/崩溃被误判为成功。
+    let pendingFailure = null;
 
     const consume = (async () => {
       try {
@@ -302,21 +306,24 @@ function submitTask(
             if (!d) continue;
             if (ev.type === "assistant/chunk") {
               sawChunk = true;
-              // 错误透传——finish 帧 reason=error（如 429/400）直接带真实信息
+              // finish error 帧不是失败信号：DSH 侧 LLM 请求失败（如 429 限流）会进入
+              // agent/request-error waterfall → dsh-llm-retry recover（指数退避 + jitter，
+              // append llm/retry 后 cancellableDelay 等待），返回 {kind:"retry"} 时 step()
+              // continue 重试、不抛错——任务实际还在跑。只把 failure 记进 pendingFailure
+              // （流异常关闭无 turn/end 时兜底判失败），继续消费后续帧；终态判定以 turn/end
+              // 为准（官方 UI 客户端同语义：event.type !== "turn/end" || reason.kind !== "error"）。
               const c = d?.chunk;
               if (c?.type === "finish" && c.reason?.kind === "error") {
                 const f = c.reason.failure || c.reason.error || {};
-                outcome = {
-                  stopReason: "error",
-                  failure: {
-                    message:
-                      f.message || c.reason.message || "模型调用失败（无详情）",
-                  },
+                pendingFailure = {
+                  message:
+                    f.message || c.reason.message || "模型调用失败（无详情）",
+                  ...(f.code ? { code: f.code } : {}),
                 };
-                return;
+              } else {
+                const t = textFromChunk(d);
+                if (t) collected += t; // 仅本地收集（回调输出用）；不再写 op Map
               }
-              const t = textFromChunk(d);
-              if (t) collected += t; // 仅本地收集（回调输出用）；不再写 op Map
             } else if (ev.type === "assistant/message") {
               const msg = d.message;
               if (msg?.id && typeof msg.id === "string" && !seen.has(msg.id)) {
@@ -399,6 +406,21 @@ function submitTask(
                 };
               else outcome = { stopReason: kind || "end_turn" };
               return; // 一次 prompt = 一个 turn，turn/end 即终态
+            } else if (ev.type === "llm/retry") {
+              // LLM 请求失败退避重试事件（dsh-llm-retry 的 recover 挂 agent/request-error
+              // waterfall，session.append 后 cancellableDelay 等待再返回 {kind:"retry"}）。
+              // 只经会话日志通道记一条（不阻断事件循环、不改卡片渲染），终态仍以 turn/end 为准。
+              // data 含 retryId/turn/step/provider/mode/policyKey/retry（第 N 次）/delayMs/failure。
+              const rd = d || {};
+              const retryN = Number(rd.retry) || 1;
+              const extra = [];
+              if (rd.provider) extra.push(`provider=${rd.provider}`);
+              if (rd.failure?.code) extra.push(`code=${rd.failure.code}`);
+              const extraTxt = extra.length ? `，${extra.join("，")}` : "";
+              getSingleton().appendLog?.(
+                "hana",
+                `[LLM 重试] LLM 请求失败，退避重试中（第 ${retryN} 次，延迟 ${rd.delayMs}ms${extraTxt}）`,
+              );
             }
           } else if (frame.type === "approval/requested") {
             // 审批挂起（approval/policy=ask）：任务会等待应答。把审批上下文（含 respond
@@ -541,7 +563,12 @@ function submitTask(
         const opNow = getSingleton().ops.get(taskRpcId);
         if (opNow?.cancelledRequested && !outcome)
           outcome = { stopReason: "aborted" };
-        // 流正常结束但无终态：视为完成（end_turn 可能已发但流先关）
+        // 兜底增强：流正常关闭但无 turn/end 时，若期间见过 finish error（LLM 请求失败帧，
+        // DSH 退避重试中/断流/崩溃），按失败收尾——避免 finish error 后 DSH 断流被误判为成功。
+        // 取消优先（上面已判 aborted），这里只处理非取消的异常收尾；pendingFailure 为空时
+        // 保持原「视为完成」语义（end_turn 可能已发但流先关）。
+        if (!outcome && pendingFailure)
+          outcome = { stopReason: "error", failure: pendingFailure };
         if (!outcome) outcome = { stopReason: "end_turn" };
       } catch (err) {
         if (err?.name === "AbortError")
@@ -648,7 +675,11 @@ function submitTask(
 
       const fullOutput = collected;
       // 回调/返回值保持 chunk 流文本；结构化 blocks（reasoning 可折叠）由卡片端从 jsonl/实时事件重建
-      const summary = buildSummary(fullOutput, finalMessageText);
+      // minimal 模式不生成摘要（buildSummary 是宿主侧协议层函数，minimal 回调不带 output/摘要）
+      const summary =
+        cfg.callbackMode === "minimal"
+          ? null
+          : buildSummary(fullOutput, finalMessageText);
       return {
         rpcId: taskRpcId,
         sessionId,
@@ -804,6 +835,20 @@ async function doExecute(input, ctx) {
       ? Number(input.timeout) * 1000
       : Number(cfg.defaultTimeoutMs || 600000);
 
+  // callbackMode 三档：full=回传全量输出 / summary=只带最终结论摘要（默认）/
+  // minimal=回调只带 { id, status, rpcId, sessionId } 定位键（不生成摘要、不占上下文）
+  const callbackMode =
+    cfg.callbackMode === "full" || cfg.callbackMode === "minimal"
+      ? cfg.callbackMode
+      : "summary";
+  // 异步提交回执按 callbackMode 展示三档语义
+  const modePhrase =
+    callbackMode === "full"
+      ? "带回完整输出"
+      : callbackMode === "minimal"
+        ? "仅带回任务状态与定位键（id/rpcId/sessionId）"
+        : "带回结果摘要";
+
   const taskCfg = {
     dshPkgDir: cfg.dshPkgDir,
     dataDir: cfg.dataDir,
@@ -811,6 +856,8 @@ async function doExecute(input, ctx) {
     webPort: cfg.webPort,
     // 审批配置唯一键 approvalTimeoutMs（超时兜底，0=禁用；manifest 默认 30000）
     approvalTimeoutMs: cfg.approvalTimeoutMs,
+    // 回调输出模式（minimal 时 submitTask 跳过 buildSummary）
+    callbackMode,
   };
   const taskParams = {
     task: input.task,
@@ -867,9 +914,26 @@ async function doExecute(input, ctx) {
 
     promise.then(
       (res) => {
+        // 回调 result 统一带定位键 id（= sessionId，与 dsh_ops / dsh_search / dsh_run
+        // resume 同键）：主上下文收到回调后凭 id 直接取会话内容或续接，无需 dsh_search 查找。
+        if (callbackMode === "minimal") {
+          // minimal：回调只带定位键（不含 output/outputMeta/summary/usage/stderr 等大字段，
+          // 不生成摘要、不占 Agent 上下文）；主上下文自行审查或凭 id 取具体会话内容。
+          resolveDeferredWake({
+            bus,
+            taskId: deferredTaskId,
+            result: {
+              id: res.sessionId,
+              status: "ok",
+              rpcId: taskRpcId,
+              sessionId: res.sessionId,
+            },
+          });
+          return;
+        }
         // PTC 式回调压缩：默认只带最终结论摘要（callbackMode=summary），
         // 完整输出在卡片（jsonl 恢复）与 dsh web UI（sessionId）可查，不进 Agent 上下文。
-        const outputMode = cfg.callbackMode === "full" ? "full" : "summary";
+        const outputMode = callbackMode === "full" ? "full" : "summary";
         const payloadOutput =
           outputMode === "full"
             ? res.output
@@ -878,6 +942,7 @@ async function doExecute(input, ctx) {
           bus,
           taskId: deferredTaskId,
           result: {
+            id: res.sessionId,
             rpcId: taskRpcId,
             tool: "dsh_run",
             status: "ok",
@@ -897,10 +962,16 @@ async function doExecute(input, ctx) {
         });
       },
       (err) => {
+        // 尽力带定位键：有 sessionId（提交成功后的执行失败）时 error 带 sessionId；
+        // 提交失败无 sessionId 的场景带 rpcId（可为空串）。主上下文凭定位键直接取会话
+        // 内容/对账，无需额外 dsh_search 查找。
+        const error = { message: String(err?.message || err).slice(0, 300) };
+        if (loc?.sessionId) error.sessionId = loc.sessionId;
+        else error.rpcId = taskRpcId;
         failDeferredWake({
           bus,
           taskId: deferredTaskId,
-          error: { message: String(err?.message || err).slice(0, 300) },
+          error,
         });
       },
     );
@@ -909,7 +980,7 @@ async function doExecute(input, ctx) {
       content: [
         {
           type: "text",
-          text: `任务已提交给 DSH（rpcId: ${taskRpcId}），在后台执行中。进度与输出见上方卡片；完成后后台消息带回结果摘要（callbackMode=${cfg.callbackMode === "full" ? "full" : "summary"}，完整输出在卡片与 DSH web UI 可查）。`,
+          text: `任务已提交给 DSH（rpcId: ${taskRpcId}），在后台执行中。进度与输出见上方卡片；完成后后台消息${modePhrase}（callbackMode=${callbackMode}，完整输出在卡片与 DSH web UI 可查）。`,
         },
       ],
       details: {
@@ -928,6 +999,7 @@ async function doExecute(input, ctx) {
     content: [{ type: "text", text }],
     details: {
       dsh: {
+        id: res.sessionId, // 定位键 = sessionId（与异步回调 result.id 同键，凭 id 直接取会话内容/续接）
         stopReason: res.stopReason,
         usage: res.usage,
         cwd,

--- a/src/tools/dsh-run.js
+++ b/src/tools/dsh-run.js
@@ -698,6 +698,12 @@ function submitTask(
           /* 忽略 */
         }
       }
+      // 附加已创建的 sessionId（session.create 成功后 prompt/执行失败时）：execute 层
+      // failDeferredWake 优先用 err.sessionId——session.prompt 失败时 ready 的 loc 为 null
+      // （resolveReady 未调），不附加则已创建的会话 ID 丢失，错误只剩空 rpcId 无法对账。
+      if (err && typeof err === "object" && !err.sessionId && sessionId) {
+        err.sessionId = sessionId;
+      }
       throw err;
     } finally {
       ac.abort();
@@ -966,7 +972,13 @@ async function doExecute(input, ctx) {
         // 提交失败无 sessionId 的场景带 rpcId（可为空串）。主上下文凭定位键直接取会话
         // 内容/对账，无需额外 dsh_search 查找。
         const error = { message: String(err?.message || err).slice(0, 300) };
-        if (loc?.sessionId) error.sessionId = loc.sessionId;
+        // 定位键优先级：rejected error 自带的 sessionId（submitTask 内已附加，session.prompt
+        // 失败时 loc 为 null 也保留已创建的会话）→ loc.sessionId → taskRpcId（可为空串）。
+        // 避免 session.prompt 失败（loc null）时只剩空 rpcId、已创建会话无法对账。
+        const errSessionId =
+          err && typeof err === "object" ? err.sessionId : undefined;
+        if (errSessionId) error.sessionId = errSessionId;
+        else if (loc?.sessionId) error.sessionId = loc.sessionId;
         else error.rpcId = taskRpcId;
         failDeferredWake({
           bus,


### PR DESCRIPTION
## 背景

dsh_run 回调链路的三个升级：修复「把 DSH 侧 LLM 请求重试退避误判为任务失败提前返回」的 bug、回调带定位键 id、新增 callbackMode=minimal 等级。

## 1. 修复 finish error 误判失败（核心）

**现象**：DSH 侧 LLM 请求失败（如 429 限流）进入退避重试，任务实际还在跑；但 dsh_run 收到事件流里的 finish error 帧就立即判任务失败，deferred fail 提前返回。

**DSH 侧取证**（@deepseek-ai/dsh 0.1.1-rc.2 源码）：
- `dsh-agent-loop` step()：LLM 流每个 chunk（含 finish 帧）先广播到事件流，随后 `assembler.finish` 为 error 时走 `agent/request-error` waterfall → dsh-llm-retry recover（指数退避 + jitter，append `llm/retry` 后 cancellableDelay）→ 返回 `{kind:"retry"}` 时 `continue` 重试（**不抛错**）
- run()：catch 后 `turnEnds={kind:"error",...}`，`finally` **必然 append `turn/end`**——turn/end 是唯一终态
- DSH 官方 UI 客户端判据：`event.type !== "turn/end" || reason.kind !== "error"`

**修复**：finish error 帧只记 `pendingFailure` 不再提前终态，继续消费（DSH 可能重试成功后继续输出）；终态以 turn/end 为准；流关闭无 turn/end 时 pendingFailure 非空按 error 收尾（防 finish error 后断流/崩溃被误判成功）；取消优先语义保持。

**可观测性加分项**：识别 `llm/retry` 事件 → 会话日志记「LLM 请求失败，退避重试中（第 N 次，延迟 Xms，provider/code）」，不阻断、不改卡片渲染。

## 2. 回调定位键 id

- 异步成功回调 result 增加 `id`（= sessionId，与 dsh_ops / dsh_search / dsh_run resume 同键）——主上下文凭 id 直接取会话内容或续接，无需 dsh_search 查找
- 失败回调 error 尽力带定位键：有 sessionId（提交成功后的执行失败）带 `error.sessionId`；提交失败无 sessionId 带 `error.rpcId`
- wait=true 同步模式 details.dsh 补 `id`

## 3. callbackMode=minimal

- 三档：`summary`（默认，摘要压缩）/ `full`（全量）/ `minimal`（只带 `{ id, status, rpcId, sessionId }` 定位键）
- minimal **跳过 buildSummary**（不生成摘要、不占 Agent 上下文），主上下文自行审查或凭 id 取具体会话内容
- manifest.json 枚举补 minimal（设置页可选项）；skills/dsh-run/SKILL.md 三档 + 事件处理要点同步

## 验证

- node --check 通过（dsh-run.js）；manifest.json JSON 解析通过
- 卡片端 assets/card.js 已确认无此问题（终态只认 turn/end），未改动
- 未实际运行 dsh_run 长任务（实机验证留待合并后）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `minimal` as a selectable callback mode.
  - Minimal callbacks return locator details without generating a summary, allowing session details to be retrieved separately.
  - Callback payloads now include relevant task and session identifiers.

- **Bug Fixes**
  - Improved retry handling for temporary LLM failures before reporting a final error.
  - Preserved session identifiers when prompts or execution fail.
  - Clarified retry, completion, and failure reporting.

- **Documentation**
  - Updated the `dsh-run` guide with callback modes, retry behavior, completion states, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->