### PR TITLE
refactor: 总线 RPC 收敛——指令面总线化（Unary RPC + respond，HTTP 兜底）

### DIFF
--- a/dsh-plugin/@dsh-hanako/bridge/index.js
+++ b/dsh-plugin/@dsh-hanako/bridge/index.js
@@ -31,6 +31,13 @@
 //   { "channel":"update.progress", "payload":{ state, at } }—— 宿主更新开始/进度回投
 //   { "channel":"update.result", "payload":{ state, version?, error? } }—— 宿主更新结果回投
 //   { "channel":"provider.refresh", "payload":{ routes } }  —— 宿主 provider 路由推送（替代 HTTP）
+//   { "channel":"rpc.request", "payload":{ reqId, method, payload } }—— 宿主 Unary RPC 指令面
+//                                                             收敛进总线（session.create/prompt/
+//                                                             selectModel/cancel + respond 审批
+//                                                             应答；翻译器自环调 /api/<method>，
+//                                                             见 translateRpcRequest）
+//   { "channel":"rpc.result", "payload":{ reqId, ok, value?, error? } }—— 翻译器回投（宿主按
+//                                                             reqId 配对等待；ok:false 带 error）
 //   { "channel":"bus.ping", "payload":{} } / { "channel":"bus.pong", "payload":{} } —— 心跳
 // 首帧必须是 hello（免鉴权身份宣告，仍要求首帧即 hello）：非 hello 首帧立即关闭
 // （close 1008）；5s 未发 hello 关闭（超时）。单连接语义：宿主是唯一客户端——新连接
@@ -59,6 +66,80 @@ const BUS_PATH = '/api/dshana.bus' // upgrade 路由路径（宿主连 ws://127.
 const HELLO_TIMEOUT_MS = 5000 // 握手超时（5s 未发 hello 关闭）
 const HELLO_CLOSE_CODE = 1008 // 握手失败关闭码（非 hello 首帧/超时）
 const REPLACED_CLOSE_CODE = 1001 // 旧连接被新连接顶掉
