### PR TITLE
feat: 双轮询事件化——settings/describe 与 /webui/health 改事件驱动

### DIFF
--- a/src-cordis/plugins/@dsh-hanako/theme/index.js
+++ b/src-cordis/plugins/@dsh-hanako/theme/index.js
@@ -9,9 +9,10 @@
 //     theme.css 变量生效，getComputedStyle 读到当前主题 16 个变量的渲染值。
 //     随宿主更新：宿主切主题 → dataset.theme 变 → 插件 iframe 重载 → 壳桥
 //     回传新值；宿主新增/修改主题无需插件更新（无静态主题表）。
-// 边界：dsh preference 经 settings/describe 读取（加载时一次 + 轻量轮询 3s——
-//   vY T7b 后 0.1.2 无旧 /api/events.host WS，官方主题 preference 走服务端注入 +
-//   client presenter；注入脚本轮询读偏好，system ↔ light/dark 切换即时重评）。
+// 边界：dsh preference 经 settings/describe 读取（加载时一次回读 + 变更事件驱动——
+//   vY T7b 后 0.1.2 无旧 /api/events.host WS；vZ 起事件化：宿主侧 bridge 订阅
+//   remote.mux $events 的 settings/document-updated（ui-theme）→ 总线 → /webui/events
+//   → 壳页 postMessage dshHanaPref → 注入脚本重读一次，替代早期 3s 轮询）。
 //   system → 覆盖 Hana 配色；light/dark → 完全原生。
 //
 // 机制：经 dsh-host-webserver 的 tapIndex 扩展点，向每个 index 响应注入：
@@ -204,6 +205,13 @@ const BRIDGE = `<script id="@dsh-hanako/theme-bridge">
         if (askTimer) { clearInterval(askTimer); askTimer = null; }
       }
     }
+    // DSH 主题偏好变更通知（壳页经 /webui/events 收到 settings/document-updated 的
+    // ui-theme 后 postMessage 转发，只带 revision）：重读一次 preference（事件驱动，
+    // 替代旧 3s 轮询 settings/describe——变更时才读，describe 调用量与官方
+    // startup-rpc-budget 语义一致）。
+    if (e.data && e.data.dshHanaPref) {
+      refreshPref();
+    }
   });
   // 回读一次 preference 并重跑 applyOrRemove（加载时 + 偏好变更时共用）。
   function refreshPref() {
@@ -228,14 +236,12 @@ const BRIDGE = `<script id="@dsh-hanako/theme-bridge">
       .catch(function () {});
   }
   refreshPref();
-  // 偏好实时化（vY：T7b 后 dsh 0.1.2 无 /api/events.host（旧 0.1.1 端点）——
-  // 官方主题 preference 走服务端注入 + client presenter，注入脚本无法访问 ctx.remote.$on；
-  // 改为轻量轮询 settings/describe（本地回环，3s 间隔；preference 变化时 refreshPref 内
-  // 自动重跑 applyOrRemove/maybeDropStatic——system ↔ light/dark 切换即时生效）。
-  var prefTimer = setInterval(function () {
-    if (document.hidden) return; // 标签页隐藏时不轮询
-    refreshPref();
-  }, 3000);
+  // 偏好实时化（vY→vZ：T7b 后 dsh 0.1.2 无 /api/events.host（旧 0.1.1 端点）——官方
+  // 主题 preference 走服务端注入 + client presenter，注入脚本无法访问 ctx.remote.$on；
+  // 先退化为 3s 轻量轮询 settings/describe（0.1.2→0.1.3 期间），后改事件驱动：宿主侧
+  // bridge 订阅 remote.mux $events 的 settings/document-updated（ui-theme）→ 总线
+  // events 频道 → /webui/events → 壳页 postMessage dshHanaPref → 上方 message 监听
+  // 调 refreshPref 重读一次（变更时才读，替换周期轮询）。加载时保留一次回读兑底。
   var mq = window.matchMedia && matchMedia("(prefers-color-scheme: dark)");
   if (mq && mq.addEventListener) mq.addEventListener("change", ask);
   // 竞态修复：壳页（宿主 iframe 外层）主题桥的注册可能与 dsh 页面加载不同步——脚本加载时

--- a/src/assets/webui-shell.jinja2
+++ b/src/assets/webui-shell.jinja2
@@ -799,10 +799,14 @@
     var readyTimer = null;
     var streamAbort = null;
     var readyReceived = false;
+    // 只清超时与安装 tick（不 abort 事件流——流常驻，attach 重挂载时不能杀流；
+    // 流的终止只在页面卸载 abortEventStream）
     function clearReadyTimers() {
       if (readyTimer) { clearTimeout(readyTimer); readyTimer = null; }
-      if (streamAbort) { try { streamAbort.abort(); } catch (e) { /* 已关闭 */ } streamAbort = null; }
       stopInstallTick();
+    }
+    function abortEventStream() {
+      if (streamAbort) { try { streamAbort.abort(); } catch (e) { /* 已关闭 */ } streamAbort = null; }
     }
     function mountReady() {
       if (readyReceived) return;
@@ -855,6 +859,7 @@
             scheduleReopen();
             return null;
           }
