### PR TITLE
refactor: g.ops 运行期协调态收敛——键改 sessionId，字段收敛为最小协调态

### DIFF
--- a/skills/dsh-approve/SKILL.md
+++ b/skills/dsh-approve/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dsh-approve
-description: "dsh_approve 工具手册（源码 tools/dsh-approve.js 核对）。触发场景：dsh 任务挂起审批怎么应答、收到 dsh-approval 通知怎么处理（payload 结构：rpcId/approvalId/toolName/callId/reason/args 命令路径原文）、allowed-once 与 rejected 怎么选、决策看 args 不听 reason、无人应答超时自动拒绝（approvalTimeoutMs）、审批已应答/已超时/不在待办列表的报错语义、Web UI 人工处理兜底。需要应答 dsh 审批前先读本技能。"
+description: "dsh_approve 工具手册（源码 tools/dsh-approve.js 核对）。触发场景：dsh 任务挂起审批怎么应答、收到 dsh-approval 通知怎么处理（payload 结构：sessionId/approvalId/toolName/callId/reason/args 命令路径原文）、allowed-once 与 rejected 怎么选、决策看 args 不听 reason、无人应答超时自动拒绝（approvalTimeoutMs）、审批已应答/已超时/不在待办列表的报错语义、Web UI 人工处理兜底。需要应答 dsh 审批前先读本技能。"
 ---
 
 # dsh_approve 工具手册
@@ -9,17 +9,17 @@ description: "dsh_approve 工具手册（源码 tools/dsh-approve.js 核对）�
 
 ## 参数契约
 
-`required: ["rpcId", "approvalId"]`：
+`required: ["sessionId", "approvalId"]`：
 
 | 参数 | 类型 | 语义 |
 |---|---|---|
-| `rpcId` | string | 审批所属 dsh 任务的 rpcId（审批通知里带；任务级 rpcId，每次任务调用唯一） |
+| `sessionId` | string | 审批所属 dsh 会话的 sessionId（审批通知里带；全链路唯一定位键，dsh_run 提交返回/卡片 URL 同键） |
 | `approvalId` | string | 审批 id（同一任务可能挂起多个审批，逐个应答） |
 | `outcome` | enum: allowed-once/rejected | 默认 `allowed-once`（安全默认：放行单次，仅本次操作）/ `rejected` 拒绝该请求 |
 
 ## 审批全链路（触发 → 应答 → 收尾）
 
-1. **触发**：dsh agent 请求越界权限（approval/policy=ask）→ 任务挂起，插件把审批上下文存进运行期协调条目 `g.ops[任务 rpcId].pendingApprovals`（审批对象含 respond 路由所需 `respondRpcId`——审批帧信封自己的 RPC id，区别于任务 rpcId），暂停任务执行超时计时。
+1. **触发**：dsh agent 请求越界权限（approval/policy=ask）→ 任务挂起，插件把审批上下文存进运行期协调条目 `g.ops[sessionId].activeApprovals`（审批对象含 respond 路由所需 `respondRpcId`——审批帧信封自己的 RPC id，区别于任务 rpcId），暂停任务执行超时计时。
 2. **通知**：经宿主 deferred 通道投递（taskId = `` `${rpcId}::approval::${approvalId}` ``，rpcId 为任务级 rpcId；独立于任务完成通道），payload：
    ```
    { kind: "dsh-approval", rpcId, sessionId, approvalId, toolName, callId,
@@ -29,21 +29,21 @@ description: "dsh_approve 工具手册（源码 tools/dsh-approve.js 核对）�
    ```
    args 来源：事件循环按 callId 从 toolCallCache 反查（tool/call 与 code-dispatch 子调用 subCallId 形如 `root:code:N` 均缓存；miss 时剥 `:code:N` 后缀回退 run_code 根调用兜底）。
 3. **决策**：**看 args（具体执行了什么），不听 reason（model 自述）**。合理 → `allowed-once`；危险 → `rejected`。
-4. **应答**：`dsh_approve(rpcId, approvalId, outcome)`，经总线 RPC（`callUnaryBus`，rpc.request/rpc.result 通道）发 `method="respond"`——bridge 在 dsh 进程内自环调 `POST /api/respond`（client-response 信封，用审批对象的 `respondRpcId` 路由 pending 表），回投 `{ accepted }` 校验 `j.accepted` 语义不变；总线未连接时降级 HTTP 直连。
+4. **应答**：`dsh_approve(sessionId, approvalId, outcome)`，经总线 RPC（`callUnaryBus`，rpc.request/rpc.result 通道）发 `method="respond"`——bridge 在 dsh 进程内自环调 `POST /api/respond`（client-response 信封，用审批对象的 `respondRpcId` 路由 pending 表），回投 `{ accepted }` 校验 `j.accepted` 语义不变；总线未连接时降级 HTTP 直连。
 5. **超时**：`approvalTimeoutMs`（默认 30000；0 = 禁用）内无人应答自动 rejected（`auto: "expired"`）。应答方失联检测：正常应答几秒内完成。
 6. **恢复**：approval/resolved（allowed-once/rejected/cancelled 一律视为已解决）→ 清该审批超时计时器，无 pending 项时恢复任务执行计时。
 7. **兜底**：也可在 dsh Web UI 人工处理；通知失败不影响任务。
 
 ## 应答校验与错误语义
 
