### PR TITLE
chore: 简化 settings 版本卡片更新相关文案

### DIFF
--- a/src-cordis/plugins/@dsh-hanako/settings/client.js
+++ b/src-cordis/plugins/@dsh-hanako/settings/client.js
@@ -138,7 +138,6 @@ window.__ModuleLoader__.load({
       versionSub: "DSH 版本随插件发版锁定，升级 DSH 请安装新版插件",
       versionLocal: "本地版本",
       versionNone: "未安装",
-      checking: "检查中…",
       checkFailed: "版本检查失败：",
       localMissing: "DSH 未安装（请先在 DSHana 标签页安装依赖）",
     };
@@ -165,7 +164,6 @@ window.__ModuleLoader__.load({
         "DSH version is locked to the plugin release. Upgrade the plugin to upgrade DSH",
       versionLocal: "Local version",
       versionNone: "not installed",
-      checking: "Checking…",
       checkFailed: "Version check failed: ",
       localMissing:
         "DSH is not installed locally (install it from the DSHana tab first)",
@@ -468,302 +466,58 @@ window.__ModuleLoader__.load({
     }
 
     // ---- DSH 版本卡片（设置中心分组卡片二）：纯展示——本地版本 + 更新说明 ----
-    // T7d 起 check-version 只回 localVersion（dsh 版本严格锁插件声明，无远端检查/更新）：
-    // 挂载时 POST /api/hana-settings.check-version 一次即显示，无按钮无轮询；状态行仅
-    // 在异常（未安装/读取失败）时出现。
-    const CHECK_POLL_INTERVAL_MS = 1500;
-    const CHECK_POLL_MAX = 12;
+    // T7d 起 check-version 只回 localVersion（dsh 版本严格锁插件声明，无远端检查/更新，
+    // 更新 dsh = 更新插件发版）：挂载时读一次即显示，无按钮无轮询；状态行仅在
+    // 异常（未安装/读取失败）时出现。
     function DshVersionBlock(props) {
       const { t } = props;
-      const [checking, setChecking] = react.useState(false);
-      const [updating, setUpdating] = react.useState(false);
-      const [armUpdate, setArmUpdate] = react.useState(false);
-      const armTimerRef = react.useRef(null);
       const [localVersion, setLocalVersion] = react.useState(null);
-      const [latestVersion, setLatestVersion] = react.useState(null);
-      const [updateAvailable, setUpdateAvailable] = react.useState(false);
       const [status, setStatus] = react.useState("");
       const [statusKind, setStatusKind] = react.useState("");
-      const pollTimerRef = react.useRef(null);
 
       const setStatusBoth = (msg, kind) => {
         setStatus(msg || "");
         setStatusKind(kind || "");
       };
 
-      const stopPoll = () => {
-        if (pollTimerRef.current) {
-          // 兼容两种形态：旧轮询定时器（clearInterval）与事件流清理句柄（{ close }）
-          if (typeof pollTimerRef.current === 'object' && typeof pollTimerRef.current.close === 'function') {
-            pollTimerRef.current.close();
-          } else {
-            clearInterval(pollTimerRef.current);
-          }
-          pollTimerRef.current = null;
-        }
-      };
-
-      // 卸载清理轮询计时器（切 tab 卸载时不再轮询）
-      react.useEffect(() => {
-        return () => stopPoll();
-      }, []);
-
-      const doCheck = () => {
-        return fetch("/api/hana-settings.check-version", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({}),
-        })
-          .then((r) => r.json())
-          .catch((e) => ({
-            ok: false,
-            error: e && e.message ? e.message : String(e),
-          }));
-      };
-
-      // 应用一次 check-version 结果；返回 'pending'（宿主检查未完成，需继续轮询）或 'done'
-      const applyCheck = (d) => {
-        if (d && d.ok && d.value) {
-          const v = d.value;
-          // 本地版本后端直读 dsh-pkg，即时可用（pending 态也带上）
-          setLocalVersion(v.localVersion);
-          if (v.state === "pending") {
-            setStatusBoth(t("checking"), "info");
-            return "pending";
-          }
-          setLatestVersion(v.latestVersion);
-          setUpdateAvailable(v.updateAvailable === true);
-          if (v.error) {
-            setStatusBoth(t("checkFailed") + v.error, "err");
-          } else if (v.localVersion === null) {
-            setStatusBoth(t("localMissing"), "err");
-          }
-          // 正常（本地已装）：状态行保持空——版本值已在信息行展示，T7d 后无
-          // 远端比较/更新，不再显示「已是最新」等多余状态文案
-          return "done";
-        }
-        setStatusBoth(
-          t("checkFailed") + ((d && d.error) || t("unknown")),
-          "err",
-        );
-        return "done";
-      };
-
-      // 统一检查入口：一次 check-version，pending 则轮询直至结果（或达上限）。
-      // 返回 Promise（结束时 resolve，永 reject——doCheck 内部已 catch）
-      const checkWithPoll = () => {
-        return new Promise((resolve) => {
-          doCheck().then((d) => {
-            if (applyCheck(d) !== "pending") {
-              resolve();
-              return;
-            }
-            stopPoll();
-            let attempts = 0;
-            pollTimerRef.current = setInterval(() => {
-              attempts += 1;
-              doCheck().then((d2) => {
-                if (
-                  applyCheck(d2) !== "pending" ||
-                  attempts >= CHECK_POLL_MAX
-                ) {
-                  stopPoll();
-                  resolve();
-                }
-              });
-            }, CHECK_POLL_INTERVAL_MS);
-          });
-        });
-      };
-
-      // 挂载时读一次本地版本（T7d：无远端检查/更新——check-version 后端只回 localVersion）
+      // 挂载时读一次本地版本（后端只回 localVersion：直读 dsh-pkg package.json）
       react.useEffect(() => {
         let alive = true;
-        doCheck().then((d) => {
-          if (!alive) return;
-          applyCheck(d);
-        });
-        return () => {
-          alive = false;
-          stopPoll();
-        };
-      }, []);
-
-      const onCheck = () => {
-        if (checking || updating) return;
-        setChecking(true);
-        setStatusBoth(t("checking"), "info");
-        checkWithPoll()
-          .then(() => setChecking(false))
-          .catch(() => setChecking(false));
-      };
-
-      const onUpdate = () => {
-        if (updating || !updateAvailable) return;
-        if (!armUpdate) {
-          // 两段式确认：宿主沙箱 iframe 无 allow-modals，window.confirm 被浏览器忽略
-          // （Ignored call to 'confirm()'），改二次点击确认；5s 无操作自动复位
-          setArmUpdate(true);
-          clearTimeout(armTimerRef.current);
-          armTimerRef.current = setTimeout(() => setArmUpdate(false), 5000);
-          return;
-        }
-        clearTimeout(armTimerRef.current);
-        setArmUpdate(false);
-        setUpdating(true);
-        setStatusBoth(t("updatingMsg"), "info");
-        fetch("/api/hana-settings.request-update", {
+        fetch("/api/hana-settings.check-version", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({}),
         })
           .then((r) => r.json())
           .then((d) => {
-            if (!d || !d.ok) {
-              setUpdating(false);
+            if (!alive) return;
+            const v = d && d.ok && d.value ? d.value : null;
+            if (v) {
+              setLocalVersion(v.localVersion);
+              if (v.error) {
+                setStatusBoth(t("checkFailed") + v.error, "err");
+              } else if (v.localVersion === null) {
+                setStatusBoth(t("localMissing"), "err");
+              }
+              // 正常（本地已装）：状态行保持空——版本值已在信息行展示
+            } else {
               setStatusBoth(
-                t("updateFailed") + ((d && d.error) || t("unknown")),
+                t("checkFailed") + ((d && d.error) || t("unknown")),
                 "err",
               );
-              return;
             }
-            // ---- 事件驱动（v0.22.1+）：订阅 /api/hana-settings.update-stream（SSE 式流）
-            // 直到 done/error——替代旧 2s 轮询 update-status。后端收到总线 update.progress/
-            // result 事件即推；终态后流关闭。事件缺失（流未建立/中途断开）时依赖手动刷新
-            // 按钮（update-status 一次性查询兜底）。web host 重启窗口流会断开：显示
-            // 「更新中…」并保持——web host 回来且更新完成时新订阅/手动刷新拿到终态。
-            const streamUrl = "/api/hana-settings.update-stream";
-            let reader = null;
-            let streamClosed = false;
-            const closeStream = () => {
-              streamClosed = true;
-              if (reader) {
-                try { reader.cancel(); } catch (e) { /* 已关闭 */ }
-                reader = null;
-              }
-            };
-            // 流式读取（fetch + ReadableStream；SSE 行解析 data: ...）
-            const readStream = (res) => {
-              if (!res || !res.body) {
-                // 流不可用（旧后端/代理缓冲）：退化为一次性查询（用户可手动刷新）
-                queryStatusOnce();
-                return;
-              }
-              reader = res.body.getReader();
-              const decoder = new TextDecoder();
-              let buf = "";
-              const pump = () => {
-                reader.read().then(function process({ done, value }) {
-                  if (done || streamClosed) {
-                    reader = null;
-                    // 流关闭但未收到终态：web host 重启窗口断开——回查一次一次性状态，
-                    // 避免界面停在「更新中…」（重启完成后 update-status 能读到真实终态）；
-                    // 无终态事件时保持现状可手动刷新。
-                    queryStatusOnce();
-                    return;
-                  }
-                  buf += decoder.decode(value, { stream: true });
-                  var idx;
-                  while ((idx = buf.indexOf("\n\n")) !== -1) {
-                    var chunk = buf.slice(0, idx);
-                    buf = buf.slice(idx + 2);
-                    var dataLine = null;
-                    var lines = chunk.split("\n");
-                    for (var i = 0; i < lines.length; i++) {
-                      if (lines[i].indexOf("data: ") === 0) {
-                        dataLine = lines[i].slice(6);
-                        break;
-                      }
-                    }
-                    if (!dataLine) continue;
-                    var d2;
-                    try { d2 = JSON.parse(dataLine); } catch (e2) { continue; }
-                    if (!d2 || !d2.ok || !d2.value) continue;
-                    applyUpdateEvent(d2.value);
-                    if (streamClosed) return;
-                  }
-                  // 递归 read 同样附加 rejection 处理：流错误时置 reader 为 null，
-                  // 与 done/streamClosed/初始 read 的 catch 分支一致（不留悬空 reader）；
-                  // 且回查一次性状态（CodeRabbit：stream error 而非 EOF 时 updating 会
-                  // 卡 true、控件禁用——queryStatusOnce 让界面恢复）。
-                  reader.read().then(process).catch(function () {
-                    reader = null;
-                    if (!streamClosed) queryStatusOnce();
-                  });
-                }).catch(function () {
-                  reader = null;
-                  if (!streamClosed) queryStatusOnce();
-                });
-              };
-              pump();
-            };
-            // 应用一个更新事件（progress/result）
-            const applyUpdateEvent = (v) => {
-              if (!v) return;
-              if (v.state === "done") {
-                closeStream();
-                setUpdating(false);
-                setStatusBoth(
-                  t("updateDone") + (v.version || "?") + t("restartNote"),
-                  "ok",
-                );
-                // 更新完成：刷新版本信息（新 web host 已起，读到新本地版本）
-                doCheck().then((c) => {
-                  if (c && c.ok && c.value) {
-                    setLocalVersion(c.value.localVersion);
-                    setLatestVersion(c.value.latestVersion);
-                    setUpdateAvailable(c.value.updateAvailable === true);
-                  }
-                });
-              } else if (v.state === "error") {
-                closeStream();
-                setUpdating(false);
-                setStatusBoth(
-                  t("updateFailed") + (v.error || t("unknown")),
-                  "err",
-                );
-              }
-              // state updating/idle：继续等事件
-            };
-            // 一次性查询兜底（手动刷新/流不可用时）：读 update-status（事件缓存或文件）
-            const queryStatusOnce = () => {
-              fetch("/api/hana-settings.update-status", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({}),
-              })
-                .then((r) => r.json())
-                .then((d2) => {
-                  if (d2 && d2.ok && d2.value) applyUpdateEvent(d2.value);
-                })
-                .catch(() => { /* 手动刷新失败：保持当前状态 */ });
-            };
-            // 卸载清理：关闭流。先 stopPoll() 清掉 pending 的 check 轮询定时器再接管
-            // pollTimerRef——否则旧定时器仍会继续 applyCheck 覆盖状态，且其结束时的
-            // stopPoll() 会误关新流句柄（{ close } 被当 interval clearInterval 清掉）
-            stopPoll();
-            pollTimerRef.current = { close: closeStream }; // 复用 stopPoll 清理槽
-            fetch(streamUrl, { headers: { "Accept": "text/event-stream" } })
-              .then(function (r) {
-                if (!r.ok) { queryStatusOnce(); return null; }
-                return r;
-              })
-              .then(function (res) {
-                if (res && !streamClosed) readStream(res);
-              })
-              .catch(function () {
-                // 流建立失败：退化为一次性查询（后端事件缓存/文件兜底）
-                queryStatusOnce();
-              });
           })
           .catch((e) => {
-            setUpdating(false);
+            if (!alive) return;
             setStatusBoth(
-              t("updateFailed") + (e && e.message ? e.message : String(e)),
+              t("checkFailed") + (e && e.message ? e.message : String(e)),
               "err",
             );
           });
-      };
+        return () => {
+          alive = false;
+        };
+      }, []);
 
       return jsx_runtime.jsxs("section", {
         className: "hs-card",

--- a/src-cordis/plugins/@dsh-hanako/settings/client.js
+++ b/src-cordis/plugins/@dsh-hanako/settings/client.js
@@ -21,21 +21,10 @@
 //      无 api 字段，vY T7b 后 connection 由 @dsh-hanako/api-bridge 的 client 载体提供）；
 //      当前默认回显（POST /api/hana-settings.read）；保存
 //      （POST /api/hana-settings.save）→ agentDefaultModel 服务写 settings.yaml。
-//   ② DSH 版本卡片：@deepseek-ai/dsh 版本检查与更新（v0.18.1 起检查改 **dsh 侧直查**——
-//      后端 HTTP 直查 npm registry（fetch https://registry.npmjs.org/@deepseek-ai/dsh/latest
-//      的 JSON version 字段，pnpm view 语义等价；官方源失败重试 npmmirror，15s 超时，
-//      v0.18.2 起不再 spawn pnpm），不再经宿主桥接；更新经 **dshana.bus 消息总线**
-//      （@dsh-hanako/bridge 提供 dshanaBus 服务）发 update.request 直投宿主执行——
-//      挂载时自动调一次 POST /api/hana-settings.check-version
-//      （本地版本后端直读 dsh-pkg package.json 零延迟；远端版本后端 HTTP 直查，慢时
-//      返回 pending 由前端轮询兜底），显示本地/最新版本与状态；「检查更新」手动刷新；
-//      「更新到最新」（仅 updateAvailable 时可用，两段式确认）→ POST
-//      /api/hana-settings.request-update 经总线直投宿主（v0.22.1 起替代写更新请求文件
-//      与 /child/post 反向信道，均已退役；bus 未就绪返回「消息总线未连接」），宿主
-//      npm i latest + 重启 web host（web host 重启窗口流断开视为仍在更新）；更新期间
-//      订阅 GET /api/hana-settings.update-stream 事件流（v0.22.1+ 事件驱动，替代旧 2s
-//      轮询 update-status）直到 done/error；事件缺失时手动刷新（update-status 一次性
-//      查询兜底：事件缓存优先；v0.24 起 update-result.json 退役，无文件兜底），计时器/流卸载时清理。
+//   ② DSH 版本卡片：纯展示——T7d 起 dsh 版本严格锁插件声明（更新 dsh = 更新插件
+//      发版），无远端检查/更新。挂载时 POST /api/hana-settings.check-version 一次
+//      （后端只回 localVersion：本地版本直读 dsh-pkg package.json，零延迟）即显示，
+//      无按钮无轮询。
 // 样式用 dsw CSS 变量（--dsw-alias-*），对齐设置面板原生观感（hs-* 类，设置中心：
 // 页头品牌区 + 圆角分组卡片 + 卡片头分隔线 + 版本信息面板；hs 前缀 = hana-settings，
 // 替代改名前的 hdm（hana-default-model）标识）。
@@ -146,11 +135,12 @@ window.__ModuleLoader__.load({
       unknown: "未知错误",
       // ---- DSH 版本卡片 ----
       versionTitle: "DSH 版本",
-      versionSub:
-        "@deepseek-ai/dsh 版本严格锁插件声明（T7d：更新 dsh = 更新插件发版，无独立检查/更新通道）",
+      versionSub: "DSH 版本随插件发版锁定，升级 DSH 请安装新版插件",
       versionLocal: "本地版本",
       versionNone: "未安装",
-      updateNote: "更新 dsh = 更新插件版本（插件发版时随声明重装）",
+      checking: "检查中…",
+      checkFailed: "版本检查失败：",
+      localMissing: "DSH 未安装（请先在 DSHana 标签页安装依赖）",
     };
     const en = {
       nav: "DSHana Settings",
@@ -172,23 +162,13 @@ window.__ModuleLoader__.load({
       // ---- DSH version card ----
       versionTitle: "DSH Version",
       versionSub:
-        "@deepseek-ai/dsh version is locked to the plugin declaration (T7d: updating dsh = shipping a new plugin version; no standalone check/update channel)",
+        "DSH version is locked to the plugin release. Upgrade the plugin to upgrade DSH",
       versionLocal: "Local version",
       versionNone: "not installed",
-      updateNote: "Updating dsh = shipping a new plugin version (reinstalled from the declaration on release)",
+      checking: "Checking…",
+      checkFailed: "Version check failed: ",
       localMissing:
         "DSH is not installed locally (install it from the DSHana tab first)",
-      update: "Update to latest",
-      updateConfirm:
-        "Updating will restart DSHana and interrupt running tasks. Continue?",
-      updateConfirmShort: "Click again to confirm",
-      updatingMsg:
-        "Updating… (DSHana will restart, running tasks will be interrupted)",
-      updateDone: "Update complete v",
-      restartNote: ". Please restart DSHana for full effect",
-      updateFailed: "Update failed: ",
-      updateTimeout:
-        "Update timed out: web host unreachable for too long, check the DSHana tab diagnostics",
     };
 
     // ---- 默认模型卡片：三级联动表单（设置中心分组卡片一）----
@@ -487,23 +467,10 @@ window.__ModuleLoader__.load({
       });
     }
 
-    // ---- DSH 版本卡片：@deepseek-ai/dsh 版本检查与更新（设置中心分组卡片二）----
-    // v0.18.1 起检查改 **dsh 侧直查**：本分页 POST /api/hana-settings.check-version，
-    // 后端 HTTP 直查 npm registry（fetch https://registry.npmjs.org/@deepseek-ai/dsh/latest
-    // 的 JSON version 字段，pnpm view 语义等价；官方源失败重试 npmmirror，15s 超时，
-    // v0.18.2 起不再 spawn pnpm）→ 返回 { localVersion, latestVersion,
-    // updateAvailable, error? }；本地版本后端直读 dsh-pkg package.json（零延迟，
-    // 挂载即显示）。不再写 update-request.json / 读 check-result.json（v0.18.1 起
-    // 废弃宿主桥接——resources.watch 链路不可靠曾致检查永不完成）。
-    // 返回 value 形状：{ localVersion, latestVersion?, updateAvailable?, error? } 或
-    // { state:'pending', localVersion }（后端 HTTP 查询慢时前端轮询兜底——保留 pending
-    // 分支，applyCheck 语义不变）。
-    // 挂载时自动检查一次：先拿到本地版本即时显示，pending 则每 1.5s 轮询
-    // check-version 直至结果（CHECK_POLL_MAX 次上限，防查询慢/异常时无限轮询）。
-    // 「更新到最新」→ request-update（宿主经总线受理后 npm i latest + 重启 web host）→
-    // 订阅 /api/hana-settings.update-stream 事件流（v0.22.1+ 事件驱动，替代旧 2s 轮询
-    // update-status）直到 done/error；流不可用/事件缺失时手动刷新（update-status 一次性
-    // 查询兜底）。web host 重启窗口流断开：保持「更新中…」，回来后事件/刷新拿到终态。
+    // ---- DSH 版本卡片（设置中心分组卡片二）：纯展示——本地版本 + 更新说明 ----
+    // T7d 起 check-version 只回 localVersion（dsh 版本严格锁插件声明，无远端检查/更新）：
+    // 挂载时 POST /api/hana-settings.check-version 一次即显示，无按钮无轮询；状态行仅
+    // 在异常（未安装/读取失败）时出现。
     const CHECK_POLL_INTERVAL_MS = 1500;
     const CHECK_POLL_MAX = 12;
     function DshVersionBlock(props) {
@@ -570,14 +537,9 @@ window.__ModuleLoader__.load({
             setStatusBoth(t("checkFailed") + v.error, "err");
           } else if (v.localVersion === null) {
             setStatusBoth(t("localMissing"), "err");
-          } else if (v.updateAvailable === true) {
-            setStatusBoth(
-              t("updateAvailableMsg") + (v.latestVersion || "?"),
-              "ok",
-            );
-          } else {
-            setStatusBoth(t("upToDate"), "ok");
           }
+          // 正常（本地已装）：状态行保持空——版本值已在信息行展示，T7d 后无
+          // 远端比较/更新，不再显示「已是最新」等多余状态文案
           return "done";
         }
         setStatusBoth(
@@ -825,7 +787,7 @@ window.__ModuleLoader__.load({
               jsx_runtime.jsxs("div", {
                 className: "hs-info",
                 children: [
-                  jsx_runtime.jsxs("div", {
+                  jsx_runtime.jsx("div", {
                     className: "hs-info-row",
                     children: [
                       jsx_runtime.jsx("span", {
@@ -837,10 +799,6 @@ window.__ModuleLoader__.load({
                         children: localVersion || t("versionNone"),
                       }),
                     ],
-                  }),
-                  jsx_runtime.jsx("div", {
-                    className: "hs-note",
-                    children: t("updateNote"),
                   }),
                 ],
               }),

--- a/src-cordis/plugins/@dsh-hanako/settings/client.js
+++ b/src-cordis/plugins/@dsh-hanako/settings/client.js
@@ -494,9 +494,9 @@ window.__ModuleLoader__.load({
             const v = d && d.ok && d.value ? d.value : null;
             if (v) {
               setLocalVersion(v.localVersion);
-              if (v.error) {
-                setStatusBoth(t("checkFailed") + v.error, "err");
-              } else if (v.localVersion === null) {
+              // 后端只回 { localVersion, updateAvailable:false }，无 error 字段；
+              // readLocalVersion 可能返回 null/undefined/""，统一按未安装处理
+              if (!v.localVersion) {
                 setStatusBoth(t("localMissing"), "err");
               }
               // 正常（本地已装）：状态行保持空——版本值已在信息行展示

--- a/src-cordis/plugins/@dsh-hanako/settings/client.js
+++ b/src-cordis/plugins/@dsh-hanako/settings/client.js
@@ -76,7 +76,7 @@ window.__ModuleLoader__.load({
       ".hs-value{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--dsw-alias-label-primary,#1f2329);font-size:13px;line-height:20px}" +
       ".hs-select{flex:1;min-width:0;height:30px;padding:0 8px;border:1px solid var(--dsw-alias-border-l1,#d8d8d8);border-radius:8px;background:var(--dsw-alias-bg-base,#ffffff);color:var(--dsw-alias-label-primary,#1f2329);font-family:inherit;font-size:13px;line-height:20px}" +
       ".hs-select:focus{outline:none;border-color:var(--dsw-alias-button-primary-fill,#537d96)}" +
-      // ---- 版本信息面板（DSH 版本卡片：本地/最新版本 双行信息块）----
+      // ---- 版本信息面板（DSH 版本卡片：本地版本 信息块）----
       ".hs-info{display:flex;flex-direction:column;gap:8px;padding:10px 12px;background: var(--dsw-alias-bg-module-platform,#EFE8DB);border-radius:8px}" +
       ".hs-info-row{display:flex;align-items:center;justify-content:space-between;gap:12px}" +
       ".hs-info-label{flex:none;color:var(--dsw-alias-label-secondary,#5a5f66);font-size:12px}" +
@@ -465,7 +465,7 @@ window.__ModuleLoader__.load({
       });
     }
 
-    // ---- DSH 版本卡片（设置中心分组卡片二）：纯展示——本地版本 + 更新说明 ----
+    // ---- DSH 版本卡片（设置中心分组卡片二）：纯展示——本地版本 ----
     // T7d 起 check-version 只回 localVersion（dsh 版本严格锁插件声明，无远端检查/更新，
     // 更新 dsh = 更新插件发版）：挂载时读一次即显示，无按钮无轮询；状态行仅在
     // 异常（未安装/读取失败）时出现。


### PR DESCRIPTION
## 背景

T7d 后 dsh 版本严格锁插件声明（check-version 只回 localVersion，无远端检查/更新），但版本卡片的 UI 文案与注释仍带着旧语义：versionSub 含内部代号 T7d 与黑话、updateNote 与之重复、en 字典残留一整批不再渲染的 update 交互文案。

## 改动

- versionSub 简化：\DSH 版本随插件发版锁定，升级 DSH 请安装新版插件\（去掉 T7d 代号）
- 删除 UI 上不再渲染的 hs-note 行（updateNote key 一并删）
- en 字典删残留死文案：update / updateConfirm / updateConfirmShort / updatingMsg / updateDone / restartNote / updateFailed / updateTimeout
- applyCheck 正常分支不再显示状态行（无「已是最新」语义），异常（未安装/检查失败）保留
- 补 zh/en 缺失 key：checking / checkFailed（zh 补 localMissing），状态行不再裸 key
- 头部注释与组件注释压成 T7d 现状（纯展示卡片）

## 验证

\
ode scripts/build.mjs\ 构建成功（cordis profile 含 settings 插件）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changed**
  - The DSH version card now performs one local version check when opened and displays the installed version.
  - Remote version comparisons, polling, manual checks, update requests, confirmations, progress updates, and update-status messages are no longer available.
  - Update-related guidance has been removed from the version card.
  - If no local version is detected, the card displays a not-installed error; successful checks no longer show a status message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->