### PR TITLE
fix: 收敛 update-request.json——去占位写入 + 完成删文件

### DIFF
--- a/dsh-plugin/@dsh-hanako/settings/client.js
+++ b/dsh-plugin/@dsh-hanako/settings/client.js
@@ -23,7 +23,7 @@
 //   ② DSH 版本卡片：@deepseek-ai/dsh 版本检查与更新（v0.18.1 起检查改 **dsh 侧直查**——
 //      后端 HTTP 直查 npm registry（fetch https://registry.npmjs.org/@deepseek-ai/dsh/latest
 //      的 JSON version 字段，pnpm view 语义等价；官方源失败重试 npmmirror，15s 超时，
-//      v0.18.2 起不再 spawn pnpm），不再经宿主桥接；更新仍写 update-request.json 由宿主
+//      v0.18.2 起不再 spawn pnpm），不再经宿主桥接；更新经反向信道直投宿主
 //      5s 轮询执行）——挂载时自动调一次 POST /api/hana-settings.check-version
 //      （本地版本后端直读 dsh-pkg package.json 零延迟；远端版本后端 HTTP 直查，慢时
 //      返回 pending 由前端轮询兜底），显示本地/最新版本与状态；「检查更新」手动刷新；

--- a/dsh-plugin/@dsh-hanako/settings/index.js
+++ b/dsh-plugin/@dsh-hanako/settings/index.js
@@ -328,9 +328,23 @@ export function apply(ctx, config) {
               }),
               signal: AbortSignal.timeout(5000),
             });
-            const data = await r.json().catch(() => ({}));
-            if (!r.ok || data?.ok === false) {
-              throw new Error(data?.error || `宿主投递失败（HTTP ${r.status}）`);
+            let data = null;
+            try {
+              data = await r.json();
+            } catch {
+              throw new Error(`宿主响应非 JSON（HTTP ${r.status}）`);
+            }
+            if (!r.ok) {
+              throw new Error(
+                (data && typeof data === "object" && data.error) ||
+                  `宿主投递失败（HTTP ${r.status}）`,
+              );
+            }
+            if (!data || typeof data !== "object" || data.ok !== true) {
+              throw new Error(
+                (data && typeof data === "object" && data.error) ||
+                  `宿主响应缺少 ok:true（HTTP ${r.status}）`,
+              );
             }
             settingsLog("更新请求已直投宿主（/child/post），将自动执行更新");
             json(res, { ok: true, ...data });

--- a/dsh-plugin/@dsh-hanako/settings/index.js
+++ b/dsh-plugin/@dsh-hanako/settings/index.js
@@ -21,7 +21,7 @@
 //      `https://registry.npmjs.org/@deepseek-ai/dsh/latest`（JSON 的 version 字段，
 //      pnpm view 语义等价；官方源失败重试一次 npmmirror，15s 超时），结果即最新版本，
 //      不再依赖 pnpm。「更新到最新」仍写 { state:'requested' } 到
-//      <dataDir>/update-request.json，宿主 5s 轮询感知后执行完整更新（停 web host →
+//      <dataDir> 经宿主反向信道直投（/child/post，loopbackToken 凭据）触发完整更新（停 web host →
 //      pnpm add @deepseek-ai/dsh latest → 起 web host），结果写
 //      <dataDir>/update-result.json，本插件 update-status 路由读它供前端轮询。
 //
@@ -35,7 +35,7 @@
 //   POST /api/hana-settings.read            → agentDefaultModel.currentSelection()
 //   POST /api/hana-settings.save            → agentDefaultModel.saveSelection(...)
 //   POST /api/hana-settings.check-version   → 本地版本直读 + 远端版本 dsh 侧 HTTP 直查（npm registry）
-//   POST /api/hana-settings.request-update  → 写 <dataDir>/update-request.json（宿主轮询触发更新）
+//   POST /api/hana-settings.request-update  → 直投宿主反向信道（/child/post，触发更新）
 //   POST /api/hana-settings.update-status   → 读 <dataDir>/update-result.json（更新进度/结果）
 // 路由经 webServer.register（kind: exact）注册——webserver 匹配 exact 优先于 apiproxy
 // 的 /api 前缀，冲突只会发生在同 (kind, path) 重复注册（插件重载未清理场景），此时
@@ -57,7 +57,7 @@
 export const name = "@dsh-hanako/settings";
 export const inject = ["webServer", "agentDefaultModel", "hanaLogger"];
 
-import { existsSync, readFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 // ---- 读请求 body（JSON）----
@@ -295,28 +295,45 @@ export function apply(ctx, config) {
           }
         });
 