-- 任务条目不存在/已过期（g.ops 条目仅活到任务终态，终态即删除）：`任务不存在或已过期（rpcId: xxx）：只可应答本会话近期提交的 dsh 任务审批`
+- 任务条目不存在/已过期（g.ops 条目仅活到任务终态，终态即删除）：`任务不存在或已过期（sessionId: xxx）：只可应答本会话近期提交的 dsh 任务审批`
 - approval 不在待办列表：`审批 xxx 不在任务 yyy 的待办列表（可能已被应答/超时）。已知: …`（列出已知项及状态）
 - 已应答：`审批 xxx 已应答（allowed-once/rejected），勿重复应答`
 - 应答未接受（`!j.accepted`）：`审批应答未接受（reason）：可能已超时或被其他方处理，任务侧会自行感知`
 
 ## 返回
 
-成功：`已放行/已拒绝审批 <approvalId> [toolName]（理由）`，details `{ dsh: { rpcId, approvalId, toolName, outcome, accepted: true } }`。
+成功：`已放行/已拒绝审批 <approvalId> [toolName]（理由）`，details `{ dsh: { sessionId, approvalId, toolName, outcome, accepted: true } }`。
 
 ## 关联
 

--- a/src/tools/dsh-approve.js
+++ b/src/tools/dsh-approve.js
@@ -3,8 +3,9 @@
 //
 // tools/dsh-approve.js — dsh 审批应答工具
 // dsh 会话审批挂起（approval/policy=ask 触发 approval/requested）时，dsh_run 任务的事件
-// 循环会把审批上下文存进运行期协调条目（g.ops，键 = 任务 rpcId；审批对象含 respond 路由
-// 所需的 respondRpcId——server-request 信封自己的 RPC id，区别于任务 rpcId），并通过宿主
+// 循环会把审批上下文存进运行期协调条目（g.ops，键 = sessionId——全链路唯一定位键；
+// 审批对象含 respond 路由所需的 respondRpcId——server-request 信封自己的 RPC id，
+// 区别于任务 rpcId），并通过宿主
 // deferred 通道通知 Agent。Agent 收到通知后调用本工具应答：allowed-once 放行单次 / rejected
 // 拒绝。内部经总线 rpc.request method="respond" 调 dsh web host /api/respond（callUnaryBus，
 // 总线优先/HTTP 兜底；bridge 回投 { accepted }，校验 j.accepted 语义不变）。
@@ -15,16 +16,16 @@ export const name = "dsh_approve";
 
 export const description =
   "应答 DSH 任务挂起的权限审批（approval/requested）：allowed-once=放行该次请求 / rejected=拒绝。" +