+
+// ---- 总线 RPC 翻译器（宿主 Unary RPC 指令面收敛进总线；导出供单测）----
+// 宿主经总线 rpc.request 帧投递 Unary RPC（session.create/prompt/selectModel/cancel 等 +
+// respond 审批应答），翻译器在 dsh 进程内自环调 dsh web /api/<method>（本机 127.0.0.1
+// 回环——子插件与 dsh 同进程，dsh 本体零改动），把 ServerResponse 翻译回 rpc.result 帧
+// 回投宿主。数据面（events.mux 事件流）仍由宿主直连，不经总线。
+// 安全：不设 method 白名单——与本机信任模型一致：本机进程本就可直接 POST 3080 /api/*
+// （总线与 mux、/api/session.* 同级，免鉴权），总线只是换入口，攻击面未扩大。
+// 回投纪律：所有异常路径（fetch 异常/超时/解析失败/HTTP 错误/rpcId 不匹配）都必须经
+// reply 回投 rpc.result（ok:false），否则宿主侧 pending 等待挂死。
+// req：{ reqId, method, payload }；port：dsh web 端口（取不到由调用方回退 3080）；
+// reply(frame)：回投一帧 rpc.result 载荷（{ reqId, ok, value? } 或 { reqId, ok:false, error }），
+// 不应抛出（插件侧接线已包 try/catch 隔离）。
+export async function translateRpcRequest(req, port, reply) {
+  const reqId = req && typeof req === 'object' ? req.reqId : undefined
+  const method = req && typeof req === 'object' ? req.method : undefined
+  // 校验：reqId/method 必须是非空 string，否则忽略（防垃圾帧）
+  if (typeof reqId !== 'string' || !reqId || typeof method !== 'string' || !method) {
+    return
+  }
+  const base = 'http://127.0.0.1:' + (Number(port) || 3080)
+  try {
+    if (method === 'respond') {
+      // 审批应答：/api/respond 要 client-response 信封（rpcId 路由 web host pending 表），
+      // 响应是 rpcReceipt { accepted } 而非 ServerResponse——与 Unary 响应结构不同，
+      // 单独构造信封/解析；value 原样回投 { accepted }，宿主侧校验 j.accepted 语义不变
+      // （与直连 HTTP 完全一致）。
+      const envelope = { type: 'client-response', ...(req.payload || {}) }
+      const res = await fetch(base + '/api/respond', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(envelope),
+      })
+      if (!res.ok) throw new Error('/api/respond HTTP ' + res.status)
+      const j = await res.json()
+      reply({ reqId, ok: true, value: j && typeof j === 'object' ? j : {} })
+      return
+    }
+    // Unary：client-request 信封，响应 ServerResponse（rpcId 回显 + result.ok/value
+    // 或 result.ok=false+error）
+    const res = await fetch(base + '/api/' + method, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        type: 'client-request',
+        rpcId: reqId,
+        method,
+        payload: req.payload,
+      }),
+    })
+    if (!res.ok) throw new Error('dsh /api/' + method + ' HTTP ' + res.status)
+    const full = await res.json()
+    if (!full || typeof full !== 'object' || full.rpcId !== reqId) {
+      reply({
+        reqId,
+        ok: false,
+        error: { code: 'rpc-id-mismatch', message: 'dsh /api/' + method + ' rpcId 不匹配' },
+      })
+      return
+    }
+    if (!full.result || !full.result.ok) {
+      const e = full.result.error || {}
+      reply({ reqId, ok: false, error: { code: e.code || 'unknown', message: e.message || '' } })
+      return
+    }
+    reply({ reqId, ok: true, value: full.result.value })
+  } catch (err) {
+    reply({
+      reqId,
+      ok: false,
+      error: { code: 'bridge-error', message: String((err && err.message) || err) },
+    })
+  }
+}
 
 // ---- 插件 apply：注册 upgrade 路由 + 提供 dshanaBus 服务（全程容错，降级不阻断）----
 export function apply(ctx, config) {
@@ -239,6 +320,25 @@ export function apply(ctx, config) {
           // 宿主下发的配置（未下发返回 null——settings/provider 据此报「总线配置未就绪」）
           getConfig: () => (busConfig ? { ...busConfig } : null),
         }
+        // ---- 总线 RPC 接线：订阅宿主 rpc.request → 翻译器执行 → 回投 rpc.result ----
+        // service.on 的监听器异常隔离是每回调包装（新订阅沿用该模式）；翻译器内部
+        // 全 try/catch，绝不外抛（回投失败也只记日志，不冒泡崩进程）。
+        service.on('rpc.request', (req) => {
+          translateRpcRequest(
+            req,
+            httpCtx.webServer && typeof httpCtx.webServer.port === 'number'
+              ? httpCtx.webServer.port
+              : undefined, // 取不到端口由翻译器回退 3080（与宿主默认 webPort 一致）
+            (frame) => {
+              try {
+                service.emit('rpc.result', frame)
+              } catch {
+                bridgeLog('rpc.result 回投失败（reqId=' + ((frame && frame.reqId) || '?') + '）')
+              }
+            },
+          )
+        })
+
         const provideDisposer = ctx.provide('dshanaBus', service)
 
         bridgeLog('bridge 插件已启动（dshana.bus 消息总线服务端，免鉴权）')

--- a/skills/dsh-approve/SKILL.md
+++ b/skills/dsh-approve/SKILL.md
@@ -29,7 +29,7 @@ description: "dsh_approve 工具手册（源码 tools/dsh-approve.js 核对）�
    ```
    args 来源：事件循环按 callId 从 toolCallCache 反查（tool/call 与 code-dispatch 子调用 subCallId 形如 `root:code:N` 均缓存；miss 时剥 `:code:N` 后缀回退 run_code 根调用兜底）。
 3. **决策**：**看 args（具体执行了什么），不听 reason（model 自述）**。合理 → `allowed-once`；危险 → `rejected`。
-4. **应答**：`dsh_approve(rpcId, approvalId, outcome)`，内部调 web host `POST /api/respond`（client-response 信封，用审批对象的 `respondRpcId` 路由 pending 表）。
+4. **应答**：`dsh_approve(rpcId, approvalId, outcome)`，经总线 RPC（`callUnaryBus`，rpc.request/rpc.result 通道）发 `method="respond"`——bridge 在 dsh 进程内自环调 `POST /api/respond`（client-response 信封，用审批对象的 `respondRpcId` 路由 pending 表），回投 `{ accepted }` 校验 `j.accepted` 语义不变；总线未连接时降级 HTTP 直连。
 5. **超时**：`approvalTimeoutMs`（默认 30000；0 = 禁用）内无人应答自动 rejected（`auto: "expired"`）。应答方失联检测：正常应答几秒内完成。
 6. **恢复**：approval/resolved（allowed-once/rejected/cancelled 一律视为已解决）→ 清该审批超时计时器，无 pending 项时恢复任务执行计时。
 7. **兜底**：也可在 dsh Web UI 人工处理；通知失败不影响任务。

--- a/skills/dsh-cancel/SKILL.md
+++ b/skills/dsh-cancel/SKILL.md
@@ -19,7 +19,7 @@ description: "dsh_cancel 工具手册（源码 tools/dsh-cancel.js 核对）。�
 
 1. **参数校验**：`sessionId` 为空 → 抛 `需要 sessionId（dsh_run 回调/卡片 URL 里带；取消一律显式传 sessionId）`。
 2. **定位**：`sessionId` 直接定位会话；g.ops 运行期条目以任务 rpcId 键控，cancel 遍历条目找 `entry.sessionId === sessionId` 的项（条目极少——仅运行中任务，遍历可忽略；极早 cancel 条目未建则为 null，跳过标记）。
-3. **请求**：调 web host `POST /api/session.cancel`（client-request 信封，rpcId 回显校验；`full.result.ok` 为假抛取消请求未接受）。
+3. **请求**：经总线 RPC（`callUnaryBus`，rpc.request/rpc.result 通道；bridge 在 dsh 进程内自环调 `POST /api/session.cancel`，client-request 信封，rpcId 回显校验语义保留）发送 `session.cancel`；总线未连接时降级 HTTP 直连。`result.ok` 为假抛取消请求未接受。
 4. **防误判**：先标记 `entry.cancelledRequested = true`（找到该会话的运行期条目时）——cancel 导致 mux 断流时，dsh-run.js 事件循环读取该标记把无终态收尾判为 aborted 而非 end_turn（防误报完成）。
 5. **收尾**：dsh agent 收到中断，任务以 aborted 终态收尾，宿主 deferred fail 以「dsh_run 已取消」唤醒 Agent。best-effort：任务刚好自然完成时 cancel 的 accepted 无副作用（cancel 幂等）。
 

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -663,6 +663,9 @@ export async function ensureWebHost(cfg) {
         );
       }
       try {
+        // web host 就绪探测保留 HTTP 直连（/api/host.describe，一次性启动握手）：发生在
+        // connectBus 之前——总线还没连上，总线化是鸡生蛋；Unary RPC 指令面已收敛进总线
+        // （callUnaryBus），此处只做端口就绪探测，不进总线。
         const r = await fetch(`http://127.0.0.1:${port}/api/host.describe`, {
           method: "POST",
           headers: { "content-type": "application/json" },

--- a/src/tools/dsh-approve.js
+++ b/src/tools/dsh-approve.js
@@ -6,15 +6,10 @@
 // 循环会把审批上下文存进运行期协调条目（g.ops，键 = 任务 rpcId；审批对象含 respond 路由
 // 所需的 respondRpcId——server-request 信封自己的 RPC id，区别于任务 rpcId），并通过宿主
 // deferred 通道通知 Agent。Agent 收到通知后调用本工具应答：allowed-once 放行单次 / rejected
-// 拒绝。内部调 dsh web host POST /api/respond（client-response 信封，rpcId 路由 pending 表）。
+// 拒绝。内部经总线 rpc.request method="respond" 调 dsh web host /api/respond（callUnaryBus，
+// 总线优先/HTTP 兜底；bridge 回投 { accepted }，校验 j.accepted 语义不变）。
 
-function hostBase() {
-  const g = globalThis.__dshHanako;
-  const web = g?.web;
-  if (!web?.ready || !web.port)
-    throw new Error("DSH web host 未就绪（有审批挂起说明任务正在运行）");
-  return `http://127.0.0.1:${web.port}`;
-}
+import { callUnaryBus } from "./lib/protocol.js";
 
 export const name = "dsh_approve";
 
@@ -85,7 +80,6 @@ async function doExecute(input, ctx) {
     );
   }
 