+          streamRetries = 0; // 成功建立响应体：连续失败计数归零（有界重试只作用于连续失败）
           var reader = r.body.getReader();
           var decoder = new TextDecoder();
           var buf = "";
@@ -879,7 +884,22 @@
                 try { ev = JSON.parse(dataLine); } catch (e2) { continue; }
                 if (!ev || typeof ev.type !== "string") continue;
                 if (ev.type === "ready") { if (!readyReceived) mountReady(); }
-                else if (ev.type === "pending") { if (!readyReceived) showLoading(); pushPanel(); }
+                else if (ev.type === "pending") {
+                  // web host 停机/重启窗口：退回未就绪态——清 readyReceived（重启完成
+                  // 后再次 ready 会经 mountReady 重挂 iframe），事件流保持常驻收 ready。
+                  // 重挂 30s 兜底（ready 事件缺失时引导看诊断）。
+                  if (readyReceived) {
+                    readyReceived = false;
+                    stopInstallTick();
+                    showLoading();
+                    if (!readyTimer) {
+                      readyTimer = setTimeout(function () {
+                        if (!readyReceived) loadDiagnosticsNow();
+                      }, 30000);
+                    }
+                  }
+                  pushPanel();
+                }
                 else if (ev.type === "diagnostics") { if (!readyReceived) showDiagnostics(ev.diagnostics); }
                 else if (ev.type === "theme-pref") { sendPrefTo(frame && frame.contentWindow, ev); }
                 else if (ev.type === "diag-changed") { refreshDiag(); }
@@ -934,6 +954,7 @@
     }
     window.addEventListener("beforeunload", function () {
       clearReadyTimers();
+      abortEventStream();
     });
     // 主题桥——dsh 页面（跨源 iframe）postMessage 索取 Hana 主题，
     // 这里回传主题 id（location.search hana-theme）+ 实时变量值（hana-css 已
@@ -1064,9 +1085,12 @@
       }, 30000);
     } else {
       // 就绪态（服务端渲染即已连接）：统一走 attach 挂载（src 由壳页 JS 设置——
-      // 直嵌根路径，无 BFF 代理/凭据透传（vY：pluginSurfaceSession 仅用于 hana.api.fetch 调用））
+      // 直嵌根路径，无 BFF 代理/凭据透传（vY：pluginSurfaceSession 仅用于 hana.api.fetch 调用）），
+      // 并订阅常驻事件流——theme-pref / diag-changed / 重启窗口的 pending → ready
+      // 周期在就绪态同样生效，全部依赖这条流。
       readyReceived = true;
       attach();
+      openReadyStream();
     }
     syncPanelFromDiag(initDiag); // 初始面板状态（readyReceived 已就位，避免初始错推「未就绪」）
 }) ();

--- a/src/assets/webui-shell.jinja2
+++ b/src/assets/webui-shell.jinja2
@@ -370,7 +370,7 @@
     function pushPanel() {
       try {
         if (!hana || !hana.panel || !hana.panel.set) return;
-        hana.panel.set({ sections: fpFullPanel(), refresh: { intervalMs: 5000 } }).catch(function () { /* 面板不可用静默降级 */ });
+        hana.panel.set({ sections: fpFullPanel(), refresh: { intervalMs: 30000 } }).catch(function () { /* 面板不可用静默降级 */ });
       } catch (err) { /* 面板不可用静默降级 */ }
     }
     function copyLogPath() {
@@ -389,8 +389,10 @@
     if (hana && hana.panel && hana.panel.onEvent) {
       hana.panel.onEvent(panelOnEvent);
       hana.panel.onRefresh(function () {
-        // 宿主刷新 tick：轻量重读诊断并同步面板（diagRefreshing 防并发）
-        refreshDiag();
+        // 宿主刷新 tick（30s 兜底）：只重推内存态面板，不周期打 /webui/health——
+        // 诊断刷新改事件驱动（bus.ready/bus.disconnect/启动失败/deps 翻转经
+        // /webui/events 推 ready/pending/diagnostics/diag-changed，壳页事件到达
+        // 时 refreshDiag 一次；安装中进度由 installing 态 tick 滚动）
         pushPanel();
       });
     }
@@ -446,7 +448,7 @@
       var list = document.getElementById("diag-list");
       if (!list) return;
       if (!diag || !diag.checks || diag.checks.length === 0) {
-        // 工具模块冷启动未加载/收集暂不可用：占位，下一轮轮询刷新
+        // 工具模块冷启动未加载/收集暂不可用：占位，diag-changed 事件到达时刷新
         list.innerHTML = '<li class="diag-item"><div class="diag-body"><div class="diag-detail">正在收集自检信息…</div></div></li>';
         return;
       }
@@ -542,7 +544,7 @@
       var p = function (n) { return (n < 10 ? "0" : "") + n; };
       return p(t.getHours()) + ":" + p(t.getMinutes()) + ":" + p(t.getSeconds());
     }