-  "rpcId 与 approvalId 来自审批通知；应答前评估通知里的 toolName 与 reason（命令原文）决定放行或拒绝。" +
+  "sessionId 与 approvalId 来自审批通知；应答前评估通知里的 toolName 与 reason（命令原文）决定放行或拒绝。" +
   "无人应答也可在 DSH Web UI 人工处理。完整调用手册见 SKILL: skills/dsh-approve/SKILL.md";
 
 export const parameters = {
   type: "object",
   properties: {
-    rpcId: {
+    sessionId: {
       type: "string",
       description:
-        "审批所属 DSH 任务的 rpcId（审批通知里带；任务级 rpcId，每次任务调用唯一）",
+        "审批所属 DSH 会话的 sessionId（审批通知里带；全链路唯一定位键，dsh_run 提交返回/卡片 URL 同键）",
     },
     approvalId: {
       type: "string",
@@ -38,7 +39,7 @@ export const parameters = {
         "allowed-once=放行单次（默认，安全默认值：仅本次操作）/ rejected=拒绝该请求",
     },
   },
-  required: ["rpcId", "approvalId"],
+  required: ["sessionId", "approvalId"],
 };
 
 export const sessionPermission = {
@@ -52,26 +53,26 @@ export const sessionPermission = {
 };
 
 async function doExecute(input, ctx) {
-  const rpcId = String(input.rpcId ?? "").trim();
+  const sessionId = String(input.sessionId ?? "").trim();
   const approvalId = String(input.approvalId ?? "").trim();
   const outcome = input.outcome === "rejected" ? "rejected" : "allowed-once";
-  if (!rpcId || !approvalId) throw new Error("rpcId 与 approvalId 必填");
+  if (!sessionId || !approvalId) throw new Error("sessionId 与 approvalId 必填");
 
   const g = globalThis.__dshHanako;
-  const op = g?.ops?.get(rpcId);
+  const op = g?.ops?.get(sessionId);
   if (!op)
     throw new Error(
-      `任务不存在或已过期（rpcId: ${rpcId}）：只可应答本会话近期提交的 DSH 任务审批`,
+      `任务不存在或已过期（sessionId: ${sessionId}）：只可应答本会话近期提交的 DSH 任务审批`,
     );
-  const approvals = Array.isArray(op.pendingApprovals)
-    ? op.pendingApprovals
+  const approvals = Array.isArray(op.activeApprovals)
+    ? op.activeApprovals
     : [];
   const ap = approvals.find((a) => a.approvalId === approvalId);
   if (!ap) {
     const known =
       approvals.map((a) => `${a.approvalId}(${a.status})`).join(", ") || "无";
     throw new Error(
-      `审批 ${approvalId} 不在任务 ${rpcId} 的待办列表（可能已被应答/超时）。已知: ${known}`,
+      `审批 ${approvalId} 不在会话 ${sessionId} 的待办列表（可能已被应答/超时）。已知: ${known}`,
     );
   }
   if (ap.status !== "pending") {
@@ -113,7 +114,7 @@ async function doExecute(input, ctx) {
       },
     ],
     details: {
-      dsh: { rpcId, approvalId, toolName: ap.toolName, outcome, accepted: true },
+      dsh: { sessionId, approvalId, toolName: ap.toolName, outcome, accepted: true },
     },
   };
 }

--- a/src/tools/dsh-cancel.js
+++ b/src/tools/dsh-cancel.js
@@ -8,8 +8,8 @@
 // cancel 后 dsh 会发 turn/end（reason.kind=aborted），事件循环判 outcome.stopReason === "aborted"
 // → throw DSH_ABORTED → promise.catch 以 aborted 终态收尾（deferred fail 带「dsh_run 已取消」唤醒 Agent）。
 // 任务状态零存储（jsonl 唯一事实源），取消必传 sessionId（dsh_run 回调/卡片 URL 取）直接定位会话；
-// g.ops 运行期条目以任务 rpcId 键控，cancel 只有 sessionId 时遍历条目找 sessionId 匹配项
-// （条目极少——仅运行中任务，遍历可忽略；极早 cancel 条目未建则跳过标记）。工具侧先标记
+// g.ops 运行期条目以 sessionId 键控（协调态最小化：{ cancelledRequested, activeApprovals }），
+// cancel 凭 sessionId 直接 ops.get 取条目（极早 cancel 条目未建则跳过标记）。工具侧先标记
 // cancelledRequested = true，防 cancel 导致 mux 断流时事件循环把取消误判为完成
 // （dsh-run.js consume 末尾的取消兜底）。best-effort 止损：任务刚好自然完成时 cancel 的 accepted
 // 无副作用（事件循环已终态，cancel 幂等）。
@@ -53,15 +53,9 @@ async function doExecute(input, ctx) {
     );
 
   const g = globalThis.__dshHanako;
-  // 运行期协调条目以任务 rpcId 键控，cancel 只有 sessionId：遍历 g.ops 找该会话条目
-  // （条目极少——仅运行中任务，遍历可忽略）；极早 cancel（条目未建）时 entry 为 null，跳过标记
-  let entry = null;
-  for (const e of g?.ops?.values() ?? []) {
-    if (e.sessionId === sessionId) {
-      entry = e;
-      break;
-    }
-  }
+  // 运行期协调条目以 sessionId 键控：凭 sessionId 直接取条目（协调态最小化，无需遍历）；
+  // 极早 cancel（条目未建）时 entry 为 null，跳过标记（语义不变）
+  const entry = g?.ops?.get(sessionId) ?? null;
   const targetSessionId = sessionId;
 
   // 总线 Unary RPC（session.cancel）：rpcId 回显校验语义保留——总线路径下由 bridge 回投的

--- a/src/tools/dsh-run.js
+++ b/src/tools/dsh-run.js
@@ -4,9 +4,10 @@
 // tools/dsh-run.js — dsh_run 工具（有状态任务提交核心 + 工具契约）
 // 把任务交给 DeepSeek Harness（dsh）的 web host（--profile web）执行：
 // 经 /api 网关提交任务（session.create → events.mux 订阅 → session.prompt），
-// 实时事件流驱动卡片输出。运行期协调键统一为任务 rpcId（session.prompt 提交产生的
-// RPC id，与 jsonl user/message 的 data.source.rpcId 同值）——g.ops 条目键 /
-// toolCallCache / approvalTimers 全部以任务 rpcId 键控，运行期协调键与数据定位键合一。
+// 实时事件流驱动卡片输出。运行期协调态收敛：g.ops 条目键 = sessionId（全链路唯一定位键，
+// dsh_run 提交返回 / 卡片 URL / dsh_cancel / dsh_session 同键）；toolCallCache /
+// approvalTimers 仍以任务 rpcId 键控（session.prompt 提交产生的 RPC id，与 jsonl
+// user/message 的 data.source.rpcId 同值，不在本次收敛范围）。
 // 本文件收敛为「有状态提交核心」——与审批状态机（g.ops / approvalTimers /
 // toolCallCache）紧耦合的代码保留在此；纯协议/解析/唤醒已剥离到 lib/*.js，
 // web host 生命周期在 app/lifecycle.js。
@@ -86,23 +87,24 @@ const toolCallCache = new Map();
 // ---- 运行期协调状态（任务状态零存储，g.ops 仅存审批/取消协调字段）----
 // 任务状态（status/output/summary/usage/耗时）不再保存在插件内存：jsonl（dsh 会话日志）是
 // 唯一事实源，卡片经 /ops/stream 从 jsonl 重建基线 + 转发 DSH 实时事件，插件零任务状态。
-// g.ops 仅保留「审批/取消」运行期协调状态：任务 rpcId → { rpcId, task, sessionId,
-// approvalPending, pendingApprovals, cancelledRequested }。任务终态时在 submitTask 的 finally
-// 删除条目。用途：① approval/requested 存审批上下文（respondRpcId 路由 respond），
-// dsh_approve 工具应答；② dsh_cancel 按 sessionId 遍历 g.ops 找条目并标记 cancelledRequested
-//   （防 mux 断流时事件循环把取消误判为完成）。
+// g.ops 仅保留「审批/取消」运行期协调状态，键 = sessionId（全链路唯一定位键：dsh_run
+// 提交返回 / 卡片 URL / dsh_cancel / dsh_session 同键）：sessionId → { cancelledRequested,
+// activeApprovals }。approvalPending 派生态删除（有 pending 项即挂起，activeApprovals 数组
+// 判断即可）。任务终态时在 submitTask 的 finally 删除条目。用途：① approval/requested
+// 存审批上下文（respondRpcId 路由 respond），dsh_approve 工具应答；② dsh_cancel 凭
+// sessionId 直接 ops.get 取条目并标记 cancelledRequested（防 mux 断流时事件循环把取消
+// 误判为完成）。前提：同一 sessionId 多轮 prompt（resume 复用会话）时条目被当轮覆盖——
+// dsh 会话串行（上一轮终态 finally 已删条目），当轮条目语义正确。
 
-function createOpEntry(taskRpcId, { task, sessionId }) {
+function createOpEntry(sessionId) {
   const g = getSingleton();
-  g.ops.set(taskRpcId, {
-    rpcId: taskRpcId,
-    task: String(task ?? "").slice(0, 500),
-    sessionId: sessionId ?? null, // prompt 提交成功后建条目时已建会话，直接回填（dsh_cancel 按 sessionId 遍历反查）
-    approvalPending: false,
-    pendingApprovals: [],
+  // 协调态最小化：task/sessionId/approvalPending 均不再存（task 原文在 jsonl user/message，
+  // sessionId 即键，approvalPending 由 activeApprovals 是否有 pending 项推出）
+  g.ops.set(sessionId, {
+    activeApprovals: [],
     cancelledRequested: false,
   });
-  return taskRpcId;
+  return sessionId;
 }
 
 // 缓存 tool/call 帧的参数原文（审批决策信息源）。
@@ -128,7 +130,8 @@ function cacheToolCall(taskRpcId, payload) {
 }
 // ---- 任务提交：注册运行期协调状态 + 后台执行（不 await）----
 // 返回 { promise, ready }：任务 rpcId 由 prompt 提交产生（submitTask 作用域提升变量，事件循环
-// 与终态回调共用；运行期协调键与数据定位键合一）；卡片 route 由 ready 的 sessionId+rpcId 定位；
+// 与终态回调共用；toolCallCache / approvalTimers 以任务 rpcId 键控，g.ops 以 sessionId 键控）；
+// 卡片 route 由 ready 的 sessionId+rpcId 定位；
 // promise 在后台跑：session.create → events.mux 订阅 → session.prompt → 事件循环 → 终态。
 // 任务状态零存储——collected/blocksSeq/usageTotal 仅用于回调返回，
 // 卡片状态由 /ops/stream 从 jsonl 重建 + 实时事件转发呈现。
@@ -418,7 +421,7 @@ function submitTask(
             }
           } else if (frame.type === "approval/requested") {
             // 审批挂起（approval/policy=ask）：任务会等待应答。把审批上下文（含 respond
-            // 路由所需的 respondRpcId）存进运行期协调状态（g.ops 条目，键 = 任务 rpcId），并触发
+            // 路由所需的 respondRpcId）存进运行期协调状态（g.ops 条目，键 = sessionId），并触发
             // 宿主 deferred 通知（独立 taskId，不占用任务完成通道），Agent 收到后
             // 调用 dsh_approve 工具应答；无人应答仍可在 dsh Web UI 人工处理。
             // 审批固定形态——挂起 → deferred 通知 Agent（附 tool/call 参数原文，
@@ -426,9 +429,8 @@ function submitTask(
             // （approvalTimeoutMs，默认 30s 应答方失联检测，0=禁用）。不再有白名单自动放行
             // 或 manual/auto 模式切换：全部审批都交 Agent 处理。
             const g = getSingleton();
-            const op = g.ops.get(taskRpcId);
+            const op = g.ops.get(sessionId);
             if (op) {
-              op.approvalPending = true;
               const approval = {
                 approvalId: frame.approvalId,
                 respondRpcId: frame.rpcId,
@@ -459,13 +461,13 @@ function submitTask(
                 }
               }
               approval.args = cachedCall?.args ?? null;
-              if (!Array.isArray(op.pendingApprovals)) op.pendingApprovals = [];
+              if (!Array.isArray(op.activeApprovals)) op.activeApprovals = [];
               if (
-                !op.pendingApprovals.some(
+                !op.activeApprovals.some(
                   (a) => a.approvalId === approval.approvalId,
                 )
               ) {
-                op.pendingApprovals.push(approval);
+                op.activeApprovals.push(approval);
                 // 统一流程：所有审批都通知 Agent 应答（不区分 manual/auto，无白名单）。
                 // 通知附带命令/路径原文（approval.args）；挂起后暂停执行超时计时（外部决策等待
                 // 不计入执行时间），并挂审批超时拒绝计时器（approvalTimeoutMs，0=禁用）。
@@ -474,7 +476,7 @@ function submitTask(
                   sessionPath,
                   rpcId: taskRpcId,
                   approval,
-                  task: op.task,
+                  task: taskText,
                 });
                 pauseTimeout(); // 审批挂起：暂停执行超时计时（外部决策等待不计入执行时间）
                 const timeoutMs = resolveApprovalTimeoutMs(cfg);
@@ -482,7 +484,7 @@ function submitTask(
                   const timerKey = `${taskRpcId}::${approval.approvalId}`;
                   const t = setTimeout(() => {
                     approvalTimers.delete(timerKey); // 计时器已触发：从表移除
-                    const ap2 = op.pendingApprovals?.find(
+                    const ap2 = op.activeApprovals?.find(
                       (a) => a.approvalId === approval.approvalId,
                     );
                     if (ap2 && ap2.status === "pending") {
@@ -494,11 +496,10 @@ function submitTask(
                             ap2.answeredAt = new Date().toISOString();
                             ap2.auto = "expired";
                             if (
-                              !op.pendingApprovals.some(
+                              !op.activeApprovals.some(
                                 (a) => a.status === "pending",
                               )
                             ) {
-                              op.approvalPending = false;
                               resumeTimeout(); // 无挂起审批：恢复计时（同 approval/resolved 语义）
                             }
                           }
@@ -519,9 +520,9 @@ function submitTask(
             // "answered" 时不再覆写，但同样不参与 pending 计数。item 变为非
             // pending（resolved/answered）即清掉该审批的超时拒绝计时器（防触发重复应答）。
             const g = getSingleton();
-            const op = g.ops.get(taskRpcId);
-            if (op?.pendingApprovals) {
-              const item = op.pendingApprovals.find(
+            const op = g.ops.get(sessionId);
+            if (op?.activeApprovals) {
+              const item = op.activeApprovals.find(
                 (a) => a.approvalId === frame.approvalId,
               );
               if (item && item.status === "pending") {
@@ -535,8 +536,7 @@ function submitTask(
                 clearTimeout(t);
                 approvalTimers.delete(timerKey);
               }
-              if (!op.pendingApprovals.some((a) => a.status === "pending")) {
-                op.approvalPending = false;
+              if (!op.activeApprovals.some((a) => a.status === "pending")) {
                 resumeTimeout(); // 无挂起审批：恢复计时，剩余时间续算
               }
             }
@@ -554,7 +554,7 @@ function submitTask(
         }
         // 取消兜底：dsh_cancel 已标记 cancelledRequested 时，若 cancel 导致 mux 断流且
         // 未收到 turn/end，把无终态收尾判为 aborted 而非 end_turn（防误报完成）
-        const opNow = getSingleton().ops.get(taskRpcId);
+        const opNow = getSingleton().ops.get(sessionId);
         if (opNow?.cancelledRequested && !outcome)
           outcome = { stopReason: "aborted" };
         // 兜底增强：流正常关闭但无 turn/end 时，若期间见过 finish error（LLM 请求失败帧，
@@ -628,8 +628,8 @@ function submitTask(
     try {
       // 3. 提交 prompt（queue 模式：立即 accepted，agent 异步执行）
       // promptMeta.rpcId = 会话 jsonl 的 user/message 事件 data.source.rpcId（同一 RPC id），
-      // 经 ready 返回给卡片 URL：插件重启后按 sessionId+rpcId 从 jsonl 精确恢复（运行期协调键
-      // 即任务 rpcId，数据定位键合一）
+      // 经 ready 返回给卡片 URL：插件重启后按 sessionId+rpcId 从 jsonl 精确恢复（运行期
+      // 协调键 = sessionId，数据定位键 = sessionId+rpcId）
       const promptMeta = {};
       await callUnaryBus(
         "session.prompt",
@@ -643,9 +643,11 @@ function submitTask(
       );
       // 任务 rpcId 此刻产生（prompt 提交成功）：赋值提升变量 + 建运行期协调条目。
       // 顺序最稳：赋值 taskRpcId → createOpEntry → resolveReady——resolveReady 后事件循环
-      // 才开始流转，审批帧到达时条目必已存在（g.ops.get(taskRpcId) 必命中）。
+      // 才开始流转，审批帧到达时条目必已存在（g.ops.get(sessionId) 必命中）。
+      // 同 sessionId 多轮 prompt（resume 复用会话）时条目被当轮覆盖：dsh 会话串行
+      // （上一轮终态 finally 已删条目），当轮条目语义正确。
       taskRpcId = promptMeta.rpcId || "";
-      createOpEntry(taskRpcId, { task: taskText, sessionId });
+      createOpEntry(sessionId);
       resolveReady({ sessionId, rpcId: taskRpcId });
 
       // 4. 竞速：事件循环终态 / 超时 / 取消
@@ -712,7 +714,7 @@ function submitTask(
       }
       // 删除运行期协调状态条目（任务状态零存储，条目仅活到终态）
       try {
-        getSingleton().ops.delete(taskRpcId);
+        getSingleton().ops.delete(sessionId);
       } catch {
         /* 忽略 */
       }
@@ -858,12 +860,13 @@ async function doExecute(input, ctx) {
   const wait = input.wait === true;
   const { promise, ready } = submitTask(taskCfg, taskParams);
   // 卡片 URL 推迟到 session.create + prompt 提交后生成：携带 sessionId+rpcId，
-  // 插件重启后旧卡片按这两个键从会话 jsonl 精确恢复（运行期协调键 = 任务 rpcId，不丢数据）
+  // 插件重启后旧卡片按这两个键从会话 jsonl 精确恢复（运行期协调键 = sessionId，不丢数据）
   const loc = await ready;
   // 任务 rpcId：ready 的 loc.rpcId（prompt 提交产生的 RPC id，与 jsonl data.source.rpcId 同值）；
   // loc 为 null（提交失败）时为空串。deferred taskId 与工具契约字段都用它。
   const taskRpcId = (loc && loc.rpcId) || "";
-  // deferred taskId = 任务 rpcId（运行期协调键与数据定位键合一）；taskRpcId 为空时兜底唯一键
+  // deferred taskId = 任务 rpcId（toolCallCache / approvalTimers / deferred 同键，与 g.ops
+  // 的 sessionId 键并存）；taskRpcId 为空时兜底唯一键
   // （该路径提交必失败，deferred fail 报错即可）
   const deferredTaskId = taskRpcId || ("dsh-run::" + Date.now().toString(36));
   // 卡片 route 定位参数只带 locQuery（sessionId+rpcId+timeoutMs）；loc 为 null（提交失败）时

--- a/src/tools/dsh-run.js
+++ b/src/tools/dsh-run.js
@@ -625,12 +625,14 @@ function submitTask(
           );
     });
 
+    // promptMeta 声明提升到 try 外：提交失败时 catch 从 promptMeta.rpcId 兜底
+    // taskRpcId（callUnaryBus/HTTP 兜底在 reject 路径也回传 meta.rpcId）
+    const promptMeta = {};
     try {
       // 3. 提交 prompt（queue 模式：立即 accepted，agent 异步执行）
       // promptMeta.rpcId = 会话 jsonl 的 user/message 事件 data.source.rpcId（同一 RPC id），
       // 经 ready 返回给卡片 URL：插件重启后按 sessionId+rpcId 从 jsonl 精确恢复（运行期
-      // 协调键 = sessionId，数据定位键 = sessionId+rpcId）
-      const promptMeta = {};
+      // 协调键 = sessionId，数据定位键 = sessionId+rpcId）。
       await callUnaryBus(
         "session.prompt",
         {
@@ -681,6 +683,12 @@ function submitTask(
         stderr: web.stderr ? web.stderr.slice(-2000) : null,
       };
     } catch (err) {
+      // 提交失败也保留 rpcId 关联：promptMeta.rpcId 由 callUnaryBus/HTTP 兜底在 reject 路径
+      // 提前回传（reqId 生成即写 meta）——session.prompt 已发出但响应失败/超时/中止时
+      // rpcId 仍已知（dsh 侧已以此写 jsonl data.source.rpcId），失败终态可凭 sessionId+rpcId
+      // 在 jsonl 定位该轮次；完全未发出（emit 失败且降级也失败）时 rpcId 为空，用
+      // 「submission-failed」占位（展示层，deferredTaskId 仍用独立 fallback 保持唯一）。
+      if (!taskRpcId && promptMeta?.rpcId) taskRpcId = promptMeta.rpcId;
       // 超时/取消：通知 web host 取消该会话的任务（best effort，agent 在 web 里仍可见）
       if (err?.code === "DSH_TIMEOUT" || err?.code === "DSH_ABORTED") {
         try {
@@ -722,7 +730,11 @@ function submitTask(
   })();
 
   promise.catch((err) => {
-    resolveReady?.(null); // 提交失败：loc 为 null，卡片 route 不带定位参数（错误态由 deferred fail 呈现）
+    // 提交失败也保留 rpcId 关联：taskRpcId 已在 catch 里从 promptMeta.rpcId 兜底（若有）——
+    // loc 带 { sessionId, rpcId } 时 doExecute 的 text / deferred 回调 / 卡片 route 都保留
+    // 关联；完全无 rpcId（提交未发出）时 loc 为 null（route 不带定位参数，错误态由
+    // deferred 呈现）。
+    resolveReady?.(taskRpcId ? { sessionId, rpcId: taskRpcId } : null);
   });
 
   return { promise, ready };
@@ -922,7 +934,11 @@ async function doExecute(input, ctx) {
         resolveDeferredWake({
           bus,
           taskId: deferredTaskId,
-          result: abnormalWakeResult({ err, loc, taskRpcId }),
+          result: abnormalWakeResult({
+            err,
+            loc,
+            taskRpcId: taskRpcId || "submission-failed",
+          }),
         });
       },
     );
@@ -937,7 +953,7 @@ async function doExecute(input, ctx) {
           // Agent 上下文（实机：wait 返回只有 text），Agent 凭 text 里的 sessionId 立即
           // dsh_cancel / dsh_session get，无需反查 list 或等终态回调。提交失败（loc
           // null）时 sessionId 占位「（提交失败）」，rpcId 仍可定位（deferred 回调兜底）。
-          text: `任务已提交给 DSH（rpcId: ${taskRpcId}，sessionId: ${(loc && loc.sessionId) || "（提交失败）"}），在后台执行中。进度与输出见上方卡片；完成后后台消息仅带回任务状态与定位键（rpcId/sessionId），取内容用 dsh_session get。`,
+          text: `任务已提交给 DSH（rpcId: ${taskRpcId || "submission-failed"}，sessionId: ${(loc && loc.sessionId) || "（提交失败）"}），在后台执行中。进度与输出见上方卡片；完成后后台消息仅带回任务状态与定位键（rpcId/sessionId），取内容用 dsh_session get。`,
         },
       ],
       details: {

--- a/src/tools/lib/protocol.js
+++ b/src/tools/lib/protocol.js
@@ -31,6 +31,10 @@ function nextRpcId() {
 
 async function callUnary(base, method, payload, signal, meta) {
   const rpcId = nextRpcId();
+  // meta.rpcId 回传：rpcId 由宿主生成（client-request 信封），dsh 侧以此写 jsonl
+  // user/message 的 data.source.rpcId——生成即有效，提前设置使失败/拒绝路径也能拿到
+  //（成功路径同值），供调用方在提交失败时保留 rpcId 关联（sessionId+rpcId 定位轮次）。
+  if (meta && typeof meta === "object") meta.rpcId = rpcId;
   const res = await fetch(`${base}/api/${method}`, {
     method: "POST",
     headers: { "content-type": "application/json" },
@@ -47,9 +51,6 @@ async function callUnary(base, method, payload, signal, meta) {
       `dsh ${method} 失败：${e.code || "unknown"} ${e.message || ""}`,
     );
   }
-  // meta.rpcId 回传：会话 jsonl 的 user/message 事件 data.source.rpcId 与此相同，
-  // 供 op 快照记录后用 sessionId+rpcId 从 jsonl 精确恢复（重启不丢、零映射文件）
-  if (meta && typeof meta === "object") meta.rpcId = rpcId;
   return full.result.value;
 }
 
@@ -82,8 +83,6 @@ function wireRpcResult() {
     // 清理（clearTimeout/delete/移除 abort 监听）统一在 settle 内做——
     // 不能在 resolve/reject 前先 delete，否则 settle 的 pending 校验会误判已 settle 而跳过。
     if (payload.ok) {
-      // meta.rpcId 回传与 callUnary 同语义：会话 jsonl data.source.rpcId == reqId
-      if (entry.meta && typeof entry.meta === "object") entry.meta.rpcId = payload.reqId;
       entry.resolve(payload.value);
     } else {
       const e = payload.error || {};
@@ -105,6 +104,10 @@ function rpcBusBase(g) {
 // AbortError 语义与 fetch 一致）；meta 成功时回传 rpcId（与 callUnary 同）。
 async function callUnaryBus(method, payload, signal, meta) {
   const reqId = nextRpcId();
+  // meta.rpcId 提前回传（同 callUnary 语义：reqId 宿主生成、dsh 侧写 jsonl
+  // data.source.rpcId）——总线路径成功/失败/超时/中止都保留 rpcId 关联；降级路径由
+  // callUnary 内部的 meta.rpcId 覆盖为实际 HTTP rpcId。
+  if (meta && typeof meta === "object") meta.rpcId = reqId;
   const g = getSingleton();
   const bus = g?.dshanaBus;
   // 总线优先：dshanaBus 就绪且 emit 送达（bus.js sendFrame 排队成功才 true——


### PR DESCRIPTION
## 背景

用户提出「是否可以减少内存态数据保存？比如去掉 g.ops」。评估结论：g.ops 不能整体去掉（cancelledRequested 是本地动作瞬时标记、审批有 30s 实时窗口），但可以大幅瘦身。

## 收敛内容

sessionId 已是全链路唯一定位键（提交返回 / 卡片 URL / dsh_cancel / dsh_session / resume 同键），g.ops 键从任务 rpcId 改为 sessionId，条目字段从 { rpcId, task, sessionId, approvalPending, pendingApprovals, cancelledRequested } 收敛为 { cancelledRequested, activeApprovals }：

- **task**：jsonl user/message 有完整原文，纯冗余 → 删（notifyApprovalWake 的 task 来源改 taskText）
- **sessionId**：提交返回已带（c720454），条目内重复 → 删（即键）
- **approvalPending**：派生态（activeApprovals 有无 pending 项即可推出）→ 删
- **pendingApprovals → activeApprovals**：审批上下文保留（respondRpcId 路由 + 30s 实时窗口 + jsonl 落盘竞态，短命运行期态留内存合理）
- **cancelledRequested**：保留（本地动作瞬时标记，jsonl 的 aborted 帧可能未落盘）

**dsh_approve 工具参数变更**：rpcId → sessionId（接口契约，审批通知 payload 本就双带；taskId 模板与 payload 仍含任务级 rpcId 用于轮次定位，保留）

## 改动文件

- src/tools/dsh-run.js：createOpEntry 键改 sessionId + 字段收敛；审批存取/状态流转/取消兜底/finally 清理全部 sessionId 键控；注释同步（多轮 prompt 条目覆盖前提：dsh 会话串行，上一轮终态 finally 已删条目）
- src/tools/dsh-approve.js：参数 rpcId → sessionId，ops.get(sessionId)，activeApprovals
- src/tools/dsh-cancel.js：遍历反查 → 直接 ops.get(sessionId) 键控标记
- skills/dsh-approve/SKILL.md：参数契约同步

## 验证

- node --check 3 文件过；单测 wake-abnormal 全过；回归 7 组 110/110 过（bus-protocol 23 / settings 6 / bus-converge 21 / plugins-converge 17 / provider-converge 6 / webui-converge 19 / patch-static 18）
- build 过；插件目录已装新版
- 实机：提交返回带 sessionId → 凭它 dsh_cancel（ops.get(sessionId) 键控）→ 取消回调 { status: cancelled, rpcId, sessionId, message } 全带（r_mtfdbxjz_gwhdg0）

## 依赖

基于 feat/fix-abnormal-minimal（PR #25，非正常终态 minimal + 提交返回带 sessionId——sessionId 回传是本收敛的前提）。PR #25 合并后本分支 rebase 到 master。