### PR TITLE
fix: 非正常终态 minimal 形态返回——取消/超时/错误统一走 resolve 回调带定位键

### DIFF
--- a/src/tools/dsh-run.js
+++ b/src/tools/dsh-run.js
@@ -30,7 +30,7 @@ import {
 import {
   registerDeferredWake,
   resolveDeferredWake,
-  failDeferredWake,
+  abnormalWakeResult,
   notifyApprovalWake,
 } from "./lib/wake.js";
 import {
@@ -687,8 +687,8 @@ function submitTask(
           /* 忽略 */
         }
       }
-      // 附加已创建的 sessionId（session.create 成功后 prompt/执行失败时）：execute 层
-      // failDeferredWake 优先用 err.sessionId——session.prompt 失败时 ready 的 loc 为 null
+      // 附加已创建的 sessionId（session.create 成功后 prompt/执行失败时）：回调层
+      // abnormalWakeResult 优先用 err.sessionId——session.prompt 失败时 ready 的 loc 为 null
       // （resolveReady 未调），不附加则已创建的会话 ID 丢失，错误只剩空 rpcId 无法对账。
       if (err && typeof err === "object" && !err.sessionId && sessionId) {
         err.sessionId = sessionId;
@@ -912,22 +912,14 @@ async function doExecute(input, ctx) {
         });
       },
       (err) => {
-        // 尽力带定位键：有 sessionId（提交成功后的执行失败）时 error 带 sessionId；
-        // 提交失败无 sessionId 的场景带 rpcId（可为空串）。主上下文凭定位键直接取会话
-        // 内容/对账，无需额外搜索（dsh_session get 直取）。
-        const error = { message: String(err?.message || err).slice(0, 300) };
-        // 定位键优先级：rejected error 自带的 sessionId（submitTask 内已附加，session.prompt
-        // 失败时 loc 为 null 也保留已创建的会话）→ loc.sessionId → taskRpcId（可为空串）。
-        // 避免 session.prompt 失败（loc null）时只剩空 rpcId、已创建会话无法对账。
-        const errSessionId =
-          err && typeof err === "object" ? err.sessionId : undefined;
-        if (errSessionId) error.sessionId = errSessionId;
-        else if (loc?.sessionId) error.sessionId = loc.sessionId;
-        else error.rpcId = taskRpcId;
-        failDeferredWake({
+        // 非正常终态（取消/超时/错误）也走 resolve 形态：宿主对 deferred:fail 只呈现
+        // error.message 纯文本（实测丢定位键），resolve 的 result JSON 完整回传——与正常
+        // 结束同构的 minimal 定位键 { status, rpcId, sessionId } + 简短 message
+        // （status：cancelled / timeout / failed）。定位键优先级见 abnormalWakeResult。
+        resolveDeferredWake({
           bus,
           taskId: deferredTaskId,
-          error,
+          result: abnormalWakeResult({ err, loc, taskRpcId }),
         });
       },
     );

--- a/src/tools/dsh-run.js
+++ b/src/tools/dsh-run.js
@@ -928,11 +928,23 @@ async function doExecute(input, ctx) {
       content: [
         {
           type: "text",
-          text: `任务已提交给 DSH（rpcId: ${taskRpcId}），在后台执行中。进度与输出见上方卡片；完成后后台消息仅带回任务状态与定位键（rpcId/sessionId），取内容用 dsh_session get。`,
+          // 提交返回即带 sessionId（持久定位键，jsonl 文件级，不依赖 g.ops 内存态）：
+          // loc.sessionId 在 await ready 后已可用（session.create + prompt 提交成功），
+          // 与卡片 URL locQuery 同源。放 content text 而非仅 details——details 不进入
+          // Agent 上下文（实机：wait 返回只有 text），Agent 凭 text 里的 sessionId 立即
+          // dsh_cancel / dsh_session get，无需反查 list 或等终态回调。提交失败（loc
+          // null）时 sessionId 占位「（提交失败）」，rpcId 仍可定位（deferred 回调兜底）。
+          text: `任务已提交给 DSH（rpcId: ${taskRpcId}，sessionId: ${(loc && loc.sessionId) || "（提交失败）"}），在后台执行中。进度与输出见上方卡片；完成后后台消息仅带回任务状态与定位键（rpcId/sessionId），取内容用 dsh_session get。`,
         },
       ],
       details: {
-        dsh: { rpcId: taskRpcId, status: "running", cwd, wait: false },
+        dsh: {
+          sessionId: (loc && loc.sessionId) || "",
+          rpcId: taskRpcId,
+          status: "running",
+          cwd,
+          wait: false,
+        },
         card: cardBase,
       },
     };

--- a/src/tools/lib/wake.js
+++ b/src/tools/lib/wake.js
@@ -67,6 +67,28 @@ async function failDeferredWake({ bus, taskId, error }) {
   }
 }
 