-    // deps 安装中实时进度块（npm i 输出尾部 + 更新时间，随 3s 轮询刷新滚动）
+    // deps 安装中实时进度块（npm i 输出尾部 + 更新时间，随 installing 态 3s tick 滚动）
     function progressHtml(d) {
       var html = '<pre class="diag-progress">' + escHtml(d.installLog || "正在准备…") + '</pre>';
       if (d.installAt) html += '<div class="diag-progress-time">更新于 ' + escHtml(fmtTime(d.installAt)) + '</div>';
@@ -563,7 +565,7 @@
       }
       return "pnpm 引导：未就绪" + (d.pnpmError ? "（原因：" + d.pnpmError + "）" : "");
     }
-    // 更新进度/结果块（内存态 updateResult = g.update 状态组合，随 3s 轮询刷新；
+    // 更新进度/结果块（内存态 updateResult = g.update 状态组合，随 diag-changed 事件刷新；
     // v0.24 update-result.json 退役）——版本管理归设置页
     // （@dsh-hanako/settings「检查与更新 DSH」卡片 + dsh_install 工具），deps 卡片已无更新
     // 按钮，仅在设置页触发更新（web host 停机期间）时被动展示进度。
@@ -703,10 +705,26 @@
     // 运行级依赖检测（GET /webui/verify-deps，只读）——进标签页自动一次 + 手动
     // 「检测依赖」按钮。服务端 await 检测（≤10s），结果写入 g.depsSmoke；拿到 ok 响应后
     // 触发一次 health 读取诊断刷新 deps 卡片（检测中显示「正在检测依赖完整性…」，结果
-    // 回来显示通过/失败）。不随 3s 轮询重复触发。
+    // 回来显示通过/失败）。verify 状态翻转经 notifyDepsChanged → diag-changed 事件刷新。
+    // deps 安装中进度滚动：仅 installing 态运行 3s tick（事件驱动刷新 + 安装态低频
+    // 进度兜底；安装结束 diag-changed 事件 → refreshDiag → installing=false 即停）。
+    var installTick = null;
+    function syncInstallTick(diag) {
+      var deps = checkByKey(diag, "deps");
+      var installing = !!(deps && deps.installing === true);
+      if (installing && !installTick) {
+        installTick = setInterval(function () { refreshDiag(); }, 3000);
+      } else if (!installing && installTick) {
+        clearInterval(installTick);
+        installTick = null;
+      }
+    }
+    function stopInstallTick() {
+      if (installTick) { clearInterval(installTick); installTick = null; }
+    }
     function refreshDiag() {
-      // 诊断数据源（一次性 health 查询；不轮询、不自动挂载——挂载只由 ready 事件驱动）。
-      // diagRefreshing 防并发（功能面板宿主刷新 tick 复用此函数）。
+      // 诊断数据源（事件驱动的一次性 health 查询；不轮询、不自动挂载——挂载只由
+      // ready 事件驱动）。diagRefreshing 防并发（diag-changed 事件/手动刷新共用）。
       if (diagRefreshing) return;
       diagRefreshing = true;
       hana.api.fetch("webui/health", { signal: AbortSignal.timeout(3000) })
@@ -716,6 +734,7 @@
           if (d && d.diagnostics) {
             renderDiagList(d.diagnostics);
             syncPanelFromDiag(d.diagnostics);
+            syncInstallTick(d.diagnostics);
           }
         })
         .catch(function () { })
@@ -783,10 +802,12 @@
     function clearReadyTimers() {
       if (readyTimer) { clearTimeout(readyTimer); readyTimer = null; }
       if (streamAbort) { try { streamAbort.abort(); } catch (e) { /* 已关闭 */ } streamAbort = null; }
+      stopInstallTick();
     }
     function mountReady() {
       if (readyReceived) return;
       readyReceived = true;
+      stopInstallTick();
       attach();
     }
     // 显示加载态（web host 启动中/停机窗口；默认进入）
@@ -817,11 +838,12 @@
       }
     }
     // 订阅宿主就绪事件流（/webui/events；SSE 式 chunked，非轮询）。
