### PR TITLE
fix: loadInprocDsh 动态 import 先 realpath，穿透宿主进程内 ESM 缓存

### DIFF
--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -488,13 +488,21 @@ export function ensureDshanaProfile(cfg) {
 // file:// URL 不适用（实机验证：dsh 包无可用 profile-boot 模块）；webpackIgnore 告诉
 // bundler 完全不要处理该 import，保留原生 import() 调用，且不丢静态语义。
 async function loadInprocDsh(pkgDir) {
-  const dshPkg = join(pkgDir, "node_modules", "@deepseek-ai", "dsh");
-  const libDir = join(dshPkg, "lib");
-  if (!existsSync(join(dshPkg, "package.json"))) {
+  const dshPkgLink = join(pkgDir, "node_modules", "@deepseek-ai", "dsh");
+  if (!existsSync(join(dshPkgLink, "package.json"))) {
     throw new Error(
-      `DSH 包未就绪：${dshPkg} 不存在。请在 DSHana 标签页执行「安装依赖」（pnpm install 按声明拉取到 dsh-pkg），或手动在插件数据目录 dsh-pkg 执行 pnpm install`,
+      `DSH 包未就绪：${dshPkgLink} 不存在。请在 DSHana 标签页执行「安装依赖」（pnpm install 按声明拉取到 dsh-pkg），或手动在插件数据目录 dsh-pkg 执行 pnpm install`,
     );
   }
+  // realpath 指纹化（升级缓存穿透）：dshPkgLink 是 pnpm symlink（顶层
+  // node_modules/@deepseek-ai/dsh），路径跨版本稳定；Node ESM 缓存按 import URL 为 key，
+  // 动态 import 不经 realpath 归一（实机验证：宿主进程内依赖升级后热重载，同 URL 命中
+  // 旧版 dsh 模块——重启宿主才恢复，曾致升级后 boot 跑旧代码读已删除的旧 .pnpm 路径
+  // 报 ENOENT）。realpath 后 URL 指向 .pnpm/@deepseek-ai+dsh@<ver>_<hash>，含版本指纹：
+  // dsh 升级 → 哈希变 → URL 变 → 缓存天然失效，无需重启宿主。子 chunk 相对 import 基于
+  // realpath URL 解析，全树同指纹，一并穿透。
+  const dshPkg = realpathSync(dshPkgLink);
+  const libDir = join(dshPkg, "lib");
   // ① profile-boot：枚举 lib 下 profile-boot-*.js，逐个 import 试 runProfile
   let profileBoot = null;
   let bootEntry = null;
@@ -531,6 +539,8 @@ async function loadInprocDsh(pkgDir) {
   //    b) 失败回退 .pnpm 虚拟存储枚举（手工/自定义链接树布局下 createRequire 的 realpath
   //       解析不可靠——实测 symlink 路径向上只到顶层 node_modules，找不到间接依赖；
   //       probe-inproc 验证过的定位方式）。
+  //    resolve/枚举结果统一再 realpath 一次（.pnpm 哈希目录），与上方 dsh 同款缓存指纹
+  //    （app-boot 自身也随 dsh 版本换哈希目录，symlink 路径 import 会命中宿主进程内旧缓存）。
   let appBootEntry = null;
   try {
     const dshRequire = createRequire(join(dshPkg, "package.json"));
@@ -568,6 +578,11 @@ async function loadInprocDsh(pkgDir) {
     throw new Error(
       `无法解析 @deepseek-ai/dsh-app-boot（dsh 依赖缺失？createRequire 与 .pnpm 枚举均未命中）`,
     );
+  }
+  try {
+    appBootEntry = realpathSync(appBootEntry);
+  } catch {
+    /* realpath 失败（边缘）：保留原路径，import 时按原样解析 */
   }
   const appBoot = await import(/* webpackIgnore: true */ pathToFileURL(appBootEntry).href);
   if (typeof appBoot.loadLayeredEnv !== "function") {

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -541,9 +541,12 @@ async function loadInprocDsh(pkgDir) {
   //       probe-inproc 验证过的定位方式）。
   //    resolve/枚举结果统一再 realpath 一次（.pnpm 哈希目录），与上方 dsh 同款缓存指纹
   //    （app-boot 自身也随 dsh 版本换哈希目录，symlink 路径 import 会命中宿主进程内旧缓存）。
+  //    createRequire 基准用原始 symlink 路径（dshPkgLink）而非 realpath 目标：从 .pnpm
+  //    深处向上解析不一定能找到 dsh-app-boot（该包仅在 pkgDir/node_modules 链暴露时
+  //    realpath 解析失败），symlink 路径沿顶层 node_modules 链必然命中（CodeRabbit）。
   let appBootEntry = null;
   try {
-    const dshRequire = createRequire(join(dshPkg, "package.json"));
+    const dshRequire = createRequire(join(dshPkgLink, "package.json"));
     appBootEntry = dshRequire.resolve("@deepseek-ai/dsh-app-boot");
   } catch {
     // 回退 .pnpm 枚举


### PR DESCRIPTION
## 背景（实机验证）

dsh 依赖升级（alpha.4 → alpha.5，插件根 node_modules 重建）后，**不重启宿主仅热重载插件**，boot 持续失败：

```
ENOENT: ...node_modules\.pnpm\@deepseek-ai+dsh@0.1.2-alph_85829f33...\node_modules\@deepseek-ai\dsh\package.json
  at readModuleFallbackManifest ... / profile-boot-BTzzdrGY.js:188
```

错误栈指向 `85829f…`（alpha.4 的 .pnpm 哈希路径）——磁盘上该目录已被新安装（`5b26c9…`）替代，**代码不可能从已删除的文件执行**。清空 `profiles/node_modules` 无效，完整重启宿主进程即恢复。

## 根因

`loadInprocDsh` 动态 import 的 URL 是 **pnpm symlink 顶层路径**（`node_modules/@deepseek-ai/dsh/lib/profile-boot-x7_BzdeW.js`），跨版本稳定。Node ESM 缓存以动态 import 的 URL 为 key，同一宿主进程内依赖升级后热重载，同 URL 命中**旧版 dsh 模块缓存**——旧代码按它记忆的旧 .pnpm 哈希路径读文件，ENOENT。`profiles/node_modules` 的清空与此无关（误导线索）。

## 修复

`loadInprocDsh` 对 dsh 入口与 app-boot **先 `realpathSync` 再 `import`**：

- URL 指向 `.pnpm/@deepseek-ai+dsh@<ver>_<hash>`，**含版本指纹**
- dsh 升级 → 哈希变 → URL 变 → ESM 缓存天然失效，**无需重启宿主**
- 子 chunk 相对 import 基于 realpath URL 解析，整树同指纹一并穿透
- app-boot 定位（createRequire.resolve / .pnpm 枚举）结果统一再 realpath

思路同源 hana-remote-dev 壳方案（读盘 + new Function 绕开 ESM 缓存），这是对 ESM 依赖树的适配版。

## 验证

- `node --check` + rspack build 通过
- 真实缓存穿透场景只能在宿主进程内验证（需：装本版 → 不重启宿主 → 热重载 → boot 应加载新 dsh 成功）

## 关联

此前对「alpha.5 上游 heal 不容错」的判断作废（那是缓存旧代码的误读）；如确认修复有效，可考虑是否值得给上游报「模块缓存穿透」的通用问题。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DSH package loading when packages are installed through symbolic links.
  * Preserved reliable module resolution for linked packages while maintaining accurate cache behavior for version-sensitive imports.
  * Improved compatibility with installations that resolve packages through both linked and canonical paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->