+// ---- 非正常终态的 minimal 结果构造 ----
+// 宿主对 deferred:fail 只呈现 error.message 纯文本（实测丢定位键）；deferred:resolve 的
+// result JSON 完整回传（正常完成已验证）。非正常终态（取消/超时/错误）统一走 resolve
+// 形态，带与正常结束同构的定位键 { status, rpcId, sessionId } + 简短 message，主上下文
+// 凭定位键直接 dsh_session get 对账，无需额外搜索。定位键优先级：err.sessionId（submitTask
+// 内已附加，session.prompt 失败时 loc 为 null 也保留已创建的会话）→ loc.sessionId → rpcId。
+// status 语义：DSH_ABORTED=取消 → cancelled；DSH_TIMEOUT → timeout；其他 → failed。
+// 纯函数（零宿主状态），供 dsh-run.js catch 分支调用；dsh-install / dsh-update 仍用
+// failDeferredWake（安装/更新失败无需会话定位，message 语义足够）。
+function abnormalWakeResult({ err, loc, taskRpcId }) {
+  const code = err && typeof err === "object" ? err.code : undefined;
+  const errSessionId = err && typeof err === "object" ? err.sessionId : undefined;
+  const status =
+    code === "DSH_ABORTED" ? "cancelled" : code === "DSH_TIMEOUT" ? "timeout" : "failed";
+  return {
+    status,
+    rpcId: taskRpcId || "",
+    sessionId: errSessionId || (loc && loc.sessionId) || "",
+    message: String((err && err.message) || err).slice(0, 300),
+  };
+}
+
 // ---- 审批挂起通知（宿主 deferred 通道，独立 taskId 不占用任务完成通道）----
 // dsh 会话触发 approval/requested 时任务挂起等应答；插件把审批上下文投递给宿主，
 // Agent 收到后调用 dsh_approve 工具应答（allowed-once / rejected）。
@@ -108,5 +130,6 @@ export {
   registerDeferredWake,
   resolveDeferredWake,
   failDeferredWake,
+  abnormalWakeResult,
   notifyApprovalWake,
 };


### PR DESCRIPTION
## 问题

dsh_run 后台回调在非正常结束（取消/abort）时走 deferred:fail，宿主只呈现 error.message 纯文本（如「dsh_run 已取消」），丢失 rpcId/sessionId 定位键，宿主无法凭定位键 dsh_session get 对账。

## 根因

- 宿主对 deferred:fail 的投递只呈现 error.message 文本，附加字段（sessionId/rpcId）不进后台消息（实机验证）
- deferred:resolve 的 result JSON 完整回传（正常完成路径已验证）
- 旧代码 catch 分支用 failDeferredWake 投递错误对象，定位键随宿主 fail 形态丢失

## 修复

非正常终态统一改走 deferred:resolve（与正常结束同构的 minimal 形态）：

- **wake.js** 新增 bnormalWakeResult 纯函数：定位键优先级 err.sessionId → loc.sessionId → rpcId；status 细分 cancelled（DSH_ABORTED）/ timeout（DSH_TIMEOUT）/ failed；message 截断 300
- **dsh-run.js** catch 分支由 failDeferredWake 改为 resolveDeferredWake + abnormalWakeResult
- failDeferredWake 保留给 dsh-install / dsh-update（安装/更新失败无会话定位需求，message 语义足够）

## 验证

- 单测 9/9 过（_tmp/tests/wake-abnormal.test.mjs，gitignored）：status 细分、定位键优先级、rpcId 兜底、message 截断、字符串错误兜底、catch 分支静态断言
- 实机：异步任务取消 → 回调 {status:"cancelled", rpcId, sessionId, message} 全带定位键（r_mtfcbj08_u8ucft）
- node --check 过；build 过；插件目录已装新版实机验证

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of abnormal task completions during deferred wake operations.
  * Abort, timeout, and other failures now resolve consistently with clear statuses.
  * Error results preserve relevant task and session details while limiting messages to 300 characters.
* **Enhancements**
  * Asynchronous submissions now display a session ID in user-facing output and metadata.
  * Submission failures include a placeholder when a session ID is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->