-  const base = hostBase();
   const body = {
     type: "client-response",
     rpcId: ap.respondRpcId,
@@ -94,16 +88,12 @@ async function doExecute(input, ctx) {
       value: { sessionId: ap.sessionId, approvalId, outcome },
     },
   };
-  const res = await fetch(`${base}/api/respond`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify(body),
-  });
-  if (!res.ok) throw new Error(`/api/respond HTTP ${res.status}`);
-  const j = await res.json();
-  if (!j.accepted) {
+  // 经总线 rpc.request method="respond" 发送（bridge 自环 /api/respond，client-response 信封
+  // rpcId 路由 pending 表）；bridge 回投 { accepted }，校验 j.accepted 语义不变。
+  const j = await callUnaryBus("respond", body);
+  if (!j || !j.accepted) {
     throw new Error(
-      `审批应答未接受（${j.reason || "unknown"}）：可能已超时或被其他方处理，任务侧会自行感知`,
+      `审批应答未接受（${(j && j.reason) || "unknown"}）：可能已超时或被其他方处理，任务侧会自行感知`,
     );
   }
 

--- a/src/tools/dsh-cancel.js
+++ b/src/tools/dsh-cancel.js
@@ -2,8 +2,9 @@
 // Copyright (c) 2026 Nyasers
 //
 // tools/dsh-cancel.js — dsh 任务取消（止损）工具
-// dsh_run 派发任务后只能等完成或超时，本工具提供主动取消：调 dsh web host
-// POST /api/session.cancel（client-request 信封，rpcId 回显校验）中断运行中的任务会话。
+// dsh_run 派发任务后只能等完成或超时，本工具提供主动取消：经总线 rpc.request 调 dsh web host
+// session.cancel（callUnaryBus，总线优先/HTTP 兜底；rpcId 回显校验语义保留——总线路径由
+// bridge 回投的 result 承载，宿主侧校验 reqId 配对 + result.ok）中断运行中的任务会话。
 // cancel 后 dsh 会发 turn/end（reason.kind=aborted），事件循环判 outcome.stopReason === "aborted"
 // → throw DSH_ABORTED → promise.catch 以 aborted 终态收尾（deferred fail 带「dsh_run 已取消」唤醒 Agent）。
 // 任务状态零存储（jsonl 唯一事实源），取消必传 sessionId（dsh_run 回调/卡片 URL 取）直接定位会话；
@@ -13,12 +14,7 @@
 // （dsh-run.js consume 末尾的取消兜底）。best-effort 止损：任务刚好自然完成时 cancel 的 accepted
 // 无副作用（事件循环已终态，cancel 幂等）。
 
-function hostBase() {
-  const g = globalThis.__dshHanako;
-  const web = g?.web;
-  if (!web?.ready || !web.port) throw new Error("DSH web host 未就绪");
-  return `http://127.0.0.1:${web.port}`;
-}
+import { callUnaryBus } from "./lib/protocol.js";
 
 export const name = "dsh_cancel";
 
@@ -68,28 +64,9 @@ async function doExecute(input, ctx) {
   }
   const targetSessionId = sessionId;
 
-  const base = hostBase();
-  const rpcId = `r_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
-  const res = await fetch(`${base}/api/session.cancel`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({
-      type: "client-request",
-      rpcId,
-      method: "session.cancel",
-      payload: { sessionId: targetSessionId },
-    }),
-  });
-  if (!res.ok) throw new Error(`/api/session.cancel HTTP ${res.status}`);
-  const full = await res.json();
-  if (!full || full.rpcId !== rpcId)
-    throw new Error("/api/session.cancel rpcId 不匹配");
-  if (!full.result?.ok) {
-    const e = full.result?.error || {};
-    throw new Error(
-      `取消请求未接受（${e.code || "unknown"} ${e.message || ""}）`,
-    );
-  }
+  // 总线 Unary RPC（session.cancel）：rpcId 回显校验语义保留——总线路径下由 bridge 回投的
+  // result 承载（reqId 配对 + result.ok），降级走 HTTP 时与改造前直连行为一致。
+  await callUnaryBus("session.cancel", { sessionId: targetSessionId });
 
   // 标记：防 mux 断流时事件循环把取消误判为完成（dsh-run.js consume 末尾取消兜底读取该标记）
   if (entry) entry.cancelledRequested = true;

--- a/src/tools/dsh-run.js
+++ b/src/tools/dsh-run.js
@@ -34,7 +34,7 @@ import {
   notifyApprovalWake,
 } from "./lib/wake.js";
 import {
-  callUnary,
+  callUnaryBus,
   openMux,
   textFromChunk,
   textFromMessageBlocks,
@@ -45,9 +45,11 @@ import {
 import { ensureWebHost, ensureConfigJson } from "../lifecycle.js";
 
 // ---- 本地审批应答（自动放行/超时拒绝共用；信封构造同 tools/dsh-approve.js，不 import 避免模块耦合）----
-// POST {base}/api/respond，client-response 信封（rpcId 路由 web host pending 表），校验 j.accepted。
+// 经总线 rpc.request method="respond" 发送（bridge 翻译器自环调 /api/respond，client-response
+// 信封 rpcId 路由 web host pending 表），校验 j.accepted 语义不变；callUnaryBus 总线优先、
+// HTTP 兜底（总线未连接时降级直连，行为与改造前一致），base 参数不再需要（端口从单例取）。
 // 成功返回 true，失败抛错由调用方决定：自动放行失败回退人工通知，超时拒绝失败静默忽略。
-async function respondApprovalLocal(base, approval, outcome) {
+async function respondApprovalLocal(approval, outcome) {
   const body = {
     type: "client-response",
     rpcId: approval.respondRpcId,
@@ -60,16 +62,10 @@ async function respondApprovalLocal(base, approval, outcome) {
       },
     },
   };
-  const res = await fetch(`${base}/api/respond`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify(body),
-  });
-  if (!res.ok) throw new Error(`/api/respond HTTP ${res.status}`);
-  const j = await res.json();
-  if (!j.accepted) {
+  const j = await callUnaryBus("respond", body);
+  if (!j || !j.accepted) {
     throw new Error(
-      `审批应答未接受（${j.reason || "unknown"}）：可能已超时或被其他方处理`,
+      `审批应答未接受（${(j && j.reason) || "unknown"}）：可能已超时或被其他方处理`,
     );
   }
   return true;
@@ -188,8 +184,9 @@ function submitTask(
   // 覆盖式只保留最后一轮、多轮任务严重偏小；按 disjoint 口径累计 = 未缓存输入/输出/缓存读取/推理之和，
   // 与 dsh 会话投影 tokenUsage.totals 对齐）。ok 终态与 promise.catch 的错误终态都能读到。
   let usageTotal = null;
-  // taskRpcId 同样提升到 submitTask 作用域：prompt 提交成功后才产生（callUnary 的 client-request
-  // 信封 rpcId，与 jsonl user/message 的 data.source.rpcId 同值）；事件循环（审批/取消/缓存键）与
+  // taskRpcId 同样提升到 submitTask 作用域：prompt 提交成功后才产生（callUnaryBus 的 rpcId，
+  // 总线路径下 bridge 回投 result 承载、HTTP 降级路径同 callUnary——client-request 信封 rpcId，
+  // 与 jsonl user/message 的 data.source.rpcId 同值）；事件循环（审批/取消/缓存键）与
   // 终态回调都读它。注意不要用 frame.rpcId（server-request 信封自己的 RPC id，仅 /api/respond 的
   // client-response 路由用，见 approval.respondRpcId）。
   let taskRpcId = null;
@@ -207,7 +204,7 @@ function submitTask(
     // agentPreset 无值不传（缺省走 web host 默认，Web UI 可调）
     let createPayload;
     if (resumeSessionId) {
-      const list = await callUnary(base, "session.list", {
+      const list = await callUnaryBus("session.list", {
         projections: ["id", "cwd"],
       });
       const items = list.items || [];
@@ -230,7 +227,7 @@ function submitTask(
     } else {
       createPayload = { cwd, ...(preset && { agentPreset: preset }) };
     }
-    const session = await callUnary(base, "session.create", createPayload);
+    const session = await callUnaryBus("session.create", createPayload);
     const sessionId = session.sessionId;
 
     // 1.5 模型选择：仅当工具显式传 provider/model/effort 时才 selectModel（显式覆盖
@@ -261,14 +258,14 @@ function submitTask(
         ...(effort ? { reasoningEffort: effort } : {}),
       };
       try {
-        await callUnary(base, "session.selectModel", selectModelPayload);
+        await callUnaryBus("session.selectModel", selectModelPayload);
       } catch (err) {
         // 显式 effort 被拒（如 reasoning:false 模型不接受 effort）：降级不带 effort 重试
         if (
           effort &&
           String(err?.message || "").includes("model-unavailable")
         ) {
-          await callUnary(base, "session.selectModel", {
+          await callUnaryBus("session.selectModel", {
             sessionId,
             provider: sp,
             model: sm,
@@ -489,7 +486,7 @@ function submitTask(
                       (a) => a.approvalId === approval.approvalId,
                     );
                     if (ap2 && ap2.status === "pending") {
-                      respondApprovalLocal(base, ap2, "rejected")
+                      respondApprovalLocal(ap2, "rejected")
                         .then(() => {
                           if (ap2.status === "pending") {
                             ap2.status = "answered";
@@ -634,8 +631,7 @@ function submitTask(
       // 经 ready 返回给卡片 URL：插件重启后按 sessionId+rpcId 从 jsonl 精确恢复（运行期协调键
       // 即任务 rpcId，数据定位键合一）
       const promptMeta = {};
-      await callUnary(
-        base,
+      await callUnaryBus(
         "session.prompt",
         {
           sessionId,
@@ -686,7 +682,7 @@ function submitTask(
       // 超时/取消：通知 web host 取消该会话的任务（best effort，agent 在 web 里仍可见）
       if (err?.code === "DSH_TIMEOUT" || err?.code === "DSH_ABORTED") {
         try {
-          await callUnary(base, "session.cancel", { sessionId });
+          await callUnaryBus("session.cancel", { sessionId });
         } catch {
           /* 忽略 */
         }

--- a/src/tools/lib/protocol.js
+++ b/src/tools/lib/protocol.js
@@ -128,6 +128,13 @@ async function callUnaryBus(method, payload, signal, meta) {
     } catch {
       /* 日志失败不阻断 */
     }
+    if (method === "respond") {
+      // respond 是 client-response 信封（rpcId 路由 web host pending 表，payload 已是
+      // { type:"client-response", rpcId, result } 原样信封）——不能用 callUnary 的
+      // client-request 信封（会再包一层，dsh /api/respond 校验失败）。总线不可用时
+      // 直发 HTTP，信封语义与总线路径（bridge 翻译器 respond 特殊处理）一致。
+      return respondDirect(rpcBusBase(g), payload, signal);
+    }
     return callUnary(rpcBusBase(g), method, payload, signal, meta);
   }
   // 总线路径：pending 配对等待 rpc.result（超时/中止清理防泄漏）
@@ -163,6 +170,19 @@ async function callUnaryBus(method, payload, signal, meta) {
     if (signal?.aborted) onAbort();
     else signal?.addEventListener("abort", onAbort, { once: true });
   });
+}
+
+// respond 审批应答直发（client-response 信封原样 POST /api/respond）：总线不可用时的
+// 降级路径。响应 rpcReceipt { accepted, reason? }，调用方校验 j.accepted 语义不变。
+async function respondDirect(base, payload, signal) {
+  const res = await fetch(`${base}/api/respond`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+    signal,
+  });
+  if (!res.ok) throw new Error(`/api/respond HTTP ${res.status}`);
+  return await res.json();
 }
 
 // ---- 事件流（/api/events.mux，WebSocket 通道）----

--- a/src/tools/lib/protocol.js
+++ b/src/tools/lib/protocol.js
@@ -2,19 +2,25 @@
 // Copyright (c) 2026 Nyasers
 //
 // tools/lib/protocol.js — dsh web /api 网关协议层共用模块（lib 提取）
-// 从 tools/dsh-run.js 剥离的纯协议/纯函数：HTTP RPC 客户端、事件流（WS mux）、文本
-// 提取。全部零宿主状态（不碰 globalThis 单例），dsh-run.js 与 dsh-session.js 静态 import。
+// 从 tools/dsh-run.js 剥离的协议/纯函数：总线 RPC 客户端（指令面收敛进 dshana.bus）、
+// HTTP RPC 兜底、事件流（WS mux）、文本提取。dsh-run.js 与 dsh-session.js 静态 import。
 //
-// 归类说明：callUnary / nextRpcId / openMux 是 dsh web host /api 网关的传输协议（Unary
-// RPC + WebSocket 事件流）；textFromChunk / textFromMessageBlocks 是同一网关事件帧的
+// 归类说明：callUnary / callUnaryBus / nextRpcId / openMux 是 dsh web host /api 网关的
+// 传输协议（Unary RPC + WebSocket 事件流）。v0.23.x 起 Unary RPC 指令面（session.create /
+// prompt / selectModel / cancel + respond 审批应答）经 dshana.bus 总线收发（callUnaryBus，
+// 总线优先、HTTP 兜底）；events.mux 事件流保持直连（流式高吞吐 + 实时审批帧不适合事件
+// 通道，见收敛边界注释）。textFromChunk / textFromMessageBlocks 是同一网关事件帧的
 // 文本提取面（assistant/chunk、assistant/message 的载荷提取）。两者同属"与 dsh web
 // 通信的线上协议"一条线，收敛在一个 protocol.js 里（若拆 format.js 反而让 callUnary
 // 与它消费的事件帧解析分处两文件，语义更散）。
 //
 // 消费方：tools/dsh-run.js submitTask（事件循环 / session.create / session.prompt /
-// session.selectModel / session.cancel 全经此层）+ tools/dsh-session.js（get 模式
-// textFromMessageBlocks 提取会话最终结论）。routes/card.js 另有一份独立 openMux
-// 事件流实现，但它不 import 本模块（是独立实现，见 dsh-run.js 头注释），不在此归并。
+// session.selectModel / session.cancel 全经此层）+ tools/dsh-cancel.js / tools/dsh-approve.js
+// （callUnaryBus）+ tools/dsh-session.js（get 模式 textFromMessageBlocks 提取会话最终结论）。
+// routes/card.js 另有一份独立 openMux 事件流实现，但它不 import 本模块（是独立实现，
+// 见 dsh-run.js 头注释），不在此归并。
+
+import { getSingleton } from "./state.js";
 
 // ---- HTTP RPC 客户端（dsh web /api 网关，fetch 载波）----
 // Unary：POST /api/<method>，body = { type:"client-request", rpcId, method, payload }
@@ -45,6 +51,118 @@ async function callUnary(base, method, payload, signal, meta) {
   // 供 op 快照记录后用 sessionId+rpcId 从 jsonl 精确恢复（重启不丢、零映射文件）
   if (meta && typeof meta === "object") meta.rpcId = rpcId;
   return full.result.value;
+}
+
+// ---- 总线 RPC（dshana.bus，Unary RPC 指令面收敛）----
+// v0.23.x 起 Unary RPC 指令面（session.create / prompt / selectModel / cancel + respond 审批
+// 应答）经 dshana.bus 总线收发：宿主 emit rpc.request（payload = { reqId, method, payload }），
+// dsh 进程内 @dsh-hanako/bridge 翻译器自环调 /api/<method> 后回投 rpc.result（payload =
+// { reqId, ok, value? } 或 { reqId, ok:false, error }），宿主按 reqId 配对等待。
+// 总线优先、HTTP 兜底：总线未连接（emit 返回 false 或 dshanaBus 未就绪）时降级回退
+// callUnary（HTTP），保可用性并 appendLog 记录降级（events.mux 事件流仍直连，不进总线）。
+// 收敛边界：数据面（events.mux 流式 chunk/审批帧/终态）与 /api/host.describe 就绪探测
+// （发生在 connectBus 之前的鸡生蛋）保留 HTTP 直连，见 lifecycle.js 注释。
+const BUS_RPC_TIMEOUT_MS = 60000; // 总线 RPC 默认超时（响应丢失/桥接异常兜底，防 pending 挂死）
+
+// callUnaryBus 的 pending 表（reqId → { resolve, reject, timer, method }）与 rpc.result
+// 订阅（模块级惰性接线一次，宿主侧 bus.js 的 on 是裸 EventEmitter 分发，无 ch: 前缀）
+const rpcPending = new Map();
+let rpcResultWired = false;
+
+function wireRpcResult() {
+  if (rpcResultWired) return;
+  const g = getSingleton();
+  const bus = g?.dshanaBus;
+  if (!bus || typeof bus.on !== "function") return;
+  rpcResultWired = true;
+  bus.on("rpc.result", (payload) => {
+    if (!payload || typeof payload !== "object" || typeof payload.reqId !== "string") return;
+    const entry = rpcPending.get(payload.reqId);
+    if (!entry) return; // 未知 reqId（已超时清理/垃圾帧）：忽略
+    // 清理（clearTimeout/delete/移除 abort 监听）统一在 settle 内做——
+    // 不能在 resolve/reject 前先 delete，否则 settle 的 pending 校验会误判已 settle 而跳过。
+    if (payload.ok) {
+      // meta.rpcId 回传与 callUnary 同语义：会话 jsonl data.source.rpcId == reqId
+      if (entry.meta && typeof entry.meta === "object") entry.meta.rpcId = payload.reqId;
+      entry.resolve(payload.value);
+    } else {
+      const e = payload.error || {};
+      entry.reject(
+        new Error("dsh " + entry.method + " 失败：" + (e.code || "unknown") + " " + (e.message || "")),
+      );
+    }
+  });
+}
+
+// 降级路径的 base 来源：web host 单例（调用方通常已 ensureWebHost / hostBase 校验就绪）
+function rpcBusBase(g) {
+  const web = g?.web;
+  if (web?.ready && web.port) return "http://127.0.0.1:" + web.port;
+  throw new Error("DSH web host 未就绪（callUnaryBus 降级路径）");
+}
+
+// 总线 Unary RPC：method/payload 同 callUnary；signal 支持中止（总线路径下
+// AbortError 语义与 fetch 一致）；meta 成功时回传 rpcId（与 callUnary 同）。
+async function callUnaryBus(method, payload, signal, meta) {
+  const reqId = nextRpcId();
+  const g = getSingleton();
+  const bus = g?.dshanaBus;
+  // 总线优先：dshanaBus 就绪且 emit 送达（bus.js sendFrame 排队成功才 true——
+  // 未连接/未握手返回 false）才走总线；否则降级 HTTP 兜底（保可用性）。
+  let queued = false;
+  if (bus && typeof bus.emit === "function") {
+    try {
+      wireRpcResult(); // 先接线再发（响应经 WS 异步到达，接线必先于回投）
+      queued = bus.emit("rpc.request", { reqId, method, payload });
+    } catch {
+      queued = false;
+    }
+  }
+  if (!queued) {
+    // 降级路径：总线未连接/未握手 → 回退现 callUnary（HTTP），错误语义与直连一致
+    try {
+      g?.appendLog?.(
+        "hana",
+        "[dshana.bus] rpc.request 未送达（总线未连接），" + method + " 降级走 HTTP",
+      );
+    } catch {
+      /* 日志失败不阻断 */
+    }
+    return callUnary(rpcBusBase(g), method, payload, signal, meta);
+  }
+  // 总线路径：pending 配对等待 rpc.result（超时/中止清理防泄漏）
+  return new Promise((resolve, reject) => {
+    const settle = (fn, value) => {
+      if (rpcPending.get(reqId) !== entry) return; // 已 settle：忽略迟到事件
+      clearTimeout(entry.timer);
+      rpcPending.delete(reqId);
+      signal?.removeEventListener("abort", onAbort);
+      fn(value);
+    };
+    const onAbort = () => {
+      settle(
+        reject,
+        Object.assign(new Error("已取消"), { name: "AbortError" }),
+      );
+    };
+    const entry = {
+      method,
+      meta,
+      resolve: (value) => settle(resolve, value),
+      reject: (err) => settle(reject, err),
+      timer: null,
+    };
+    entry.timer = setTimeout(() => {
+      settle(
+        reject,
+        new Error("dsh " + method + " 总线 RPC 超时（" + BUS_RPC_TIMEOUT_MS / 1000 + "s）"),
+      );
+    }, BUS_RPC_TIMEOUT_MS);
+    entry.timer.unref?.();
+    rpcPending.set(reqId, entry);
+    if (signal?.aborted) onAbort();
+    else signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 // ---- 事件流（/api/events.mux，WebSocket 通道）----
@@ -149,6 +267,7 @@ function textFromMessageBlocks(content) {
 export {
   nextRpcId,
   callUnary,
+  callUnaryBus,
   openMux,
   textFromChunk,
   textFromMessageBlocks,


### PR DESCRIPTION
## 总线 RPC 收敛：指令面全总线化（v0.23.x 续）

延续 v0.23.0"总线替代进程间 HTTP 碎片"声明，把宿主侧协议面的**指令面**（Unary RPC）收敛进 dshana.bus。

### 收敛边界（与用户确认）
- **收进总线**：Unary RPC（session.create / prompt / selectModel / cancel）+ respond 审批应答
- **保留直连**：/api/events.mux WS 事件流（流式 chunk + 实时审批帧 + 终态，高吞吐不适合事件通道）；/api/host.describe 就绪探测（connectBus 之前的鸡生蛋，启动期一次性握手）

### 设计
- **新通道**：pc.request（宿主→dsh，{reqId, method, payload}）+ pc.result（dsh→宿主，{reqId, ok, value|error}），reqId 配对复用 update 链路模式
- **bridge 翻译器**（dsh 进程内）：订阅 rpc.request → 本机自环 etch 127.0.0.1:webServer.port/api/<method>（dsh mux 零改动）→ 回投 rpc.result；respond 走 client-response 信封（rpcId 路由 pending 表）单独处理；**所有异常路径必须回投**（防宿主 pending 挂死）
- **宿主侧 callUnaryBus**：总线优先、HTTP 兜底（总线未连接 emit 返回 false 时降级 callUnary + appendLog 记录）；pending Map + 60s 超时（unref）+ AbortSignal + settle 幂等（迟到回投忽略）
- **安全**：不设 method 白名单（本机信任模型：本机进程本就可直接 POST 3080 /api/*，总线只是换入口，攻击面未扩大）

### 验证
- dsh 单测 25/25：call-unary-bus 10（配对/超时/abort/降级/pending 清理）+ bridge-translator 10（成功/失败/异常/reqId 回显/非法帧忽略）+ bridge-translator-http 5（respond 信封/HTTP 错误）
- 完整回归 112/112（7 组既有测试）+ build 通过
- 审批链路走查：approval/requested 帧（events.mux WS）→ respondApprovalLocal 经总线 → bridge 自环 /api/respond → dsh mux，j.accepted 校验语义不变

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bus-based RPC support for request handling and responses.
  * Updated approval, cancellation, session, model, and prompt operations to use the message bus.
  * Added automatic HTTP fallback when bus communication is unavailable.
  * Added request correlation, metadata propagation, cancellation, timeouts, and error handling.

* **Documentation**
  * Documented the new RPC message types and bus-first communication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->