-    // 流在 ready 前断开（网络/服务端关闭）时按 10s 退避重开（有界 10 次）——
-    // 覆盖「web host 启动失败后用户修复重新拉起」的 ready 到达窗口
+    // 流断开（网络/服务端关闭）时按 10s 退避重开（有界 10 次）——覆盖
+    // 「web host 启动失败后用户修复重新拉起」的 ready 到达窗口；ready 后流保持
+    // 常驻（theme-pref / diag-changed 事件持续推送），断流同样重开恢复事件接收。
     var streamRetries = 0;
     function openReadyStream() {
-      if (readyReceived || streamRetries >= 10) return;
+      if (streamRetries >= 10) return;
       var ac = new AbortController();
       streamAbort = ac;
       var retryTimer = null;
@@ -838,8 +860,8 @@
           var buf = "";
           var pump = function () {
             reader.read().then(function process({ done, value }) {
-              if (done || readyReceived) {
-                if (done && !readyReceived) scheduleReopen();
+              if (done) {
+                scheduleReopen();
                 return;
               }
               buf += decoder.decode(value, { stream: true });
@@ -856,32 +878,34 @@
                 var ev;
                 try { ev = JSON.parse(dataLine); } catch (e2) { continue; }
                 if (!ev || typeof ev.type !== "string") continue;
-                if (ev.type === "ready") { mountReady(); return; }
+                if (ev.type === "ready") { if (!readyReceived) mountReady(); }
                 else if (ev.type === "pending") { if (!readyReceived) showLoading(); pushPanel(); }
                 else if (ev.type === "diagnostics") { if (!readyReceived) showDiagnostics(ev.diagnostics); }
+                else if (ev.type === "theme-pref") { sendPrefTo(frame && frame.contentWindow, ev); }
+                else if (ev.type === "diag-changed") { refreshDiag(); }
               }
-              // 递归 read 同样附加 rejection 处理：仅 readyReceived false 时重开流
-              // （ready 已收到后流错误不再重试，与 done/初始 read 的 catch 分支一致）
+              // 递归 read 同样附加 rejection 处理：断流重开（ready 后亦然——事件流
+              // 常驻，theme-pref/diag-changed 依赖它持续到达）
               reader.read().then(process).catch(function () {
-                if (!readyReceived) scheduleReopen();
+                scheduleReopen();
               });
             }).catch(function () {
-              if (!readyReceived) scheduleReopen();
+              scheduleReopen();
             });
           };
           pump();
           return null;
         })
         .catch(function () {
-          if (!readyReceived) scheduleReopen();
+          scheduleReopen();
         });
       function scheduleReopen() {
-        if (readyReceived || streamRetries >= 10) return;
+        if (streamRetries >= 10) return;
         streamRetries += 1;
         if (retryTimer) clearTimeout(retryTimer);
         retryTimer = setTimeout(function () {
           retryTimer = null;
-          if (!readyReceived) openReadyStream();
+          openReadyStream();
         }, 10000);
       }
     }
@@ -942,6 +966,14 @@
     }
     function sendThemeTo(dst) {
       var msg = { dshHanaTheme: readThemeVars() };
+      try { dst.postMessage(msg, "*"); } catch (err) { /* 目标不可达忽略 */ }
+    }
+    function sendPrefTo(dst, ev) {
+      // DSH 主题偏好变更通知（宿主经 /webui/events 收到 settings/document-updated 的
+      // ui-theme 后转来）：只带 revision，preference 值由注入脚本收到后重读一次
+      // settings/describe（事件驱动替代 3s 轮询）。
+      if (!dst) return;
+      var msg = { dshHanaPref: { revision: ev && ev.revision != null ? ev.revision : null } };
       try { dst.postMessage(msg, "*"); } catch (err) { /* 目标不可达忽略 */ }
     }
     // —— 宿主主题实时跟随（feat/theme-live）——

--- a/src/routes/webui.js
+++ b/src/routes/webui.js
@@ -333,8 +333,10 @@ export default function registerWebuiRoutes(app, ctx) {
           }
         };
         if (busReady()) {
+          // 流保持常驻：壳页就绪态也订阅（theme-pref / diag-changed / 重启窗口的
+          // pending → ready 周期全依赖它）；ready 事件作首帧信号（就绪态壳页已
+          // readyReceived，收到即忽略，随后流挂起等后续事件）。
           send({ type: "ready" });
-          close();
           return;
         }
         send({ type: "pending" });

--- a/src/routes/webui.js
+++ b/src/routes/webui.js
@@ -4,11 +4,12 @@
 // routes/webui.js — dsh-hanako 插件页：contributes.cards（realization:page）内嵌 dsh Web UI
 //   GET /webui            插件页（iframe 嵌 http://127.0.0.1:<port>/，含就绪事件化/主题注入/失败自检；
 //                         壳页另接入功能面板 functionPanel（hana.panel 推送状态/操作，见 webui-shell））
-//   GET /webui/events     就绪事件流（SSE 式 chunked）：bus ready → 推 ready 事件；web host
-//                         启动失败 → 推 diagnostics 事件；web host 停机 → 推 pending 事件。
-//                         壳页订阅此流实现「就绪事件化挂载」（替代旧 3s health 轮询）。
+//   GET /webui/events     就绪事件流（SSE 式 chunked，常驻）：bus ready → 推 ready；
+//                         启动失败 → 推 diagnostics；停机 → 推 pending；deps 状态翻转
+//                         → 推 diag-changed；DSH 主题偏好变更 → 推 theme-pref。
+//                         壳页订阅此流实现事件化（挂载/诊断刷新/偏好跟随全事件驱动）。
 //   GET /webui/health     纯诊断 GET 端点：返回 readDiagnostics 自检结果 + web host 状态
-//                         （probeHost 逻辑仅诊断路径使用；不再有「就绪轮询」语义）
+//                         （probeHost 逻辑仅诊断路径使用；事件化后仅兑底/手动刷新）
 //   POST /webui/start        手动启动 web host（process 卡片「手动启动」按钮；ready/starting/触发启动三态）
 //   POST /webui/install-deps 自动安装 dsh 依赖（deps 卡片「安装依赖」按钮；installing/触发安装）
 //   GET  /webui/verify-deps  运行级依赖检测（node cliBin --version；进标签页自动一次 + 手动「检测依赖」按钮）