-        // POST /api/hana-settings.request-update：写更新请求文件（宿主 5s 轮询到后自动
-        // npm i latest + 重启 web host，结果写 update-result.json）
+        // POST /api/hana-settings.request-update：经子插件反向信道直投宿主
+        // （v0.21.2 起替代 update-request.json 文件桥——宿主侧无轮询、无文件）。
+        // 宿主 POST /child/post 受理后执行 npm i latest + 重启 web host，结果写
+        // update-result.json（本插件 update-status 路由读）。hostApi 由宿主 patch
+        // 注入（server-info.json 的 loopbackToken + 端口，过宿主鉴权墙）。
         registerRoute("/api/hana-settings.request-update", async (req, res) => {
           try {
             await readJsonBody(req);
-            const dataDir = cfg.dataDir;
-            if (!dataDir)
-              throw new Error("缺少 dataDir 配置（patch config 未渲染？）");
-            mkdirSync(dataDir, { recursive: true });
-            writeFileSync(
-              join(dataDir, "update-request.json"),
-              JSON.stringify({
-                state: "requested",
-                at: new Date().toISOString(),
-                fromVersion: readLocalVersion(),
+            const hostApi = cfg.hostApi;
+            if (
+              !hostApi ||
+              typeof hostApi.url !== "string" ||
+              typeof hostApi.token !== "string"
+            ) {
+              throw new Error("宿主反向信道未配置（hostApi 缺失）");
+            }
+            const url =
+              hostApi.url +
+              (hostApi.url.includes("?") ? "&" : "?") +
+              "token=" +
+              encodeURIComponent(hostApi.token);
+            const r = await fetch(url, {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({
+                channel: "dsh.update-request",
+                payload: {
+                  at: new Date().toISOString(),
+                  fromVersion: readLocalVersion(),
+                },
               }),
-              "utf8",
-            );
-            settingsLog(
-              "更新请求已写入 update-request.json（宿主轮询将自动执行更新）",
-            );
-            json(res, { ok: true });
+              signal: AbortSignal.timeout(5000),
+            });
+            const data = await r.json().catch(() => ({}));
+            if (!r.ok || data?.ok === false) {
+              throw new Error(data?.error || `宿主投递失败（HTTP ${r.status}）`);
+            }
+            settingsLog("更新请求已直投宿主（/child/post），将自动执行更新");
+            json(res, { ok: true, ...data });
           } catch (e) {
             try {
               settingsLog(`更新请求失败：${e?.message || e}`);

--- a/dsh-plugin/dsh-hanako.patch.yml.tpl
+++ b/dsh-plugin/dsh-hanako.patch.yml.tpl
@@ -24,3 +24,4 @@
       config:
         dshPkgDir: '{{DSH_PKG_DIR}}'
         dataDir: '{{DATA_DIR}}'
+        hostApi: {{DSH_HOST_API}}

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -105,6 +105,7 @@ walk(join(ROOT, "dist"));
 for (const [relPath, name] of Object.entries({
   "routes/webui.js": "webuiRoute",
   "routes/card.js": "cardRoute",
+  "routes/child.js": "childRoute",
 })) {
   const p = join(ROOT, "dist", relPath);
   const shell =

--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,7 @@ import * as dshSearch from "./tools/dsh-search.js";
 // 路由工厂（默认导出）
 import registerWebuiRoutes from "./routes/webui.js";
 import registerCardRoutes from "./routes/card.js";
+import registerChildRoutes from "./routes/child.js";
 
 // 工具清单（registerTool 消费普通契约；宿主自动加 pluginId_ 前缀）
 const HANAKO_TOOLS = [dshRun, dshUpdate, dshInstall, dshApprove, dshCancel, dshOps, dshSearch];
@@ -138,6 +139,7 @@ function compressArchivedLogs(logsDir) {
 // routes 具名导出：dist/routes/*.js 壳 import { webuiRoute } from "../index.js" 转发
 export const webuiRoute = registerWebuiRoutes;
 export const cardRoute = registerCardRoutes;
+export const childRoute = registerChildRoutes;
 
 export default class DshHanakoPlugin {
   async onload() {

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -856,7 +856,7 @@ function ensureProviderPushWatch(cfg) {
 // { state: done|error, version?, error?, at }（dsh 设置页 update-status 路由读）。
 // 并发防护：g.updating 进行中重复调用返回 { ok:false, state:"updating" } 不重复执行；
 // 与 installDepsFromPlugin 内部 g.depsInstalling 独立（本标志管整条更新流程）。----
-export async function updateDsh(cfg) {
+export async function updateDsh(cfg, claimedAt) {
   const g = getSingleton();
   if (g.updating) return { ok: false, state: "updating" };
   g.updating = true;
@@ -937,12 +937,23 @@ export async function updateDsh(cfg) {
     log(`更新失败：${err}`);
     return { ok: false, state: "error", error: err };
   } finally {
-    // ⑥ 清 update-request.json（删文件，无请求态 = 文件不存在，与轮询语义一致；
-    // 防重复触发由 g.updateWatchLastAt 内存去重承担）
-    try {
-      rmSync(requestFile, { force: true });
-    } catch {
-      /* 清理失败不阻断 */
+    // ⑥ 清 update-request.json：仅当当前文件的 at 仍是本次 claim 的 at 才删
+    //（处理期间新写入的请求（新 at）保留——轮询 g.updateWatchLastAt 未设防，
+    // 新请求可正常触发；Agent 工具 dsh_update 直接调用不带 claimedAt，不碰请求文件）
+    if (claimedAt) {
+      try {
+        let cur = null;
+        try {
+          cur = JSON.parse(readFileSync(requestFile, "utf8"));
+        } catch {
+          cur = null;
+        }
+        if (cur && cur.at === claimedAt) {
+          rmSync(requestFile, { force: true });
+        }
+      } catch {
+        /* 清理失败不阻断 */
+      }
     }
     // ⑦ 解锁
     g.updating = false;
@@ -989,6 +1000,15 @@ function ensureUpdateWatch(cfg) {
       return; // 不存在/解析失败：忽略，下轮重试
     }
     if (!req || typeof req !== "object") return;
+    if (req.state === "idle") {
+      // 遗留 idle 文件（v0.21.1 占位写残留）：无请求态 = 文件不存在，删掉
+      try {
+        rmSync(path, { force: true });
+      } catch {
+        /* 清理失败不阻断 */
+      }
+      return;
+    }
     if (req.state !== "requested") return;
     const at = typeof req.at === "string" ? req.at : "";
     if (!at || at === g.updateWatchLastAt) return; // 同请求只处理一次
@@ -1019,7 +1039,9 @@ function onBridgeRequestChanged(dataDir, path, cfg) {
   if (req.state === "requested") {
     if (g.updating) return; // 更新中：跳过（重复触发防护）
     console.log("[dsh-run] 收到 DSH 更新请求（设置页），执行 updateDsh");
-    updateDsh(cfg).catch((e) => {
+    // 传 claimedAt（本次 claim 的请求 at）：updateDsh 收尾只在当前文件 at 仍是
+    // 该 at 时才删——处理期间新写入的请求（新 at）保留，轮询可继续触发
+    updateDsh(cfg, typeof req.at === "string" ? req.at : "").catch((e) => {
       console.warn(`[dsh-run] DSH 更新异常：${e?.message || e}`);
     });
   }

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -45,6 +45,7 @@ import {
   unlinkSync,
   renameSync,
   appendFileSync,
+  rmSync,
   readdirSync,
 } from "node:fs";
 import { join, dirname } from "node:path";

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -856,14 +856,13 @@ function ensureProviderPushWatch(cfg) {
 // { state: done|error, version?, error?, at }（dsh 设置页 update-status 路由读）。
 // 并发防护：g.updating 进行中重复调用返回 { ok:false, state:"updating" } 不重复执行；
 // 与 installDepsFromPlugin 内部 g.depsInstalling 独立（本标志管整条更新流程）。----
-export async function updateDsh(cfg, claimedAt) {
+export async function updateDsh(cfg, claimedPath) {
   const g = getSingleton();
   if (g.updating) return { ok: false, state: "updating" };
   g.updating = true;
   g.updateError = null;
   const dataDir = cfg.dataDir || g.dataDir;
   const resultFile = join(dataDir, "update-result.json");
-  const requestFile = join(dataDir, "update-request.json");
   const stamp = () => new Date().toISOString();
   const log = (s) => {
     try {
@@ -937,20 +936,13 @@ export async function updateDsh(cfg, claimedAt) {
     log(`更新失败：${err}`);
     return { ok: false, state: "error", error: err };
   } finally {
-    // ⑥ 清 update-request.json：仅当当前文件的 at 仍是本次 claim 的 at 才删
-    //（处理期间新写入的请求（新 at）保留——轮询 g.updateWatchLastAt 未设防，
-    // 新请求可正常触发；Agent 工具 dsh_update 直接调用不带 claimedAt，不碰请求文件）
-    if (claimedAt) {
+    // ⑥ 清请求文件：删本次 claim 的私有路径（claimedPath）。claimed 是原子
+    // rename 出来的独占文件，处理期间新写入的请求在 update-request.json（原路径）
+    // 独立存在，删 claimed 不会误删新请求。Agent 工具/webui 直接调用不带
+    // claimedPath，不碰请求文件。
+    if (claimedPath) {
       try {
-        let cur = null;
-        try {
-          cur = JSON.parse(readFileSync(requestFile, "utf8"));
-        } catch {
-          cur = null;
-        }
-        if (cur && cur.at === claimedAt) {
-          rmSync(requestFile, { force: true });
-        }
+        rmSync(claimedPath, { force: true });
       } catch {
         /* 清理失败不阻断 */
       }
@@ -1001,11 +993,15 @@ function ensureUpdateWatch(cfg) {
     }
     if (!req || typeof req !== "object") return;
     if (req.state === "idle") {
-      // 遗留 idle 文件（v0.21.1 占位写残留）：无请求态 = 文件不存在，删掉
-      try {
-        rmSync(path, { force: true });
-      } catch {
-        /* 清理失败不阻断 */
+      // 遗留 idle 文件（v0.21.1 占位写残留）：无请求态 = 文件不存在。
+      // 先原子 claim（rename）再删 claimed——读-删之间的并发写入不会被误删
+      const claimed = claimRequest(path);
+      if (claimed) {
+        try {
+          rmSync(claimed, { force: true });
+        } catch {
+          /* 清理失败不阻断 */
+        }
       }
       return;
     }
@@ -1013,7 +1009,11 @@ function ensureUpdateWatch(cfg) {
     const at = typeof req.at === "string" ? req.at : "";
     if (!at || at === g.updateWatchLastAt) return; // 同请求只处理一次
     g.updateWatchLastAt = at;
-    onBridgeRequestChanged(dataDir, path, cfg);
+    // 原子 claim：rename 后原路径即刻消失，处理期间新写入的请求（新 at）落在
+    // 原路径独立成文件，下轮轮询读到即可触发——与本次处理互不干扰
+    const claimed = claimRequest(path);
+    if (!claimed) return; // claim 失败（并发竞争）：下轮重试
+    onBridgeRequestChanged(dataDir, claimed, cfg, at);
   }, 5000);
   g.updateWatchCleanup = () => {
     clearInterval(timer);
@@ -1024,27 +1024,39 @@ function ensureUpdateWatch(cfg) {
   );
 }
 
-// update-request.json 分发（requested → 更新）。v0.18.1 起仅剩更新桥接（版本检查
+// claimRequest：原子 claim——把 update-request.json rename 为唯一 claimed 路径。
+// rename 是文件系统原子操作：claim 后原路径即刻不存在，并发写入的新请求落在
+// 原路径（新文件），与 claimed 文件互不干扰。返回 claimed 路径（失败返回 null）。
+function claimRequest(path) {
+  const claimed = `${path}.${Date.now()}.${Math.random().toString(36).slice(2, 8)}.claimed`;
+  try {
+    renameSync(path, claimed);
+    return claimed;
+  } catch {
+    return null;
+  }
+}
+
+// update-request.json 分发（claimed → 更新）。v0.18.1 起仅剩更新桥接（版本检查
 // 改 dsh 侧直查 HTTP 直查 npm registry，不走此通道）；防抖沿用能力层运行期标志（g.updating）。
 // 失败只记日志不抛出。
-function onBridgeRequestChanged(dataDir, path, cfg) {
+// claimedPath 是轮询原子 claim（rename）后的私有路径：本请求独占，处理完成由
+// updateDsh 收尾删除；g.updating 跳过时此处直接删（请求已 claim = 已消费，不重放）。
+function onBridgeRequestChanged(dataDir, claimedPath, cfg, at) {
   const g = getSingleton();
-  let req = null;
-  try {
-    req = JSON.parse(readFileSync(path, "utf8"));
-  } catch {
-    return; // 解析失败/不存在：忽略
+  if (g.updating) {
+    // 更新中：跳过（重复触发防护）。claimed 文件已消费（不重放），直接删
+    try {
+      rmSync(claimedPath, { force: true });
+    } catch {
+      /* 清理失败不阻断 */
+    }
+    return;
   }
-  if (!req || typeof req !== "object") return;
-  if (req.state === "requested") {
-    if (g.updating) return; // 更新中：跳过（重复触发防护）
-    console.log("[dsh-run] 收到 DSH 更新请求（设置页），执行 updateDsh");
-    // 传 claimedAt（本次 claim 的请求 at）：updateDsh 收尾只在当前文件 at 仍是
-    // 该 at 时才删——处理期间新写入的请求（新 at）保留，轮询可继续触发
-    updateDsh(cfg, typeof req.at === "string" ? req.at : "").catch((e) => {
-      console.warn(`[dsh-run] DSH 更新异常：${e?.message || e}`);
-    });
-  }
+  console.log("[dsh-run] 收到 DSH 更新请求（设置页），执行 updateDsh");
+  updateDsh(cfg, claimedPath).catch((e) => {
+    console.warn(`[dsh-run] DSH 更新异常：${e?.message || e}`);
+  });
 }
 // push dsh web host 刷新（回环调用 127.0.0.1:{port}；结果写入统一会话日志 + console 简记，
 // 失败不阻断。B方案：body 携带组装好的 route 目录（buildProviderRoutes() 的

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -936,9 +936,10 @@ export async function updateDsh(cfg) {
     log(`更新失败：${err}`);
     return { ok: false, state: "error", error: err };
   } finally {
-    // ⑥ 清 update-request.json（写回 idle，防重复触发）
+    // ⑥ 清 update-request.json（删文件，无请求态 = 文件不存在，与轮询语义一致；
+    // 防重复触发由 g.updateWatchLastAt 内存去重承担）
     try {
-      writeFileSync(requestFile, JSON.stringify({ state: "idle" }), "utf8");
+      rmSync(requestFile, { force: true });
     } catch {
       /* 清理失败不阻断 */
     }
@@ -973,20 +974,10 @@ function ensureUpdateWatch(cfg) {
     return;
   }
   const path = join(dataDir, "update-request.json");
-  // 轮询前确保文件存在（占位 idle，避免「文件不存在」读失败）
-  try {
-    if (!existsSync(path)) {
-      mkdirSync(dataDir, { recursive: true });
-      writeFileSync(path, JSON.stringify({ state: "idle" }), "utf8");
-    }
-  } catch (e) {
-    console.warn(
-      `[dsh-run] update-request.json 占位写入失败（${e?.message || e}），DSH 更新桥接轮询未建立`,
-    );
-    return;
-  }
   // 5s 轮询：watch 事件不可靠（宿主 resources.watch 失效/未注入）时仍能感知
-  // 设置页更新请求。state === 'requested' 且 at 与上次处理的不同（单例
+  // 设置页更新请求。文件不存在即无请求（不占位写入——idle 文件会让数据目录
+  // 每次启动都残留 update-request.json；轮询本来就有 !existsSync 保护）。
+  // state === 'requested' 且 at 与上次处理的不同（单例
   // g.updateWatchLastAt，ISO 字符串比较）才触发——同请求只处理一次。
   const timer = setInterval(() => {
     let req = null;

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -12,9 +12,7 @@
 //   关闭回收         closeProcess（先清 provider/update watch，再 kill 子进程）
 //   连接失败自检     collectWebDiagnostics + buildDepsDiagCheck + buildProcessDiagCheck + pickProcessFix
 //   更新 DSH         updateDsh（停 host → 装依赖 → 起 host → 读版本，写 update-result.json）
-//   watch + 轮询     ensureProviderPushWatch（provider 热跟随 watch）/ ensureUpdateWatch
-//                    （DSH 更新请求 5s 轮询，v0.18.1 起替代 resources.watch 桥接）/
-//                    onBridgeRequestChanged
+//   watch           ensureProviderPushWatch（provider 热跟随 watch）
 //   provider 路由     detectHostProviderPaths / readJsonFile / mapModel / readHostConfig / buildProviderRoutes
 //                    → pushProviderRefresh（HTTP push 到 dsh web host）
 //   config 引导       ensureConfigJson（自动生成 config.json，幂等）
@@ -565,21 +563,56 @@ export async function ensureWebHost(cfg) {
   // 只剩 dshPkgDir（子进程解析 pi-ai 依赖用）。DSH_PKG_DIR = dsh 包安装目录
   // （provider/settings 段）；LOG_PATH = 本次会话日志文件路径（logger 段，四个内嵌
   // 插件经统一日志服务写入同一文件）；DATA_DIR = settings 段「检查与更新 DSH」链路
-  // （更新请求/结果文件写入数据目录）。v0.18.2 起远端版本查询改 HTTP 直查 npm registry
-  // （settings 侧与 lib/check.js 同款，pnpm view 语义等价），NPM_CLI_PATH / ELECTRON_NODE
-  // 占位符已从模板删除（settings 不再 spawn pnpm，渲染为同步函数，无异步依赖）。
+  // （更新结果文件写入数据目录）；DSH_HOST_API = settings 段子插件反向信道凭据
+  // （宿主 server-info.json 的 loopbackToken + 端口，经 /child/post 直投触发更新，
+  // 替代 update-request.json 文件桥——文件桥已退役）。v0.18.2 起远端版本查询改 HTTP
+  // 直查 npm registry（settings 侧与 lib/check.js 同款，pnpm view 语义等价），
+  // NPM_CLI_PATH / ELECTRON_NODE 占位符已从模板删除（settings 不再 spawn pnpm，
+  // 渲染为同步函数，无异步依赖）。
   const renderPatchTpl = () => {
     const gen = join(cfg.dataDir, "dsh-hanako.patch.generated.yml");
+    // 子插件反向信道凭据：宿主 server-info.json（<home>/.hanako/）的 loopbackToken +
+    // 端口——宿主启动时官方落盘，供本机进程过鉴权墙（Vit 认 query token 匹配
+    // loopbackToken 且 local transport，实测受保护端点 200）。注入 settings 的 hostApi，
+    // 投递 POST /child/post 直触发 updateDsh（替代 update-request.json 文件桥）。
+    // 文件缺失（宿主旧版本）→ {}（settings 投递报「宿主信道未配置」，不降级回文件）。
+    const hostApi = readChildHostApi(cfg.dataDir);
+    const hostApiJson = hostApi ? JSON.stringify(hostApi) : "{}";
     const content = readFileSync(patchTpl, "utf8")
       .split("{{DSH_PKG_DIR}}")
       .join(cfg.dshPkgDir || resolveDshPkgDir(cfg))
       .split("{{LOG_PATH}}")
       .join(logPath)
       .split("{{DATA_DIR}}")
-      .join(cfg.dataDir);
+      .join(cfg.dataDir)
+      .split("{{DSH_HOST_API}}")
+      .join(hostApiJson);
     writeFileSync(gen, content, "utf8");
     return gen;
   };
+  // readChildHostApi：读宿主 server-info.json（loopbackToken + 端口，宿主启动时官方
+  // 落盘，供本机进程过鉴权墙）。dataDir = <home>/.hanako/plugin-data/dsh-hanako →
+  // server-info.json = <home>/.hanako/server-info.json（join(dataDir, "../..")）。
+  // 返回 { url, token } 或 null（宿主旧版本/异常——信道不可用，不降级回文件）。
+  function readChildHostApi(dataDir) {
+    try {
+      const info = join(dataDir, "..", "..", "server-info.json");
+      if (!existsSync(info)) return null;
+      const s = JSON.parse(readFileSync(info, "utf8"));
+      if (typeof s?.token !== "string" || !s.token) return null;
+      const port = Number(s.port) || 0;
+      if (!port) return null;
+      return {
+        url: `http://127.0.0.1:${port}/api/plugins/dsh-hanako/child/post`,
+        token: s.token,
+      };
+    } catch (e) {
+      console.warn(
+        `[dsh-run] 读 server-info.json 失败（${e?.message || e}），子插件反向信道不可用`,
+      );
+      return null;
+    }
+  }
   if (existsSync(patchTpl)) {
     try {
       patchFiles.push(renderPatchTpl());
@@ -856,7 +889,7 @@ function ensureProviderPushWatch(cfg) {
 // { state: done|error, version?, error?, at }（dsh 设置页 update-status 路由读）。
 // 并发防护：g.updating 进行中重复调用返回 { ok:false, state:"updating" } 不重复执行；
 // 与 installDepsFromPlugin 内部 g.depsInstalling 独立（本标志管整条更新流程）。----
-export async function updateDsh(cfg, claimedPath) {
+export async function updateDsh(cfg) {
   const g = getSingleton();
   if (g.updating) return { ok: false, state: "updating" };
   g.updating = true;
@@ -900,13 +933,13 @@ export async function updateDsh(cfg, claimedPath) {
       restartError = String(e?.message || e).slice(0, 1500);
       log(`web host 重启失败：${restartError}`);
     }
-    // ④b 重启后重建宿主侧 watch/轮询——closeProcess 已清理（provider 热跟随 +
-    // DSH 更新请求轮询），ensureWebHost 本身不建（只有 startWebHostFromPlugin 建），
-    // 不重建则更新后设置页更新请求不再触发宿主处理
+    // ④b 重启后重建宿主侧 provider 热跟随 watch——closeProcess 已清理，
+    // ensureWebHost 本身不建（只有 startWebHostFromPlugin 建），不重建则
+    // 更新后 provider 配置变更不再推送。DSH 更新请求不走 watch/轮询：
+    // v0.21.2 起子插件经反向信道（POST /child/post）直投宿主触发。
     ensureProviderPushWatch(cfg);
     // 重启用进程后首批 provider 的初始 push 已由 ensureWebHost（唯一就绪点）
     // 发出；此处只重建跟随 watch，不再重复 push。
-    ensureUpdateWatch(cfg);
     // ⑤ 读新版本 → done（installDepsFromPlugin 已刷新 g.depsSmoke，优先用；无则直读 package.json）
     const version =
       (g.depsSmoke && !g.depsSmoke.running && g.depsSmoke.ok
@@ -936,127 +969,9 @@ export async function updateDsh(cfg, claimedPath) {
     log(`更新失败：${err}`);
     return { ok: false, state: "error", error: err };
   } finally {
-    // ⑥ 清请求文件：删本次 claim 的私有路径（claimedPath）。claimed 是原子
-    // rename 出来的独占文件，处理期间新写入的请求在 update-request.json（原路径）
-    // 独立存在，删 claimed 不会误删新请求。Agent 工具/webui 直接调用不带
-    // claimedPath，不碰请求文件。
-    if (claimedPath) {
-      try {
-        rmSync(claimedPath, { force: true });
-      } catch {
-        /* 清理失败不阻断 */
-      }
-    }
-    // ⑦ 解锁
+    // ⑥ 解锁（更新请求信道已由 /child/post 受理，无请求文件可清理）
     g.updating = false;
   }
-}
-// ---- 宿主侧 DSH 更新桥接轮询（dsh 设置页「DSH 版本」块 → 宿主能力层）----
-// 语义：@dsh-hanako/settings 插件写 <dataDir>/update-request.json（state: 'requested'
-// 请求更新；版本检查 v0.18.1 起改 dsh 侧直查（v0.18.2 起 HTTP 直查 npm registry），不再走桥接），宿主侧 5s
-// 轮询读文件（替代早期 ctx.resources.watch——watch 依赖宿主 resources 注入 + bus
-// 事件订阅，链路不可靠：曾出现设置页检查/更新请求写入后宿主无感知的故障，
-// check-result.json 永不更新、前端永久 pending）→ 按 state 分发：requested →
-// updateDsh（写 update-result.json，pnpm add latest + 重启 web host）。at 去重：
-// 同一请求（at 相同）只处理一次（单例 g.updateWatchLastAt，见轮询回调）。
-// 幂等：startWebHost 重复调用 / web host 重建时先清定时器再建；cleanup 挂单例
-// g.updateWatchCleanup，closeProcess 回收 web host 时调用（clearInterval）。
-function ensureUpdateWatch(cfg) {
-  const g = getSingleton();
-  // 幂等：先清旧定时器（startWebHost 重复调用 / web host 重建时）
-  if (typeof g.updateWatchCleanup === "function") {
-    try {
-      g.updateWatchCleanup();
-    } catch {
-      /* 清理失败不阻断 */
-    }
-    g.updateWatchCleanup = null;
-  }
-  const dataDir = cfg.dataDir || g.dataDir;
-  if (!dataDir) {
-    console.warn("[dsh-run] 缺少 dataDir，DSH 更新桥接轮询未建立");
-    return;
-  }
-  const path = join(dataDir, "update-request.json");
-  // 5s 轮询：watch 事件不可靠（宿主 resources.watch 失效/未注入）时仍能感知
-  // 设置页更新请求。文件不存在即无请求（不占位写入——idle 文件会让数据目录
-  // 每次启动都残留 update-request.json；轮询本来就有 !existsSync 保护）。
-  // state === 'requested' 且 at 与上次处理的不同（单例
-  // g.updateWatchLastAt，ISO 字符串比较）才触发——同请求只处理一次。
-  const timer = setInterval(() => {
-    let req = null;
-    try {
-      if (!existsSync(path)) return;
-      req = JSON.parse(readFileSync(path, "utf8"));
-    } catch {
-      return; // 不存在/解析失败：忽略，下轮重试
-    }
-    if (!req || typeof req !== "object") return;
-    if (req.state === "idle") {
-      // 遗留 idle 文件（v0.21.1 占位写残留）：无请求态 = 文件不存在。
-      // 先原子 claim（rename）再删 claimed——读-删之间的并发写入不会被误删
-      const claimed = claimRequest(path);
-      if (claimed) {
-        try {
-          rmSync(claimed, { force: true });
-        } catch {
-          /* 清理失败不阻断 */
-        }
-      }
-      return;
-    }
-    if (req.state !== "requested") return;
-    const at = typeof req.at === "string" ? req.at : "";
-    if (!at || at === g.updateWatchLastAt) return; // 同请求只处理一次
-    g.updateWatchLastAt = at;
-    // 原子 claim：rename 后原路径即刻消失，处理期间新写入的请求（新 at）落在
-    // 原路径独立成文件，下轮轮询读到即可触发——与本次处理互不干扰
-    const claimed = claimRequest(path);
-    if (!claimed) return; // claim 失败（并发竞争）：下轮重试
-    onBridgeRequestChanged(dataDir, claimed, cfg, at);
-  }, 5000);
-  g.updateWatchCleanup = () => {
-    clearInterval(timer);
-    g.updateWatchCleanup = null;
-  };
-  console.log(
-    `[dsh-run] DSH 更新桥接轮询已建立（${path}，5s），设置页更新请求将触发宿主处理`,
-  );
-}
-
-// claimRequest：原子 claim——把 update-request.json rename 为唯一 claimed 路径。
-// rename 是文件系统原子操作：claim 后原路径即刻不存在，并发写入的新请求落在
-// 原路径（新文件），与 claimed 文件互不干扰。返回 claimed 路径（失败返回 null）。
-function claimRequest(path) {
-  const claimed = `${path}.${Date.now()}.${Math.random().toString(36).slice(2, 8)}.claimed`;
-  try {
-    renameSync(path, claimed);
-    return claimed;
-  } catch {
-    return null;
-  }
-}
-
-// update-request.json 分发（claimed → 更新）。v0.18.1 起仅剩更新桥接（版本检查
-// 改 dsh 侧直查 HTTP 直查 npm registry，不走此通道）；防抖沿用能力层运行期标志（g.updating）。
-// 失败只记日志不抛出。
-// claimedPath 是轮询原子 claim（rename）后的私有路径：本请求独占，处理完成由
-// updateDsh 收尾删除；g.updating 跳过时此处直接删（请求已 claim = 已消费，不重放）。
-function onBridgeRequestChanged(dataDir, claimedPath, cfg, at) {
-  const g = getSingleton();
-  if (g.updating) {
-    // 更新中：跳过（重复触发防护）。claimed 文件已消费（不重放），直接删
-    try {
-      rmSync(claimedPath, { force: true });
-    } catch {
-      /* 清理失败不阻断 */
-    }
-    return;
-  }
-  console.log("[dsh-run] 收到 DSH 更新请求（设置页），执行 updateDsh");
-  updateDsh(cfg, claimedPath).catch((e) => {
-    console.warn(`[dsh-run] DSH 更新异常：${e?.message || e}`);
-  });
 }
 // push dsh web host 刷新（回环调用 127.0.0.1:{port}；结果写入统一会话日志 + console 简记，
 // 失败不阻断。B方案：body 携带组装好的 route 目录（buildProviderRoutes() 的
@@ -1154,10 +1069,8 @@ getSingleton().startWebHost = async function startWebHostFromPlugin(
     ensureProviderPushWatch(cfg);
     // 首批 provider 的初始 push 已收敛进 ensureWebHost（唯一就绪点，含重试），
     // 此处不再重复推；后续每次 resource.changed 经防抖 watch 增量 push。
-    // DSH 更新请求轮询（幂等）：dsh 设置页「更新到最新」写 update-request.json →
-    // 宿主 updateDsh（单一事实源）；版本检查 v0.18.1 起由 dsh 侧设置页直查，
-    // 不再经桥接
-    ensureUpdateWatch(cfg);
+    // DSH 更新请求 v0.21.2 起由子插件反向信道（POST /child/post）直投，
+    // 无宿主侧轮询/文件。
     return true;
   } catch (e) {
     // 记录失败原因供诊断（onload 侧只能看到布尔）；后续工具调用重试
@@ -1475,13 +1388,6 @@ export async function closeProcess() {
   if (typeof g.providerPushCleanup === "function") {
     try {
       g.providerPushCleanup();
-    } catch {
-      /* 清理失败不阻断 */
-    }
-  }
-  if (typeof g.updateWatchCleanup === "function") {
-    try {
-      g.updateWatchCleanup();
     } catch {
       /* 清理失败不阻断 */
     }

--- a/src/routes/child.js
+++ b/src/routes/child.js
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2026 Nyasers
+//
+// routes/child.js — 子插件反向投递信道（dsh 进程内 @dsh-hanako/* → 宿主插件）
+//   POST /child/post  接收子插件主动投递 { channel, payload }，按 channel 分发。
+//   当前通道：channel "dsh.update-request" → 触发 g.updateDsh（设置页「更新到最新」
+//   直投，替代 update-request.json 文件桥——文件桥已退役：无轮询、无残留）。
+//
+// 鉴权：宿主鉴权墙已校验——子插件投递带 server-info.json 的 loopbackToken 作 query
+// token（宿主官方本机进程凭据，Vit 校验 p.token === loopbackToken 且 connectionKind
+// local 放行，实测受保护端点 200）。能到达本路由即已过墙，路由内不再二次校验。
+// 返回 { ok:true, state:"updating" }（受理即回，结果走 update-result.json 供前端
+// update-status 轮询）；g.updating 时回同形（不重复触发）。异常一律容错不抛。
+export default function registerChildRoutes(app, ctx) {
+  app.post("/child/post", async (c) => {
+    const g = globalThis.__dshHanako;
+    try {
+      let body = {};
+      try {
+        body = await c.req.json();
+      } catch {
+        /* 空 body / 非 JSON：按无 channel 处理 */
+      }
+      const channel = typeof body?.channel === "string" ? body.channel : "";
+      if (channel === "dsh.update-request") {
+        if (!g || typeof g.updateDsh !== "function") {
+          return c.json({ ok: false, error: "插件工具模块未加载，稍后重试" });
+        }
+        if (g.updating) return c.json({ ok: true, state: "updating" });
+        // 异步触发（updateDsh 内部 try/catch 写 update-result.json；这里 .catch 兜底，
+        // 路由不等待完成）。cfg 与 webui/update-dsh 同构（dataDir 缺省用单例记录值）
+        Promise.resolve(
+          g.updateDsh({ dataDir: ctx.dataDir || g.dataDir, webPort: Number(g.webServerPort) || 3080 }),
+        ).catch(() => {});
+        return c.json({ ok: true, state: "updating" });
+      }
+      return c.json({ ok: false, error: `未知 channel: ${channel || "(空)"}` });
+    } catch (e) {
+      ctx.log?.warn?.("[dsh-hanako] child/post 处理失败:", e?.message || String(e));
+      return c.json({ ok: false, error: "投递处理失败" });
+    }
+  });
+}


### PR DESCRIPTION
子插件反向信道替代 update-request.json 文件桥，文件通道彻底退役。

## 背景
dsh 设置页「更新到最新」原经 <dataDir>/update-request.json 通知宿主（设置页写 requested → 宿主 5s 轮询读 → updateDsh → 写回 idle）。文件生命周期管理（占位残留、读-删竞态、原子 claim）是文件通道自身复杂度的代价。

## 方案：子插件反向信道（HTTP 直投）
- 宿主侧 `routes/child.js`：`POST /api/plugins/dsh-hanako/child/post`，channel 分发（`dsh.update-request` → updateDsh），受理即回，结果走 update-result.json
- 凭据：宿主 `server-info.json` 官方落盘 loopbackToken（本机进程凭据，实测过宿主鉴权墙 200）——lifecycle `readChildHostApi` 读取并经 tpl 注入 settings `hostApi`
- settings `request-update`：写文件 → fetch 直投（token query 过墙）；hostApi 缺失报错不降级

## 退役
- ensureUpdateWatch（5s 轮询）、claimRequest（原子 claim）、onBridgeRequestChanged 全部删除；updateDsh 签名还原；closeProcess/startWebHost 清理点删除
- update-request.json 无写点、无轮询、无残留

## 为什么 HTTP 不是 WS
宿主 0.769 插件路由 upgrade 丢 raw socket（WS #1 已证伪），子插件无法直连宿主 WS 端点；宿主→dsh 的 WS #2 有 dispatch 403 构造差异且已被 HTTP fetch 替代。HTTP 直投是唯一干净路径（即 bridge 方向的 HTTP 形态）。

## 验证
- loopbackToken 过墙：受保护端点无 token 403 / 带 token 200（实测）
- node --check 全绿；pack 产物 routes 含 child.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updates are now delivered directly through the authenticated host connection.
  * Added clear success and failure responses for update requests.
  * Added validation to reject unsupported or duplicate updates.
  * Provider monitoring continues after successful updates.

* **Bug Fixes**
  * Removed reliance on temporary update request files and polling.
  * Improved update handling to prevent lost, repeated, or stale requests.
  * Added safer handling for invalid or unexpected update requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->