### PR TITLE
fix: callbackMode 直读 config.json 即时生效（minimal 回传修复）

### DIFF
--- a/src/tools/dsh-run.js
+++ b/src/tools/dsh-run.js
@@ -26,6 +26,7 @@ import {
   resolveReasoningEffort,
   resolveApprovalTimeoutMs,
   resolveDefaultCwd,
+  resolveCallbackMode,
 } from "./lib/config.js";
 import {
   registerDeferredWake,
@@ -842,11 +843,10 @@ async function doExecute(input, ctx) {
       : Number(cfg.defaultTimeoutMs || 600000);
 
   // callbackMode 三档：full=回传全量输出 / summary=只带最终结论摘要（默认）/
-  // minimal=回调只带 { id, status, rpcId, sessionId } 定位键（不生成摘要、不占上下文）
-  const callbackMode =
-    cfg.callbackMode === "full" || cfg.callbackMode === "minimal"
-      ? cfg.callbackMode
-      : "summary";
+  // minimal=回调只带 { id, status, rpcId, sessionId } 定位键（不生成摘要、不占上下文）。
+  // 直读 dataDir/config.json 的 global.callbackMode（单一事实源，设置界面改动/Agent 直改
+  // 文件均即时生效），无则回退配置快照；与 defaultCwd/approvalTimeoutMs 同款直读兜底。
+  const callbackMode = resolveCallbackMode(cfg);
   // 异步提交回执按 callbackMode 展示三档语义
   const modePhrase =
     callbackMode === "full"

--- a/src/tools/lib/config.js
+++ b/src/tools/lib/config.js
@@ -115,3 +115,21 @@ export function resolveDefaultCwd(cfg) {
   }
   return String(cfg.defaultCwd || "");
 }
+
+// callbackMode 解析（「配置单一事实源」哲学，与 defaultCwd/approvalTimeoutMs 同款直读兜底）：
+// 优先直读 dataDir/config.json 的 global.callbackMode（设置界面改动即时生效；Agent 直改文件
+// 同样生效），无则回退配置快照。三档合法值 summary/full/minimal 采用，非法/缺失回 summary。
+export function resolveCallbackMode(cfg) {
+  try {
+    const cf = join(cfg.dataDir, "config.json");
+    if (existsSync(cf)) {
+      const j = JSON.parse(readFileSync(cf, "utf8"));
+      const v = j?.global?.callbackMode;
+      if (v === "summary" || v === "full" || v === "minimal") return v;
+    }
+  } catch {
+    /* 读配置失败忽略 */
+  }
+  const v = cfg.callbackMode;
+  return v === "summary" || v === "full" || v === "minimal" ? v : "summary";
+}


### PR DESCRIPTION
## 根因
dsh_run 的 callbackMode 只读宿主注入的配置快照 \ctx.config.callbackMode\，设置界面保存 / Agent 直改 config.json 后快照未刷新，回调仍走默认 summary。config.json 已存 \global.callbackMode: minimal\ 但不生效，正是缺了 defaultCwd/approvalTimeoutMs 已有的直读兜底。

## 修复
- \src/tools/lib/config.js\ 新增 \esolveCallbackMode(cfg)\：优先直读 dataDir/config.json 的 global.callbackMode（单一事实源，改动即时生效），无则回退快照；非法值回 summary。
- \src/tools/dsh-run.js\ doExecute 改用 \esolveCallbackMode(cfg)\ 解析，其余逻辑不变（minimal 分支本身正确，只是进不去）。

## 验证
node --check 通过；单测场景 5 个全 PASS（真实 config minimal / 无配置回退 summary / 快照 full / config 非法值回退 / 非法值取快照）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Callback behavior can now be configured using `summary`, `full`, or `minimal` modes.
  * Configuration settings are applied consistently across command execution.

* **Bug Fixes**
  * Invalid or missing callback mode settings now safely default to `summary`.
  * Configuration file read or parsing issues no longer interrupt command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->