@@ -43,6 +44,11 @@ import { render as webuiShellHtml } from "../assets/webui-shell.jinja2";
 // 多个壳页 tab 可同时订阅；Set 保存，流关闭时移除。notifyWebStartFailed 每次模块加载
 // 都重新赋值（闭包指向当前模块的 Set，见下方挂钩处），不设一次性守卫。
 const webStartFailedListeners = new Set();
+
+// ---- deps 状态翻转通知订阅者（tools/lib/install.js 调 g.notifyDepsChanged）----
+// 与 webStartFailedListeners 同模式：安装/检测进入与终态时通知壳页一次性刷新诊断
+// （事件驱动替代面板 5s 周期 tick；安装中进度滚动由壳页 installing 态 tick 承担）。
+const depsChangedListeners = new Set();
 
 function esc(v) {
   return String(v)
@@ -192,19 +198,25 @@ export default function registerWebuiRoutes(app, ctx) {
     );
   });
 
-  // 就绪事件流（GET /webui/events，SSE 式 chunked）——壳页就绪事件化的宿主推送通道：
-  //   · 打开时已 ready（bus 已连接）→ 立即推 ready 事件并关闭；
+  // 就绪事件流（GET /webui/events，SSE 式 chunked）——壳页事件化的宿主推送通道
+  // （就绪/诊断/主题偏好/deps 状态，全部事件驱动，替代周期轮询）：
+  //   · 打开时已 ready（bus 已连接）→ 立即推 ready 事件并关闭（壳页就绪态不开流）；
   //   · 未 ready → 先推 pending 事件（壳页保持加载态），挂起等待：
-  //       - bus.ready（本机事件，hello-ok 到达）→ 推 ready 事件并关闭；
+  //       - bus.ready（本机事件，hello-ok 到达）→ 推 ready 事件（流保持常驻）；
   //       - bus.disconnect（web host 停机/重启窗口）→ 推 pending 事件（壳页退回加载态）；
