### PR TITLE
fix: contributes.settings 改回 configuration（dshTag 等设置项未加载）

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,70 +8,56 @@
   "minAppVersion": "0.810.0",
   "trust": "full-access",
   "ui": {
-    "hostCapabilities": [
-      "clipboard.writeText"
-    ]
+    "hostCapabilities": ["clipboard.writeText"]
   },
-  "capabilities": [
-    "resource.watch",
-    "network.fetch"
-  ],
+  "capabilities": ["resource.watch", "network.fetch"],
   "network": {
-    "allowedHosts": [
-      "127.0.0.1",
-      "localhost"
-    ],
-    "methods": [
-      "POST"
-    ],
+    "allowedHosts": ["127.0.0.1", "localhost"],
+    "methods": ["POST"],
     "defaultTimeoutMs": 5000,
     "maxResponseBytes": 1024
   },
-  "activationEvents": [
-    "onStartup"
-  ],
+  "activationEvents": ["onStartup"],
   "entry": "index.js",
   "contributes": {
-    "settings": {
+    "configuration": {
       "title": "DSHana 设置",
-      "schema": {
-        "properties": {
-          "webPort": {
-            "type": "number",
-            "default": 3080,
-            "title": "dsh Web UI 端口",
-            "description": "dsh web host 监听端口（执行后端 + 浏览器观察面，默认 3080）。"
-          },
-          "defaultCwd": {
-            "type": "string",
-            "default": "",
-            "title": "默认工作目录",
-            "description": "dsh agent 的沙箱工作目录（bash 与文件系统工具的活动范围）。初始为空（不预设路径），建议安装后设置为你自己的项目工作目录；工具调用显式传 cwd 时优先。"
-          },
-          "approvalTimeoutSec": {
-            "type": "number",
-            "default": 30,
-            "title": "审批超时自动拒绝（秒）",
-            "description": "审批唯一配置（单位：秒）。dsh agent 请求越界权限时任务挂起，插件通知 Agent 应答（附命令/路径原文）；挂起超过该时长无人应答自动 rejected（默认 30 秒：应答方失联检测，正常应答几秒内完成；宿主重启场景由会话中断兜底，不走超时拒绝）；0=禁用超时拒绝。改后对新审批立即生效。旧键 approvalTimeoutMs（毫秒）由迁移自动换算并删除。"
-          },
-          "defaultTimeoutSec": {
-            "type": "number",
-            "default": 1800,
-            "title": "默认超时（秒）",
-            "description": "单次任务默认超时（单位：秒），工具调用未显式传 timeout 时使用。默认 1800 秒（30 分钟）。旧键 defaultTimeoutMs（毫秒）由迁移自动换算并删除。"
-          },
-          "nodejsPath": {
-            "type": "string",
-            "default": "",
-            "title": "自定义 Node.js 路径",
-            "description": "可选：指定系统安装的 node 可执行文件绝对路径（如 /opt/homebrew/bin/node）。留空（默认）用 Electron 自带 node。macOS 上 Electron 内嵌 node 跑 pnpm 会触发签名校验失败（Electron 的 node 二进制非标准 node 签名），此时填系统 node 绝对路径解决。路径不存在、指向目录或不可执行时均发出警告并回退 Electron node。改后对下一次子进程（pnpm / web host）立即生效；已生成的 node 代理脚本（wrapper）在下次依赖安装时更新为新的 node 执行体。"
-          },
-          "dshTag": {
-            "type": "string",
-            "default": "latest",
-            "title": "DSH 更新基线（dist-tag）",
-            "description": "dsh 检查/更新跟随的 npm dist-tag（默认 latest，可选 next/alpha 等）。dsh_install 工具的 check/update 未显式传 version/tag 时使用此基线（version 参数优先于 tag 参数，tag 参数优先于本配置）；install 未指定版本时同样按此 tag 安装。改后对下一次 check/install/update 立即生效。"
-          }
+      "properties": {
+        "webPort": {
+          "type": "number",
+          "default": 3080,
+          "title": "dsh Web UI 端口",
+          "description": "dsh web host 监听端口（执行后端 + 浏览器观察面，默认 3080）。"
+        },
+        "defaultCwd": {
+          "type": "string",
+          "default": "",
+          "title": "默认工作目录",
+          "description": "dsh agent 的沙箱工作目录（bash 与文件系统工具的活动范围）。初始为空（不预设路径），建议安装后设置为你自己的项目工作目录；工具调用显式传 cwd 时优先。"
+        },
+        "approvalTimeoutSec": {
+          "type": "number",
+          "default": 30,
+          "title": "审批超时自动拒绝（秒）",
+          "description": "审批唯一配置（单位：秒）。dsh agent 请求越界权限时任务挂起，插件通知 Agent 应答（附命令/路径原文）；挂起超过该时长无人应答自动 rejected（默认 30 秒：应答方失联检测，正常应答几秒内完成；宿主重启场景由会话中断兜底，不走超时拒绝）；0=禁用超时拒绝。改后对新审批立即生效。旧键 approvalTimeoutMs（毫秒）由迁移自动换算并删除。"
+        },
+        "defaultTimeoutSec": {
+          "type": "number",
+          "default": 1800,
+          "title": "默认超时（秒）",
+          "description": "单次任务默认超时（单位：秒），工具调用未显式传 timeout 时使用。默认 1800 秒（30 分钟）。旧键 defaultTimeoutMs（毫秒）由迁移自动换算并删除。"
+        },
+        "nodejsPath": {
+          "type": "string",
+          "default": "",
+          "title": "自定义 Node.js 路径",
+          "description": "可选：指定系统安装的 node 可执行文件绝对路径（如 /opt/homebrew/bin/node）。留空（默认）用 Electron 自带 node。macOS 上 Electron 内嵌 node 跑 pnpm 会触发签名校验失败（Electron 的 node 二进制非标准 node 签名），此时填系统 node 绝对路径解决。路径不存在、指向目录或不可执行时均发出警告并回退 Electron node。改后对下一次子进程（pnpm / web host）立即生效；已生成的 node 代理脚本（wrapper）在下次依赖安装时更新为新的 node 执行体。"
+        },
+        "dshTag": {
+          "type": "string",
+          "default": "latest",
+          "title": "DSH 更新基线（dist-tag）",
+          "description": "dsh 检查/更新跟随的 npm dist-tag（默认 latest，可选 next/alpha 等）。dsh_install 工具的 check/update 未显式传 version/tag 时使用此基线（version 参数优先于 tag 参数，tag 参数优先于本配置）；install 未指定版本时同样按此 tag 安装。改后对下一次 check/install/update 立即生效。"
         }
       }
     },

--- a/manifest.json
+++ b/manifest.json
@@ -52,12 +52,6 @@
           "default": "",
           "title": "自定义 Node.js 路径",
           "description": "可选：指定系统安装的 node 可执行文件绝对路径（如 /opt/homebrew/bin/node）。留空（默认）用 Electron 自带 node。macOS 上 Electron 内嵌 node 跑 pnpm 会触发签名校验失败（Electron 的 node 二进制非标准 node 签名），此时填系统 node 绝对路径解决。路径不存在、指向目录或不可执行时均发出警告并回退 Electron node。改后对下一次子进程（pnpm / web host）立即生效；已生成的 node 代理脚本（wrapper）在下次依赖安装时更新为新的 node 执行体。"
-        },
-        "dshTag": {
-          "type": "string",
-          "default": "latest",
-          "title": "DSH 更新基线（dist-tag）",
-          "description": "dsh 检查/更新跟随的 npm dist-tag（默认 latest，可选 next/alpha 等）。dsh_install 工具的 check/update 未显式传 version/tag 时使用此基线（version 参数优先于 tag 参数，tag 参数优先于本配置）；install 未指定版本时同样按此 tag 安装。改后对下一次 check/install/update 立即生效。"
         }
       }
     },


### PR DESCRIPTION
## 问题
宿主 0.810.0 插件运行时读取的是 \contributes.configuration\（properties 平铺），\contributes.settings\ 声明不生效——manifest 里的设置项（webPort/defaultCwd/approvalTimeoutSec 等）一直没被宿主加载，设置页改配置存不进去。

## 修复
1. manifest.json 的 \contributes.settings\（v2 包裹层）改回 \contributes.configuration\（properties 平铺），对齐宿主运行时契约
2. 撤回 configuration 的 \dshTag\ 设置项——dist-tag 是 registry 动态返回（pnpm view dist-tags），静态字符串手输不合理，改由 @dsh-hanako/settings 页 DSH 版本卡片动态拉取列表做选择器（运行时支持保留：config.json global.dshTag + resolveDshTag 三阶回退，默认 latest）

## 验证
- 配置项实际加载（configuration 键名生效）
- dshTag 不在宿主设置 UI 出现（等 settings 页动态选择器）