### PR TITLE
fix: node 代理改回插件根部署，与 PATH 前缀同源（修复 install script 找不到 node）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ specs/
 
 data/
 
+# 运行期 node 代理（installDepsFromPlugin 写入插件根，每次安装幂等重建；不进 git）
+# /node 为 Linux/macOS 无扩展名形态；仓库根无同名资产，安全忽略
+/node.cmd
+/node
+

--- a/src/tools/lib/install.js
+++ b/src/tools/lib/install.js
@@ -19,7 +19,6 @@ import { spawn } from "node:child_process";
 import {
   readFileSync,
   existsSync,
-  mkdirSync,
   writeFileSync,
   copyFileSync,
   rmSync,
@@ -529,21 +528,34 @@ export async function installDepsFromPlugin(ctxConfig, ctxDataDir, opts = {}) {
     if (!existsSync(srcWs))
       throw new Error("插件根缺少 pnpm-workspace.yaml：" + srcWs);
     milestone("部署清单：插件根 package.json（声明）+" + srcWs);
-    // 3. 创建 node 代理（数据目录，不污染插件根）；pnpm 入口 = 运行时引导
+    // 3. 创建 node 代理（插件根，与部署物同目录）；pnpm 入口 = 运行时引导
     //    （lib/pnpm.js ensurePnpm 下载单文件 pnpm.mjs 到数据目录 pnpm-dist/）。
-    //    PATH 首部指向代理目录——install script（koffi/node-pty 等 build）能找到宿主 node。
-    const proxyDir = join(dataDir, "pnpm-proxy");
-    mkdirSync(proxyDir, { recursive: true });
+    //    代理与 pnpm run 的 PATH 前缀同源绑定 pkgDir（见下）——install script
+    //    （koffi/node-pty 等 build）经 cmd 起子进程 node 时命中代理 → 转发到解析后的
+    //    node 执行体（nodejsPath 或宿主 electron node）。历史教训（T7d 过渡期）：代理
+    //    写数据目录 pnpm-proxy 而 PATH 仍指插件根，cmd 找不到 node，install script 全挂
+    //    （ELIFECYCLE 'node' is not recognized，全新安装必现）；代理随部署走、与 PATH
+    //    同目录即无漂移可能。清理段只删 node_modules/lock，pnpm 不碰 node_modules 外
+    //    文件，代理每次安装幂等重建、不受影响。
+    const legacyProxy = join(dataDir, "pnpm-proxy");
+    if (existsSync(legacyProxy)) {
+      try {
+        rmSync(legacyProxy, { recursive: true, force: true });
+        milestone("[兼容] 旧数据目录 pnpm-proxy 已删除（代理改随插件根部署）");
+      } catch (e) {
+        milestone("[兼容] 旧 pnpm-proxy 删除失败（可手动清理）：" + (e?.message || e));
+      }
+    }
     if (IS_WIN) {
-      const script = join(proxyDir, "node.cmd");
+      const script = join(pkgDir, "node.cmd");
       const content = `@"${nodeExec}" %*\n`;
       writeFileSync(script, content);
     } else {
-      const script = join(proxyDir, "node");
+      const script = join(pkgDir, "node");
       const content = `#!/bin/sh\nexec "${nodeExec}" "$@"\n`;
       writeFileSync(script, content, { mode: 0o755 });
     }
-    milestone("node 代理就绪：" + proxyDir);
+    milestone("node 代理就绪：" + pkgDir);
     // pnpm 不再内置（zip 摘除 node_modules/pnpm）：运行时下载 pnpm-{version} 单文件
     // pnpm.mjs 到数据目录 pnpm-dist/（缓存独立于 dsh-pkg）。引导失败（网络/校验）与
     // 旧「pnpm.cjs 不存在」语义区分：抛可读错误（含两个 CDN 提示），由外层 catch 记入
@@ -627,6 +639,11 @@ export async function installDepsFromPlugin(ctxConfig, ctxDataDir, opts = {}) {
         cwd: pkgDir,
         env: {
           ...nodeEnv,
+          // PATH 首部 = pkgDir（插件根）：node 代理（node.cmd/node）与部署物同目录、
+          // 同源绑定（见上方「创建 node 代理」）——install script（koffi/node-pty 等
+          // build）经 cmd 起子进程 node 时命中代理，转发到解析后的 node 执行体
+          // （nodejsPath 或宿主 electron node）。代理目录与 PATH 前缀为同一常量，
+          // 不存在漂移可能（T7d 过渡期代理在数据目录而 PATH 指插件根，曾致全挂）。
           PATH: pkgDir + delimiter + (process.env.PATH || ""),
         },
         onStdout: makePipe(buffers.out),


### PR DESCRIPTION
## 背景（实测暴露）

v1.0.0-alpha.8 启动自动安装日志（宿主触发全新安装）报错：

`koffi@3.1.6 install: node ./cnoke.cjs ...` → ELIFECYCLE exit 1，乱码原文为 GBK 的「'node' 不是内部或外部命令」。官方源与 npmmirror 重试都栽在同一处，整次 pnpm install 失败。

## 根因（T7d 过渡期漂移）

T7d 把部署目标从 dsh-pkg 改回插件根 node_modules，node 代理（node.cmd / node）却从部署目录单独挪去了数据目录 `pnpm-proxy`，而 pnpm run 的 PATH 首部仍指 `pkgDir`——代理目录与 PATH 前缀双常量漂移。全新安装（node_modules 重建）时 koffi 等原生依赖必须重跑 install script，cmd 起子进程 node 找不到 → 全挂；增量安装 install script 不重跑，故此前一直潜伏。宿主进程 PATH 无 node 时必现（手动在带 node 的终端跑不暴露）。

## 修复

代理改回**随部署目录走**（写插件根 `pkgDir`，恢复旧 dsh-pkg 时代「代理在部署目录」的原始语义），pnpm run 的 PATH 首部指 `pkgDir`——代理目录与 PATH 前缀**同源绑定同一常量**，此类漂移结构上不再可能。

- 顺手清理旧数据目录 `pnpm-proxy` 残留（兼容删除）
- `.gitignore` 忽略运行期 `/node.cmd` 与 `/node`（dev 源码仓库跑 install 会在仓库根生成代理）
- pack 清单为固定项，代理不进发布 zip

## 验证

- 复现：PATH=$pkgDir（无 node）时 `cmd /c node -v` → `'node' is not recognized`（与日志一致，exit 1）
- 修复机制：代理落插件根后，PATH=$pkgDir 即命中 node.cmd → 转发到解析后的 node 执行体（宿主 node，实测 `v26.8.1`）
- node --check + rspack build 通过

## 影响

修复后全新安装 / 依赖重建场景 koffi 等原生依赖 install script 正常执行；已装环境增量安装不受影响。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved plugin dependency installation by ensuring runtime tooling can reliably locate the required Node executable.
  - Removed obsolete runtime proxy artifacts when they are no longer needed.
  - Updated environment handling so package installation commands run consistently within the plugin context.

- **Chores**
  - Added repository ignore rules for generated runtime proxy files to keep them out of source control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->