-  //       - web host 启动失败（lifecycle notifyWebStartFailed）→ 推 diagnostics 事件
-  //         （诊断对象由 readDiagnostics 收集；壳页直接显示自检），随后关闭。
-  // 事件格式：SSE data: JSON，{ type: "ready" | "pending" | "diagnostics", diagnostics? }。
+  //       - web host 启动失败（lifecycle notifyWebStartFailed）→ 推 diagnostics 事件；
+  //       - deps 状态翻转（install.js notifyDepsChanged）→ 推 diag-changed 事件；
+  //       - DSH 设置变更（bridge $events 转发 settings/document-updated 的 ui-theme）
+  //         → 推 theme-pref 事件（壳页转告注入脚本重读偏好，替代 3s 轮询 describe）。
+  // ready 后流保持常驻：重启窗口的 pending → ready 周期、主题偏好与 deps 变更继续推送。
+  // 事件格式：SSE data: JSON，{ type: "ready" | "pending" | "diagnostics" |
+  // "diag-changed" | "theme-pref", diagnostics? }。
   // 实现与 routes/card.js 的 /ops/dep-stream 同构（ReadableStream + c.body）；客户端
   // 断开（ReadableStream cancel）时清理订阅与挂钩，不泄漏。
   app.get("/webui/events", (c) => {
     let unsubs = [];
     let onStartFailed = null;
+    let onDepsChanged = null;
     const stream = new ReadableStream({
       start(controller) {
         const enc = new TextEncoder();
@@ -231,6 +243,7 @@ export default function registerWebuiRoutes(app, ctx) {
           }
           unsubs.length = 0;
           if (onStartFailed) webStartFailedListeners.delete(onStartFailed);
+          if (onDepsChanged) depsChangedListeners.delete(onDepsChanged);
           try {
             controller.close();
           } catch {
@@ -246,20 +259,48 @@ export default function registerWebuiRoutes(app, ctx) {
             diagnostics: readDiagnostics(ctx, cfg, port),
           });
         };
-        // 订阅总线本机事件（bus.ready / bus.disconnect）
+        // deps 状态翻转（安装/检测进入与终态）→ 推 diag-changed 事件：壳页收到后
+        // 一次性刷新诊断（事件驱动替代面板 5s 周期 tick；install.js 状态翻转点调用
+        // g.notifyDepsChanged）。
+        onDepsChanged = () => {
+          if (closed) return;
+          send({ type: "diag-changed" });
+        };
+        // 订阅总线本机事件（bus.ready / bus.disconnect / events 转发）
         const g = globalThis.__dshHanako;
         if (g && g.dshanaBus && typeof g.dshanaBus.on === "function") {
           unsubs.push(
             g.dshanaBus.on("bus.ready", () => {
               if (closed) return;
+              // 流常驻：ready 后不关流——后续事件（theme-pref / diag-changed /
+              // 重启窗口的 pending → ready）继续推送，壳页事件驱动刷新
               send({ type: "ready" });
-              close();
             }),
           );
           unsubs.push(
             g.dshanaBus.on("bus.disconnect", () => {
               if (closed) return;
               send({ type: "pending" });
+            }),
+          );
+          // DSH 设置变更转发（bridge $events 订阅 → 总线 events 频道 → 这里过滤）：
+          // settings/document-updated 的 ui-theme 命名空间 = 主题偏好变更，推给壳页
+          // 转告注入脚本重读偏好（事件驱动替代 3s 轮询 settings/describe）。
+          unsubs.push(
+            g.dshanaBus.on("events", (frame) => {
+              if (closed) return;
+              if (!frame || frame.type !== "emit") return;
+              if (
+                frame.event === "settings/document-updated" &&
+                Array.isArray(frame.args) &&
+                frame.args[0] === "ui-theme"
+              ) {
+                send({
+                  type: "theme-pref",
+                  ns: "ui-theme",
+                  revision: frame.args[1] ?? null,
+                });
+              }
             }),
           );
         }
@@ -271,9 +312,19 @@ export default function registerWebuiRoutes(app, ctx) {
         // 每次赋值覆盖为新模块的 Set，与新加载的模块实例保持一致（lifecycle 经单例调用，
         // 幂等无害）。
         webStartFailedListeners.add(onStartFailed);
+        depsChangedListeners.add(onDepsChanged);
         const hookG = globalThis.__dshHanako || (globalThis.__dshHanako = {});
         hookG.notifyWebStartFailed = () => {
           for (const fn of [...webStartFailedListeners]) {
+            try {
+              fn();
+            } catch {
+              /* 通知失败不阻断 */
+            }
+          }
+        };
+        hookG.notifyDepsChanged = () => {
+          for (const fn of [...depsChangedListeners]) {
             try {
               fn();
             } catch {
@@ -299,6 +350,7 @@ export default function registerWebuiRoutes(app, ctx) {
         }
         unsubs.length = 0;
         if (onStartFailed) webStartFailedListeners.delete(onStartFailed);
+        if (onDepsChanged) depsChangedListeners.delete(onDepsChanged);
       },
     });
     return c.body(stream, 200, {
@@ -309,11 +361,11 @@ export default function registerWebuiRoutes(app, ctx) {
     });
   });
 
-  // 纯诊断 GET 端点（v0.22.1+ 收缩）：返回 readDiagnostics 自检结果 + web host 状态
-  // （probeHost 探测 ok + 总线连接状态）。壳页不再轮询此端点做挂载（就绪事件化——
-  // 挂载由 /webui/events ready 事件/父窗口 postMessage ready 驱动）；此处仅作
-  // 30s 超时兜底「查看诊断」与手动刷新的诊断数据源。就绪时也带 diagnostics（低频
-  // 兜底探测需感知 deps 更新/安装进行中状态）。diagnostics 为 null 时下一轮补上。
+  // 纯诊断 GET 端点（v0.22.1+ 收缩，vZ 事件化后仅剩兜底）：返回 readDiagnostics 自检
+  // 结果 + web host 状态（probeHost 探测 ok + 总线连接状态）。壳页不再轮询此端点——
+  // 挂载由 /webui/events ready 事件驱动，诊断刷新由 diag-changed 事件驱动；此处仅作
+  // 30s 超时兑底「查看诊断」、手动刷新与事件驱动 refreshDiag 的数据源。
+  // diagnostics 为 null 时事件到达会再补上（refreshDiag 每次查询都重新收集）。
   app.get("/webui/health", async (c) => {
     const ready = busReady() || (await probeHost(port, ctx.log));
     const body = {

--- a/src/tools/lib/install.js
+++ b/src/tools/lib/install.js
@@ -506,8 +506,10 @@ export async function installDepsFromPlugin(ctxConfig, ctxDataDir, opts = {}) {
       // verifyDepsSmoke 的终态（error）是独立入口语义；此处嵌套于 install 流程——
       // 重装仍进行中，恢复 installing 外层锁，守卫保持拦截并发 install（否则 verify
       // 失败后到安装完成的窗口内第二次 install 请求可进入，两个 pnpm install 同时
-      // 删/建 node_modules）。
+      // 删/建 node_modules）。恢复后补一次通知：verify 失败已推 error（壳页可能显示
+      // 错误与重装按钮），需告知状态已回到 installing，避免壳页停留错误展示诱导重复操作。
       g.deps.status = "installing";
+      notifyDepsChanged();
     }
     // 1.6 部署前停 web host：后续要删旧 node_modules，Windows 上被运行中进程加载的原生
     //    模块（koffi/node-pty 的 .node）会锁文件，rmSync 直接失败（EBUSY/EPERM）。

--- a/src/tools/lib/install.js
+++ b/src/tools/lib/install.js
@@ -665,8 +665,11 @@ export async function installDepsFromPlugin(ctxConfig, ctxDataDir, opts = {}) {
     // verifyDepsSmoke 会把 g.deps.result 刷新为最新 smoke（含 status running→ok/error）
     g.deps.result = null;
     await verifyDepsSmoke(cfg, { force: true });
-    // 安装链路终态 ok（终态保留；verify 若失败其详情在 g.deps.result，不影响安装结论）
+    // 安装链路终态 ok（终态保留；verify 若失败其详情在 g.deps.result，不影响安装结论）——
+    // 成功终态清 error：verifyDepsSmoke 失败路径可能已写入 g.deps.error，不带矛盾状态
+    // （status ok + error 非空）进事件驱动诊断。
     g.deps.status = "ok";
+    g.deps.error = null;
     notifyDepsChanged();
     return { ok: true, state: "installed", cliBin };
   } catch (e) {

--- a/src/tools/lib/install.js
+++ b/src/tools/lib/install.js
@@ -423,11 +423,18 @@ export async function installDepsFromPlugin(ctxConfig, ctxDataDir, opts = {}) {
   const declaredVersion = readDeclaredDshVersion();
   // 声明注入面校验（保留）：声明来自插件根 package.json（单一事实源），仅允许严格
   // SemVer 或合法 dist-tag——"npm:evil@1.0.0" / "github:user/repo" 等非法声明直接拒绝。
+  // 终态发布：声明非法视为部署失败，置 error 并通知（壳页事件驱动刷新诊断，UI 不
+  // 卡在 installing 禁用态）。
   if (declaredVersion === null) {
+    g.deps.error =
+      "插件声明缺少合法 @deepseek-ai/dsh 版本（dependencies 未声明或非法）";
+    g.deps.status = "error";
+    g.deps.time = new Date().toISOString();
+    notifyDepsChanged();
     return {
       ok: false,
       state: "error",
-      error: "插件声明缺少合法 @deepseek-ai/dsh 版本（dependencies 未声明或非法）",
+      error: g.deps.error,
     };
   }
   // 子进程 node 解析（每次部署解析一次；wrapper 与 pnpm add 用同一解析结果——自定义

--- a/src/tools/lib/install.js
+++ b/src/tools/lib/install.js
@@ -836,9 +836,11 @@ export async function verifyDepsSmoke(cfg, opts = {}) {
     // 验证链路终态（ok/error 保留；下次 verify 入口才回到 running）——注意 install 内部
     // 调用本函数后还会把 g.deps.status 置 ok（安装结论优先，verify 详情在 g.deps.result）
     g.deps.status = smoke.ok ? "ok" : "error";
-    notifyDepsChanged();
-    // error 字段与验证结果同步（ok → 清空；失败 → smoke.error，供诊断展示）
+    // error 字段与验证结果同步（ok → 清空；失败 → smoke.error，供诊断展示）——
+    // 先写 error 再通知：notifyDepsChanged 同步调订阅者，若在其前发出则订阅者读到
+    // 的终态缺 error（状态与错误不一致的诊断帧）。
     g.deps.error = smoke.ok ? "" : smoke.error;
+    notifyDepsChanged();
   }
   return smoke;
 }

--- a/src/tools/lib/install.js
+++ b/src/tools/lib/install.js
@@ -385,6 +385,19 @@ export function readDshInstalledVersion(cfg) {
 // 单一事实源），不再回退配置基线 resolveDshTag（保留仅作旧版兼容兜底）。
 // 解耦（D6）：工具包/生命周期自身不 import pnpm 或 cordis 运行时——pnpm 经运行时引导
 // （ensurePnpm 下载单文件）；诊断经 spawn subprocess + HTTP 直查，不加载 cordis。
+// 通知宿主侧 deps 状态翻转（routes/webui.js 挂的 g.notifyDepsChanged → 壳页一次性
+// 刷新诊断，事件驱动替代面板周期 tick）。通知失败不阻断部署/验证主流程。
+function notifyDepsChanged() {
+  const g = getSingleton();
+  if (g && typeof g.notifyDepsChanged === "function") {
+    try {
+      g.notifyDepsChanged();
+    } catch {
+      /* 通知失败不阻断 */
+    }
+  }
+}
+
 export async function installDepsFromPlugin(ctxConfig, ctxDataDir, opts = {}) {
   const g = getSingleton();
   // 部署中并发调用直接返回（路由侧也会先查 g.deps.status，这里是直调兜底）。
@@ -427,6 +440,7 @@ export async function installDepsFromPlugin(ctxConfig, ctxDataDir, opts = {}) {
   g.deps.error = null;
   g.deps.time = new Date().toISOString();
   g.deps.log = "";
+  notifyDepsChanged();
   // 统一日志通道（见文件头）：同一份文本进内存尾环（≤DEPS_LOG_CAP，实时）+ 会话日志
   // 文件（src=pnpm 原始输出 / src=hana 里程碑）。每次写入刷新 g.deps.time（前端
   // installing 态显示「更新于 HH:MM:SS」、3s 轮询 health 随诊断刷新 log 尾部）。
@@ -472,6 +486,7 @@ export async function installDepsFromPlugin(ctxConfig, ctxDataDir, opts = {}) {
         g.deps.error = null;
         g.deps.result = smoke;
         g.deps.status = "ok";
+        notifyDepsChanged();
         return { ok: true, state: "installed", cliBin, skipped: true };
       }
       milestone(
@@ -640,10 +655,12 @@ export async function installDepsFromPlugin(ctxConfig, ctxDataDir, opts = {}) {
     await verifyDepsSmoke(cfg, { force: true });
     // 安装链路终态 ok（终态保留；verify 若失败其详情在 g.deps.result，不影响安装结论）
     g.deps.status = "ok";
+    notifyDepsChanged();
     return { ok: true, state: "installed", cliBin };
   } catch (e) {
     g.deps.error = String(e?.message || e).slice(0, 1500);
     g.deps.status = "error";
+    notifyDepsChanged();
     milestone("[失败] " + g.deps.error);
     return { ok: false, state: "error", error: g.deps.error };
   }
@@ -719,6 +736,7 @@ export async function verifyDepsSmoke(cfg, opts = {}) {
   // 结果缓存（g.deps.result 复合对象整体引用）+ 验证进行中状态
   g.deps.result = smoke;
   g.deps.status = "running";
+  notifyDepsChanged();
   // pnpm 引导检查（与 dsh 运行级验证并行，互不拖累）：verifyDepsSmoke 虽是运行级
   // 只读检测，但 pnpm 检查允许自愈——ensurePnpm 幂等：缓存完整（sha256 一致）直接
   // 返回（快速路径），缺失/损坏自动重新下载（网络操作无副作用）。dataDir 显式传入
@@ -801,6 +819,7 @@ export async function verifyDepsSmoke(cfg, opts = {}) {
     // 验证链路终态（ok/error 保留；下次 verify 入口才回到 running）——注意 install 内部
     // 调用本函数后还会把 g.deps.status 置 ok（安装结论优先，verify 详情在 g.deps.result）
     g.deps.status = smoke.ok ? "ok" : "error";
+    notifyDepsChanged();
     // error 字段与验证结果同步（ok → 清空；失败 → smoke.error，供诊断展示）
     g.deps.error = smoke.ok ? "" : smoke.error;
   }

--- a/src/tools/lib/install.js
+++ b/src/tools/lib/install.js
@@ -503,6 +503,11 @@ export async function installDepsFromPlugin(ctxConfig, ctxDataDir, opts = {}) {
           ((smoke && (smoke.error || smoke.stderr)) || "verify 失败") +
           "），走重装流程",
       );
+      // verifyDepsSmoke 的终态（error）是独立入口语义；此处嵌套于 install 流程——
+      // 重装仍进行中，恢复 installing 外层锁，守卫保持拦截并发 install（否则 verify
+      // 失败后到安装完成的窗口内第二次 install 请求可进入，两个 pnpm install 同时
+      // 删/建 node_modules）。
+      g.deps.status = "installing";
     }
     // 1.6 部署前停 web host：后续要删旧 node_modules，Windows 上被运行中进程加载的原生
     //    模块（koffi/node-pty 的 .node）会锁文件，rmSync 直接失败（EBUSY/EPERM）。


### PR DESCRIPTION
## 背景

两处周期轮询，替代为事件驱动：

1. **settings/describe 3s 轮询**（src-cordis theme 注入脚本）：DSH 0.1.2 退役 events.host WS 后退化而来。官方 0.1.2 提供转发事件 \settings/document-updated\（mode: emit，args=[ns, revision]），官方客户端全部 \ 订阅、零轮询（e2e 断言冷启动最多 2 次 describe）。
2. **/webui/health 5s 面板 tick**：挂载早已事件化（v0.22.1+ 就绪事件流），剩余周期调用是功能面板 onRefresh tick 驱动 refreshDiag。

## 改动

- **theme/index.js**：删 prefTimer（3s 轮询），改监听壳页 postMessage \dshHanaPref\（变更事件驱动重读一次 describe，保留加载时一次回读兜底）
- **routes/webui.js**：/webui/events 流常驻（ready 后不关流）；新增 dshanaBus events 频道订阅（过滤 settings/document-updated 的 ui-theme → 推 theme-pref）；新增 deps 状态翻转通知 g.notifyDepsChanged（仿 notifyWebStartFailed）→ 推 diag-changed
- **install.js**：install/verify 状态翻转点（installing/running/ok/error）调 notifyDepsChanged
- **webui-shell.jinja2**：事件流 ready 后继续 pump + 新事件处理（theme-pref → postMessage 推 iframe、diag-changed → 一次性 refreshDiag）；面板 tick 5s→30s 兜底且不再周期打 health；安装中进度保留 installing 态 3s tick（结束即停）；ready 后断流同样退避重开

## 事件链路

DSH settings/update(ui-theme) → cordis 事件 → gateway → bridge \ 订阅（remote.mux）→ 总线 events 频道 → 宿主 bus.js 分发 → /webui/events → 壳页 postMessage → 注入脚本重读偏好

## 验证

- node --check 全过；\
ode scripts/build.mjs\ 构建成功（dist 含新事件链路）
- 兜底保留：加载时一次回读、30s 超时、手动刷新、事件流断线重开

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live web-interface updates for dependency status, diagnostics, readiness, and theme preferences.
  * Theme changes now synchronize automatically with the embedded interface.
  * Dependency installation and verification transitions are reported in real time.

* **Improvements**
  * Event connections remain active, recover after interruptions, and refresh embedded interfaces when readiness changes.
  * Invalid dependency configurations retain an error status.
  * Health diagnostics remain available as a fallback when live updates are unavailable.
  * Reduced background polling for theme preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->