### PR TITLE
feat: 错误分类器 errclass（T1）

### DIFF
--- a/src/tools/lib/errclass.js
+++ b/src/tools/lib/errclass.js
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2026 Nyasers
+//
+// tools/lib/errclass.js — 依赖安装失败错误分类器（spec：dsh-deps-zero-intervention，T1 纯函数）
+//
+// 背景（spec「错误只看 exit 1 无法引导」）：install/boot 失败时只看到退出码无法决定
+// 策略——分类才决定退避重试 / 停+引导 / 等条件续跑与用户指引。本模块把结构化失败
+// 信号（pnpm 退出码、stdout/stderr 尾、里程碑日志）归类为六类 errorClass，每类带
+// 一句面向用户的中文引导（guidance）。分类结果 = 退避重试调度器（T2）与 Bootstrap
+// 诊断页（T3/T4）的输入，落 g.deps.errorClass（见 install.js 失败路径接入）。
+//
+// 纯函数纪律：无 I/O、不读单例状态、不抛异常；input 非对象 / 字段缺省一律按空串
+// 兜底（exitCode 仅作上下文参考，不参与归类——这些失败路径退出码恒非零，本身无法
+// 区分故障类），内部不可能失败，最坏落 unknown（保守可重试 + 标记需诊断）。
+//
+// 特征表（与 spec.md「1. 错误分类器」逐行对应）：
+//   network            ENOTFOUND / EAI_AGAIN / ECONNRESET / ECONNREFUSED / ETIMEDOUT /
+//                      socket hang up / 下载连接超时（registry/CDN 不可达）
+//   macos-signature    codesign / code signature invalid（内置 Electron Node 执行 install
+//                      script 触发签名校验失败）
+//   native-toolchain   ELIFECYCLE（或 command failed）× koffi/node-pty/cnoke/node-gyp
+//   declaration        ERR_PNPM_*（404 / peer 冲突 / invalid spec / 版本不存在 / 声明非法）
+//   environment        EACCES / EPERM / EBUSY / ENOSPC（锁重试 / 权限与空间引导清理）
+//   unknown            兜底（保守可重试 + 标记需诊断）
+//
+// 匹配优先级（从具体到一般，防止错误引导）：
+//   ① network 最高——回归样本①「koffi ELIFECYCLE 且含网络特征时归 network」：install
+//      script 内嵌的网络下载失败根因是网络而非工具链；
+//   ② macos-signature——与 native 同是 ELIFECYCLE 场景，但签名问题指引「配置
+//      nodejsPath」而非装工具链，须先于 native 命中；
+//   ③ environment——OS 层具体错误（权限/空间/锁）优先于猜测性的工具链/声明问题
+//      （如 koffi 编译撞 EACCES 是权限问题，指引装工具链无意义）；
+//   ④ native-toolchain——ELIFECYCLE × 原生包名（「非网络段」由 ① 前置保证）；
+//   ⑤ declaration——ERR_PNPM_* / 404 / peer 冲突 / 非法 spec / 版本不存在；
+//   ⑥ unknown——兜底（含 ENOENT，理由见下）。
+//
+// ENOENT 归属说明（回归样本②③）：ENOENT（文件/目录不存在）不在特征表内，本模块落
+// unknown 而非 environment——environment 三特征是权限/空间/锁（用户可操作的本地状态），
+// 而样本②「升级后旧 .pnpm 路径 ENOENT 缓存残留」、样本③「dsh 树内部 require.resolve
+// 命中旧 .pnpm（typert 133 contributor ENOENT）」是进程内缓存指向已删 .pnpm 路径的
+// 残留（自愈靠清理缓存/重装，用户无操作面），归 unknown 走保守重试 + 诊断标记最贴切。
+//
+// 回归样本 → errorClass（tests/errclass.test.mjs 覆盖）：
+//   ① koffi ELIFECYCLE（install script 失败）       → native-toolchain（含网络特征 → network）
+//   ② 升级后旧 .pnpm 路径 ENOENT 缓存残留            → unknown
+//   ③ typert 133 contributor ENOENT                  → unknown
+//   ④ 网络断（registry 不可达）                       → network
+//
+// 注释风格保持宿主侧（中文/双引号/分号），与 lib 侧其它模块一致。
+
+// ---- 单类中文引导文案 ----
+// 要求（tasks.md T1）：每类一句面向用户的人话 + 必要操作步骤；network/declaration/
+// unknown 不做操作指引（自动重试或上报）。文案导出供 install.js 预判失败路径（声明
+// 非法提前返回等）直取复用，避免同文案散落两处。
+export const ERROR_CLASS_GUIDANCE = Object.freeze({
+  network:
+    "网络不可达（registry/CDN 连接失败）：插件会自动退避重试，网络恢复后自动继续，无需手动操作。",
+  "macos-signature":
+    "macOS 代码签名校验失败（内置 Electron Node 无法执行依赖安装脚本）：请在「设置 → DSHana 设置 → 自定义 NodeJS 路径」（nodejsPath 配置项）填入系统 Node 绝对路径（如 /opt/homebrew/bin/node），保存后插件会自动续跑。",
+  "native-toolchain":
+    "原生模块编译失败（install 脚本退出，多为 koffi / node-pty / cnoke 等）：请安装系统编译工具链——macOS 执行「xcode-select --install」安装 Command Line Tools，Windows 安装 Visual Studio Build Tools；完成后插件会自动重试。",
+  declaration:
+    "依赖声明解析失败（ERR_PNPM_*：包或版本不存在 / peer 冲突 / 非法 spec）：属插件声明或上游 registry 问题，请等待插件更新或将诊断详情上报插件作者，无需手动操作。",
+  environment:
+    "系统环境问题（文件占用 / 权限不足 / 磁盘空间不足）：插件会自动重试，权限与空间问题请按需清理后等待自动恢复。",
+  unknown:
+    "未能识别本次安装失败的原因：插件会保守自动重试并记录诊断日志，若持续失败请将诊断详情上报插件作者。",
+});
+
+// environment 细类引导（同 errorClass=environment，按具体原因给不同指引；spec：
+// EBUSY 锁 → 重试；空间/权限 → 引导清理）
+const ENVIRONMENT_GUIDANCE_EBUSY =
+  "安装目标文件被占用（EBUSY，多为杀软实时扫描或并发依赖操作锁定）：插件会自动重试，无需手动操作。";
+const ENVIRONMENT_GUIDANCE_ENOSPC =
+  "磁盘空间不足（ENOSPC）：请清理磁盘释放空间，插件会自动重试。";
+const ENVIRONMENT_GUIDANCE_PERM =
+  "文件或目录权限不足（EACCES/EPERM）：请以有写权限的用户运行，或将插件目录与数据目录加入杀软/安全软件白名单，插件会自动重试。";
+
+// ---- 特征正则表 ----
+// 全部非 /g 修饰（/g 的 lastIndex 会跨调用残留导致误判）；命中任一即算该类。
+// network：Node 网络错误码 + socket hang up + 引导下载/连接超时（中文形态）。
+const NETWORK_PATTERNS = [
+  /\bENOTFOUND\b/i,
+  /\bEAI_AGAIN\b/i,
+  /\bECONNRESET\b/i,
+  /\bECONNREFUSED\b/i,
+  /\bETIMEDOUT\b/i,
+  /socket\s*hang\s*up?/i,
+  /(?:下载|连接|请求)\s*超时/,
+];
+
+// macos-signature：codesign / code signature invalid（含中文「签名校验失败」形态）。
+const MACOS_SIGNATURE_PATTERNS = [
+  /\bcodesign\b/i,
+  /code\s+signature/i,
+  /signature\s+invalid/i,
+  /(?:代码)?签名(?:校验|检查|验证)?\s*(?:失败|错误|不通过)/,
+];
+
+// environment：EACCES / EPERM / EBUSY / ENOSPC（细类判定在 environmentKind 内按序）。
+const ENVIRONMENT_KIND_EBUSY = /\bEBUSY\b/i;
+const ENVIRONMENT_KIND_ENOSPC = /\bENOSPC\b/i;
+const ENVIRONMENT_KIND_PERM = /\b(?:EACCES|EPERM)\b/i;
+
+// native-toolchain 两半：生命周期脚本失败信号 × 原生模块名（两者都命中才算）。
+const LIFECYCLE_FAIL_PATTERNS = [/\bELIFECYCLE\b/i, /\bCommand\s+failed\b/i];
+const NATIVE_MODULE_PATTERNS = [
+  /\b(?:koffi|node-pty|cnoke)\b/i,
+  /node-gyp/i,
+  /gyp\s+ERR/i,
+];
+
+// declaration：pnpm 规范错误码（ERR_PNPM_*）+ 404 + peer 冲突 + invalid spec +
+// 版本不存在 + 「声明缺少/非法」中文形态（install.js 声明校验提前返回路径共用）。
+const DECLARATION_PATTERNS = [
+  /ERR_PNPM_[A-Z0-9_]+/i,
+  /\b404\b/,
+  /peer\s+(?:dependencies?|conflicts?|issues?)/i,
+  /no\s+matching\s+version/i,
+  /invalid\s+(?:spec|version|range|semver|package\s*name)/i,
+  /版本(?:不存在|未找到|找不到)|找不到\s*.*版本/,
+  /(?:插件)?声明(?:缺少|缺失|非法|不合法|无效)/,
+];
+
+// 任一正则命中（正则表都是非 /g 的简单匹配，test 无状态）
+function anyMatch(patterns, text) {
+  for (const re of patterns) if (re.test(text)) return true;
+  return false;
+}
+
+// 组装返回结构 { errorClass, guidance }
+function result(errorClass, guidance) {
+  return { errorClass, guidance };
+}
+
+// environment 细类（EBUSY → ENOSPC → 权限；均非空文本才判定，空输入走 unknown）
+function environmentKind(text) {
+  if (!text) return null;
+  if (ENVIRONMENT_KIND_EBUSY.test(text))
+    return result("environment", ENVIRONMENT_GUIDANCE_EBUSY);
+  if (ENVIRONMENT_KIND_ENOSPC.test(text))
+    return result("environment", ENVIRONMENT_GUIDANCE_ENOSPC);
+  if (ENVIRONMENT_KIND_PERM.test(text))
+    return result("environment", ENVIRONMENT_GUIDANCE_PERM);
+  return null;
+}
+
+// 分类入口：结构化信号 → { errorClass, guidance }（纯函数，永不抛，见模块头）
+export function classifyInstallError(input) {
+  // 容错：input 非对象 / 字段缺省按空串处理（不抛异常）
+  const s = input && typeof input === "object" ? input : {};
+  const text = [
+    typeof s.stderrTail === "string" ? s.stderrTail : "",
+    typeof s.stdoutTail === "string" ? s.stdoutTail : "",
+    typeof s.milestoneLog === "string" ? s.milestoneLog : "",
+  ]
+    .filter((x) => x !== "")
+    .join("\n");
+  if (anyMatch(NETWORK_PATTERNS, text))
+    return result("network", ERROR_CLASS_GUIDANCE.network);
+  if (anyMatch(MACOS_SIGNATURE_PATTERNS, text))
+    return result("macos-signature", ERROR_CLASS_GUIDANCE["macos-signature"]);
+  const env = environmentKind(text);
+  if (env) return env;
+  if (
+    anyMatch(LIFECYCLE_FAIL_PATTERNS, text) &&
+    anyMatch(NATIVE_MODULE_PATTERNS, text)
+  )
+    return result("native-toolchain", ERROR_CLASS_GUIDANCE["native-toolchain"]);
+  if (anyMatch(DECLARATION_PATTERNS, text))
+    return result("declaration", ERROR_CLASS_GUIDANCE.declaration);
+  return result("unknown", ERROR_CLASS_GUIDANCE.unknown);
+}

--- a/src/tools/lib/errclass.js
+++ b/src/tools/lib/errclass.js
@@ -34,6 +34,17 @@
 //   ⑤ declaration——ERR_PNPM_* / 404 / peer 冲突 / 非法 spec / 版本不存在；
 //   ⑥ unknown——兜底（含 ENOENT，理由见下）。
 //
+// 分层判定语义（CodeRabbit PR #50 修复）：决定性信号与上下文分离——
+//   stderrTail + stdoutTail 拼成 decisive 文本，按上方优先级完整判定一遍；decisive
+//   无任何命中时，才把 milestoneLog 并入（decisive + milestoneLog 拼全文）按同一
+//   优先级兜底再判定一遍（两层共用 classifyText）。理由：install.js run() 的结构化
+//   throw 保证 stderrTail/stdoutTail = 最后一次 registry 尝试（官方源 → npmmirror）
+//   的原始输出，决定性；若与 milestoneLog（历史上下文，可能含前次尝试特征）直接
+//   拼接，前次尝试的 ENOTFOUND 等会污染最终分类（决定性 declaration 被 network 抢
+//   判）。milestoneLog 只作兜底上下文——非 run() 的其它 throw 点（pnpm 引导失败等）
+//   只有 message 形态（经 install.js catch 落入 milestoneLog），decisive 为空时仍可
+//   命中特征；但它不覆盖决定性信号。
+//
 // ENOENT 归属说明（回归样本②③）：ENOENT（文件/目录不存在）不在特征表内，本模块落
 // unknown 而非 environment——environment 三特征是权限/空间/锁（用户可操作的本地状态），
 // 而样本②「升级后旧 .pnpm 路径 ENOENT 缓存残留」、样本③「dsh 树内部 require.resolve
@@ -145,17 +156,9 @@ function environmentKind(text) {
   return null;
 }
 
-// 分类入口：结构化信号 → { errorClass, guidance }（纯函数，永不抛，见模块头）
-export function classifyInstallError(input) {
-  // 容错：input 非对象 / 字段缺省按空串处理（不抛异常）
-  const s = input && typeof input === "object" ? input : {};
-  const text = [
-    typeof s.stderrTail === "string" ? s.stderrTail : "",
-    typeof s.stdoutTail === "string" ? s.stdoutTail : "",
-    typeof s.milestoneLog === "string" ? s.milestoneLog : "",
-  ]
-    .filter((x) => x !== "")
-    .join("\n");
+// 单层全文判定（决定性文本与兜底全文共用同一优先级顺序，见模块头「分层判定语义」）；
+// 命中返回 { errorClass, guidance }，未命中返回 null（由调用方决定兜底或 unknown）
+function classifyText(text) {
   if (anyMatch(NETWORK_PATTERNS, text))
     return result("network", ERROR_CLASS_GUIDANCE.network);
   if (anyMatch(MACOS_SIGNATURE_PATTERNS, text))
@@ -169,5 +172,29 @@ export function classifyInstallError(input) {
     return result("native-toolchain", ERROR_CLASS_GUIDANCE["native-toolchain"]);
   if (anyMatch(DECLARATION_PATTERNS, text))
     return result("declaration", ERROR_CLASS_GUIDANCE.declaration);
-  return result("unknown", ERROR_CLASS_GUIDANCE.unknown);
+  return null;
+}
+
+// 分类入口：结构化信号 → { errorClass, guidance }（纯函数，永不抛，见模块头）
+// 分层判定：① decisive（stderrTail + stdoutTail）按优先级完整跑一遍——最后一次失败
+// 尝试的输出决定分类；② decisive 无任何命中时 milestoneLog 并入兜底（decisive +
+// milestoneLog 拼全文，同优先级），不覆盖决定性信号；两层都未命中 → unknown。
+export function classifyInstallError(input) {
+  // 容错：input 非对象 / 字段缺省按空串处理（不抛异常）
+  const s = input && typeof input === "object" ? input : {};
+  const decisive = [
+    typeof s.stderrTail === "string" ? s.stderrTail : "",
+    typeof s.stdoutTail === "string" ? s.stdoutTail : "",
+  ]
+    .filter((x) => x !== "")
+    .join("\n");
+  const firstPass = classifyText(decisive);
+  if (firstPass) return firstPass;
+  // decisive 无命中 → milestoneLog 兜底并入（decisive 为空串时 full = milestoneLog 本身）
+  const milestoneText =
+    typeof s.milestoneLog === "string" ? s.milestoneLog : "";
+  const full = milestoneText
+    ? [decisive, milestoneText].filter((x) => x !== "").join("\n")
+    : decisive;
+  return classifyText(full) || result("unknown", ERROR_CLASS_GUIDANCE.unknown);
 }

--- a/src/tools/lib/install.js
+++ b/src/tools/lib/install.js
@@ -725,10 +725,15 @@ export async function installDepsFromPlugin(ctxConfig, ctxDataDir, opts = {}) {
     // T1 错误分类接入：失败路径对失败信号归类，产出 errorClass + guidance 存
     // g.deps.errorClass（{ errorClass, guidance } 对象，见 errclass.js 模块头；g.deps.error
     // 原样保留 = 可读错误文本，分类是它之上的结构化附加）。信号来源：
-    //   ① 本函数内部 throw 已附原始 stdout/stderr 尾 + 退出码（见上方 run() 结构化 throw）；
+    //   ① 本函数内部 throw 已附原始 stdout/stderr 尾 + 退出码（见上方 run() 结构化
+    //      throw）——决定性信号 = 最后一次 registry 尝试（官方源 → npmmirror）的输出，
+    //      分类器按「分层判定」先只看 tail（见 errclass.js 模块头）；
     //   ② 其它 throw 点（pnpm 引导失败等）只有 message——message 即含错误特征文本
-    //      （如 ENOTFOUND/ETIMEDOUT），并入 milestoneLog 一并喂分类器；
-    //   ③ g.deps.log 尾（里程碑 + pnpm 实时输出）作 milestoneLog 兜底上下文。
+    //      （如 ENOTFOUND/ETIMEDOUT），经 milestoneLog 喂分类器（tail 为空时的兜底层）。
+    // 注意：milestoneLog 只传本次失败的 e.message，不拼接 g.deps.log 全文——g.deps.log
+    // 是两次 registry 尝试的累积输出（官方源失败的 ENOTFOUND 等仍留在日志里），拼入会
+    // 让分类器误判成前次尝试的类（CodeRabbit PR #50：决定性 declaration 被残留 network
+    // 特征抢判）；message 与 tail 同属最后一次失败，特征一致无冲突。
     // 分类器纯函数永不抛，这里直接调用不需再包 try（分类失败不可能，最坏 unknown）。
     const errObj = e instanceof Error ? e : null;
     const classified = classifyInstallError({
@@ -738,10 +743,9 @@ export async function installDepsFromPlugin(ctxConfig, ctxDataDir, opts = {}) {
         errObj && typeof errObj.stdoutTail === "string" ? errObj.stdoutTail : "",
       stderrTail:
         errObj && typeof errObj.stderrTail === "string" ? errObj.stderrTail : "",
-      // e 非 Error（或 message 形态）时文本特征主要落在 message：并入 milestoneLog
-      // （分类器按文本特征归类，message 携带的错误码/错误文本与原始尾同效）
-      milestoneLog:
-        String(e?.message || e) + "\n" + String(g.deps.log || ""),
+      // e 非 Error（或 message 形态）时文本特征主要落在 message：经 milestoneLog 喂
+      // 分类器（message 携带的错误码/错误文本与同次 tail 特征一致，不冲突）
+      milestoneLog: String(e?.message || e),
     });
     g.deps.errorClass = classified;
     g.deps.error = String(e?.message || e).slice(0, 1500);

--- a/src/tools/lib/install.js
+++ b/src/tools/lib/install.js
@@ -40,6 +40,12 @@ import {
   buildPnpmInstallArgs,
   isValidPkgSpec,
 } from "./pnpm.js";
+// T1 错误分类器（spec：dsh-deps-zero-intervention）：install 失败路径对失败信号归类，
+// 产出 errorClass + guidance 存 g.deps.errorClass（纯函数，见 errclass.js 模块头）
+import {
+  classifyInstallError,
+  ERROR_CLASS_GUIDANCE,
+} from "./errclass.js";
 
 // ---- 依赖安装日志通道（统一）----
 // installDepsFromPlugin 内部 emitLog(s, src)：同一份文本同时进
@@ -429,6 +435,13 @@ export async function installDepsFromPlugin(ctxConfig, ctxDataDir, opts = {}) {
       "插件声明缺少合法 @deepseek-ai/dsh 版本（dependencies 未声明或非法）";
     g.deps.status = "error";
     g.deps.time = new Date().toISOString();
+    // T1：声明非法属 declaration（不可恢复 → 停 + 上报），与 catch 失败路径同一产出
+    // 形态（{ errorClass, guidance } 对象，见 errclass.js 模块头）——status=error 时
+    // errorClass 不落空，诊断展示/调度器可依赖。
+    g.deps.errorClass = {
+      errorClass: "declaration",
+      guidance: ERROR_CLASS_GUIDANCE.declaration,
+    };
     notifyDepsChanged();
     return {
       ok: false,
@@ -444,6 +457,9 @@ export async function installDepsFromPlugin(ctxConfig, ctxDataDir, opts = {}) {
   const nodeEnv = resolveNodeExecEnv({ dataDir, nodejsPath: cfg.nodejsPath });
   g.deps.status = "installing";
   g.deps.error = null;
+  // T1：新一次安装尝试清空上次失败的分类（errorClass 只反映最近一次 install 失败，
+  // 与 error 同生命周期；成功路径/新入口不残留旧分类误导诊断展示）
+  g.deps.errorClass = null;
   g.deps.time = new Date().toISOString();
   g.deps.log = "";
   notifyDepsChanged();
@@ -656,10 +672,24 @@ export async function installDepsFromPlugin(ctxConfig, ctxDataDir, opts = {}) {
           if (readable !== "") emitLog(readable + "\n", "pnpm");
         }
       }
-      if (r.code !== 0)
-        throw new Error(
-          "pnpm install 失败 " + DSH_PACKAGE + "（exit " + r.code + "）：" + pnpmErrorTail(buffers.out.tail, buffers.err.tail),
+      if (r.code !== 0) {
+        // T1：失败信号结构化——message 保持原可读文本形态（日志/诊断兼容），原始
+        // stdout/stderr 尾 + 退出码附在 Error 上随 throw 上行，外层 catch 组分类信号
+        // （classifyInstallError）时能拿到完整特征（pnpm 原始输出中的错误码/错误文本，
+        // 不止 pnpmErrorTail 裁过的 ≤300 字摘要）。
+        const installErr = new Error(
+          "pnpm install 失败 " +
+            DSH_PACKAGE +
+            "（exit " +
+            r.code +
+            "）：" +
+            pnpmErrorTail(buffers.out.tail, buffers.err.tail),
         );
+        installErr.exitCode = r.code;
+        installErr.stdoutTail = buffers.out.tail;
+        installErr.stderrTail = buffers.err.tail;
+        throw installErr;
+      }
       return buffers.out.tail; // 无消费者（run 返回值未使用）；保持 string 返回语义
     };
     try {
@@ -692,6 +722,28 @@ export async function installDepsFromPlugin(ctxConfig, ctxDataDir, opts = {}) {
     notifyDepsChanged();
     return { ok: true, state: "installed", cliBin };
   } catch (e) {
+    // T1 错误分类接入：失败路径对失败信号归类，产出 errorClass + guidance 存
+    // g.deps.errorClass（{ errorClass, guidance } 对象，见 errclass.js 模块头；g.deps.error
+    // 原样保留 = 可读错误文本，分类是它之上的结构化附加）。信号来源：
+    //   ① 本函数内部 throw 已附原始 stdout/stderr 尾 + 退出码（见上方 run() 结构化 throw）；
+    //   ② 其它 throw 点（pnpm 引导失败等）只有 message——message 即含错误特征文本
+    //      （如 ENOTFOUND/ETIMEDOUT），并入 milestoneLog 一并喂分类器；
+    //   ③ g.deps.log 尾（里程碑 + pnpm 实时输出）作 milestoneLog 兜底上下文。
+    // 分类器纯函数永不抛，这里直接调用不需再包 try（分类失败不可能，最坏 unknown）。
+    const errObj = e instanceof Error ? e : null;
+    const classified = classifyInstallError({
+      exitCode:
+        errObj && typeof errObj.exitCode === "number" ? errObj.exitCode : null,
+      stdoutTail:
+        errObj && typeof errObj.stdoutTail === "string" ? errObj.stdoutTail : "",
+      stderrTail:
+        errObj && typeof errObj.stderrTail === "string" ? errObj.stderrTail : "",
+      // e 非 Error（或 message 形态）时文本特征主要落在 message：并入 milestoneLog
+      // （分类器按文本特征归类，message 携带的错误码/错误文本与原始尾同效）
+      milestoneLog:
+        String(e?.message || e) + "\n" + String(g.deps.log || ""),
+    });
+    g.deps.errorClass = classified;
     g.deps.error = String(e?.message || e).slice(0, 1500);
     g.deps.status = "error";
     notifyDepsChanged();

--- a/src/tools/lib/state.js
+++ b/src/tools/lib/state.js
@@ -170,6 +170,10 @@ export function getSingleton() {
   if (g.deps.status === undefined) g.deps.status = "idle";
   if (g.deps.result === undefined) g.deps.result = null;
   if (g.deps.error === undefined) g.deps.error = null;
+  // T1 错误分类（spec：dsh-deps-zero-intervention）：install 失败后存 { errorClass,
+  // guidance } 对象（见 lib/errclass.js 模块头）；默认 null = 无失败分类（成功/从未
+  // 失败/新一次安装尝试中）。热更新兼容：旧 globalThis 对象缺该字段时兜底。
+  if (g.deps.errorClass === undefined) g.deps.errorClass = null;
   if (g.deps.time === undefined) g.deps.time = null;
   if (g.deps.log === undefined) g.deps.log = "";
   // 共享依赖操作互斥（vX）：tools/dsh-install.js 的 install/update 动作共用——任一

--- a/tests/errclass.test.mjs
+++ b/tests/errclass.test.mjs
@@ -110,6 +110,46 @@ test("network：特征信号落在 stdoutTail / milestoneLog 也能命中（字�
   assert.equal(viaMilestone.errorClass, "network");
 });
 
+test("分层判定：决定性 tail 决定分类，milestoneLog 历史特征不覆盖（CodeRabbit PR #50）", () => {
+  // 回归 CodeRabbit PR #50：官方源先 ENOTFOUND（network）→ npmmirror 最终
+  // ERR_PNPM_NO_MATCHING_VERSION（declaration）。决定性 tail = 最后一次尝试输出 →
+  // 必须归 declaration；milestoneLog 携带的历史 network 特征（模拟旧实现拼 g.deps.log
+  // 全文的跨尝试污染）不得抢先覆盖（network 优先级最高，旧实现会误判 network）。
+  const decisiveDecl = classifyInstallError({
+    exitCode: 1,
+    stderrTail:
+      "[pnpm] 错误：ERR_PNPM_NO_MATCHING_VERSION No matching version found for @deepseek-ai/dsh@0.1.2-alpha.9",
+    stdoutTail: "",
+    milestoneLog:
+      "[官方源失败] pnpm install 失败 … getaddrinfo ENOTFOUND registry.npmjs.org，重试 npmmirror…（前次尝试残留，不应参与最终分类）",
+  });
+  assert.equal(decisiveDecl.errorClass, "declaration");
+  assert.equal(decisiveDecl.guidance, ERROR_CLASS_GUIDANCE.declaration);
+  // 反向对照：决定性 tail 是 network、milestoneLog 残留 declaration → 仍归 network
+  const decisiveNet = classifyInstallError({
+    exitCode: 1,
+    stderrTail:
+      "pnpm install 失败 @deepseek-ai/dsh（exit 1）：getaddrinfo ENOTFOUND registry.npmjs.org",
+    stdoutTail: "",
+    milestoneLog:
+      "ERR_PNPM_NO_MATCHING_VERSION 残留（历史尝试，不应参与分类）",
+  });
+  assert.equal(decisiveNet.errorClass, "network");
+});
+
+test("分层兜底：决定性无命中时 milestoneLog 并入仍可命中（milestoneLog 兜底语义不破坏）", () => {
+  // 非 run() 的其它 throw 点（pnpm 引导失败等）只有 message → 决定性 tail 为空、
+  // message 经 milestoneLog 传入：兜底层必须仍能归出类（既有 milestone-only 用例语义）
+  const r = classifyInstallError({
+    exitCode: 1,
+    stdoutTail: "",
+    stderrTail: "",
+    milestoneLog:
+      "pnpm 引导失败（pnpm.mjs）：下载超时（60000ms）：https://unpkg.com/pnpm@11.24.0/dist/pnpm.mjs",
+  });
+  assert.equal(r.errorClass, "network");
+});
+
 test("macos-signature：codesign / code signature invalid → 引导配置 nodejsPath", () => {
   const samples = [
     [

--- a/tests/errclass.test.mjs
+++ b/tests/errclass.test.mjs
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2026 Nyasers
+//
+// tests/errclass.test.mjs — T1 错误分类器单测（spec：dsh-deps-zero-intervention）
+// 零依赖测试：Node 内置 node:test + node:assert（无新 devDeps，无 test script——
+// 验收命令 node --test tests/ 由测试运行器按 tests/**/*.test.mjs 发现本文件）。
+// 覆盖：六类 errorClass 特征 + unknown 兜底 + 字段缺省容错 + 回归样本（spec「未决」：
+// koffi ELIFECYCLE / ENOENT 缓存残留 / typert 133 / 网络断）作特征用例。
+//
+// 分类器契约（与 errclass.js 模块头一致）：classifyInstallError(input) 纯函数永不抛，
+// 返回 { errorClass, guidance }，两字段恒为字符串；input 非对象/字段缺省按空串兜底。
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  classifyInstallError,
+  ERROR_CLASS_GUIDANCE,
+} from "../src/tools/lib/errclass.js";
+
+// 便捷构造：字段缺省时补全为常见失败形态（exit 1），单测只覆盖关心的字段
+function sig(overrides) {
+  return {
+    exitCode: 1,
+    stdoutTail: "",
+    stderrTail: "",
+    milestoneLog: "",
+    ...overrides,
+  };
+}
+
+// 回归样本① koffi ELIFECYCLE（install script 失败，无网络/签名/环境特征）
+const KOFFI_ELIFECYCLE_TEXT = [
+  "> koffi@2.9.1 install",
+  "> node scripts/build.js",
+  "",
+  "ELIFECYCLE koffi@2.9.1 install: node scripts/build.js (via node)",
+  "",
+].join("\n");
+
+// 回归样本② 升级后旧 .pnpm 路径 ENOENT 缓存残留（boot/加载读已删路径）
+const STALE_PNPM_ENOENT_TEXT = [
+  "[错误] 读旧 .pnpm 路径失败：Error: ENOENT: no such file or directory, open",
+  "'C:\\...\\node_modules\\.pnpm\\@deepseek-ai+dsh@0.1.2-alpha.4\\node_modules\\",
+  "@deepseek-ai\\dsh\\lib\\entry.js'（升级后旧路径残留）",
+].join(" ");
+
+// 回归样本③ typert 133 contributor ENOENT（dsh 树内部 require.resolve 命中旧 .pnpm）
+const TYPERT_133_ENOENT_TEXT = [
+  "Error: Cannot find module",
+  "'C:\\...\\node_modules\\.pnpm\\typert@133.0.0\\node_modules\\typert\\",
+  "dist\\contributors.json'（require.resolve 命中旧 .pnpm 缓存路径）",
+  "code: 'MODULE_NOT_FOUND', cause: { errno: -2, code: 'ENOENT' }",
+].join(" ");
+
+// 回归样本④ 网络断（registry 不可达）
+const REGISTRY_DOWN_TEXT =
+  "pnpm install 失败 @deepseek-ai/dsh（exit 1）：[pnpm] 错误：getaddrinfo ENOTFOUND registry.npmjs.org";
+
+test("返回值结构：errorClass 与 guidance 恒为字符串", () => {
+  const cases = [
+    sig({ stderrTail: REGISTRY_DOWN_TEXT }),
+    sig({ stderrTail: KOFFI_ELIFECYCLE_TEXT }),
+    sig(),
+    null,
+    undefined,
+    42,
+    "字符串非法输入",
+  ];
+  for (const input of cases) {
+    const r = classifyInstallError(input);
+    assert.equal(typeof r, "object", "返回必须是对象");
+    assert.equal(typeof r.errorClass, "string", "errorClass 恒为字符串");
+    assert.equal(typeof r.guidance, "string", "guidance 恒为字符串");
+    assert.ok(r.guidance.length > 0, "guidance 非空");
+  }
+});
+
+test("network：ENOTFOUND / ETIMEDOUT / ECONNRESET / ECONNREFUSED / socket hang up / 超时", () => {
+  const samples = [
+    // 回归样本④ 网络断（registry 不可达）：官方源失败重试 npmmirror 仍断网
+    REGISTRY_DOWN_TEXT,
+    "ETIMEDOUT 请求 https://registry.npmmirror.com/@deepseek-ai/dsh 超时",
+    "fetch failed: request to https://registry.npmjs.org/... failed, reason: connect ECONNREFUSED 10.0.0.1:443",
+    "Error: read ECONNRESET",
+    "socket hang up 下载 @deepseek-ai/cordis tarball 中断",
+    "pnpm 引导下载超时（60000ms）：https://unpkg.com/pnpm@11.24.0/dist/pnpm.mjs",
+  ];
+  for (const t of samples) {
+    const r = classifyInstallError(sig({ stderrTail: t }));
+    assert.equal(r.errorClass, "network", "应为 network：" + t.slice(0, 60));
+  }
+});
+
+test("network 优先于 native-toolchain：koffi ELIFECYCLE 含网络特征归 network（回归样本①）", () => {
+  const text =
+    KOFFI_ELIFECYCLE_TEXT +
+    "\n> node scripts/build.js\nError: getaddrinfo ENOTFOUND registry.npmjs.org\n";
+  const r = classifyInstallError(sig({ stderrTail: text }));
+  assert.equal(r.errorClass, "network");
+});
+
+test("network：特征信号落在 stdoutTail / milestoneLog 也能命中（字段容缺）", () => {
+  const viaStdout = classifyInstallError(
+    sig({ stderrTail: "无特征", stdoutTail: "connect ECONNREFUSED 127.0.0.1:443" }),
+  );
+  assert.equal(viaStdout.errorClass, "network");
+  const viaMilestone = classifyInstallError(
+    sig({ milestoneLog: "[官方源失败] … 重试 npmmirror… 下载超时（60000ms）" }),
+  );
+  assert.equal(viaMilestone.errorClass, "network");
+});
+
+test("macos-signature：codesign / code signature invalid → 引导配置 nodejsPath", () => {
+  const samples = [
+    [
+      "> koffi@2.9.1 install",
+      "> node scripts/build.js",
+      "Error: The binary ... is not a valid code signature (Electron node)",
+      "ELIFECYCLE ...",
+    ].join("\n"),
+    "codesign --verify 失败：code object is not signed at all（electron node 执行 install script）",
+    "Error: 签名校验失败：Electron 内置 node 无法作为系统 node 执行",
+  ];
+  for (const t of samples) {
+    const r = classifyInstallError(sig({ stderrTail: t }));
+    assert.equal(r.errorClass, "macos-signature", "应为 macos-signature：" + t.slice(0, 50));
+    // 必须指向「设置 → DSHana 设置 → 自定义 NodeJS 路径」（nodejsPath 配置项）
+    assert.match(r.guidance, /自定义 NodeJS 路径/);
+    assert.match(r.guidance, /nodejsPath/);
+  }
+});
+
+test("native-toolchain：koffi / node-pty / node-gyp ELIFECYCLE（非网络段）", () => {
+  const samples = [
+    // 回归样本① koffi ELIFECYCLE（install script 失败，无网络/签名特征）
+    KOFFI_ELIFECYCLE_TEXT,
+    [
+      "node-pty@1.0.0 install: node scripts/install.js",
+      "Command failed with exit code 1",
+      "ELIFECYCLE ...",
+    ].join("\n"),
+    "gyp ERR! node-gyp rebuild 失败：缺少编译器\nELIFECYCLE cnoke@2.0.0 install",
+    "node-gyp configure 失败（ELIFECYCLE）",
+  ];
+  for (const t of samples) {
+    const r = classifyInstallError(sig({ stderrTail: t }));
+    assert.equal(r.errorClass, "native-toolchain", "应为 native-toolchain：" + t.slice(0, 50));
+    assert.match(r.guidance, /编译工具链/);
+  }
+});
+
+test("native-toolchain：特征信号落在 milestoneLog 也能命中", () => {
+  const r = classifyInstallError(
+    sig({
+      milestoneLog: "[依赖安装] pnpm:lifecycle exit=1\nELIFECYCLE koffi@2.9.1 install: node scripts/build.js",
+    }),
+  );
+  assert.equal(r.errorClass, "native-toolchain");
+});
+
+test("declaration：ERR_PNPM_* 404 / peer 冲突 / invalid spec / 版本不存在 / 声明非法", () => {
+  const samples = [
+    "[pnpm] 错误：ERR_PNPM_FETCH_404 GET https://registry.npmjs.org/@deepseek-ai/dsh - 404 Not Found",
+    "[pnpm] 错误：ERR_PNPM_PEER_DEP_ISSUES … Peer dependencies that are not met: @deepseek-ai/cordis@4.0.2",
+    "ERR_PNPM_NO_MATCHING_VERSION No matching version found for @deepseek-ai/dsh@^0.1.3",
+    "[pnpm] 错误：Invalid spec: \"@deepseek-ai/dsh@npm:evil@1.0.0\" is not a valid dependency",
+    "[pnpm] 错误：找不到 @deepseek-ai/dsh@0.1.2-alpha.9 版本（registry 无此版本）",
+    "插件声明缺少合法 @deepseek-ai/dsh 版本（dependencies 未声明或非法）",
+  ];
+  for (const t of samples) {
+    const r = classifyInstallError(sig({ stderrTail: t }));
+    assert.equal(r.errorClass, "declaration", "应为 declaration：" + t.slice(0, 50));
+    assert.match(r.guidance, /上报|插件声明|上游/);
+  }
+});
+
+test("environment：EBUSY 锁 → 自动重试引导（无操作指引）；ENOSPC/EACCES/EPERM → 引导清理", () => {
+  const busy = classifyInstallError(
+    sig({ stderrTail: "EBUSY: resource busy or locked, rmdir '...node_modules\\.pnpm'" }),
+  );
+  assert.equal(busy.errorClass, "environment");
+  assert.match(busy.guidance, /自动重试/);
+  assert.doesNotMatch(busy.guidance, /清理磁盘/); // EBUSY 是锁，非空间
+
+  const noSpace = classifyInstallError(
+    sig({ stderrTail: "ENOSPC: no space left on device, write '...node_modules...'" }),
+  );
+  assert.equal(noSpace.errorClass, "environment");
+  assert.match(noSpace.guidance, /清理磁盘/);
+
+  const permDenied = classifyInstallError(
+    sig({ stderrTail: "EACCES: permission denied, mkdir 'C:\\...\\node_modules'" }),
+  );
+  assert.equal(permDenied.errorClass, "environment");
+  assert.match(permDenied.guidance, /权限/);
+
+  const eperm = classifyInstallError(
+    sig({ stderrTail: "EPERM: operation not permitted, unlink '...node.cmd'" }),
+  );
+  assert.equal(eperm.errorClass, "environment");
+});
+
+test("unknown 兜底：ENOENT 缓存残留 / 无特征文本 / 仅退出码", () => {
+  // 回归样本②③：ENOENT（文件/目录不存在）不在特征表内——非 environment 的权限/空间/
+  // 锁三特征（旧 .pnpm 路径残留是缓存/中断遗留，用户无操作面），落 unknown 保守重试 +
+  // 标记需诊断（理由见 errclass.js 模块头 ENOENT 归属说明）
+  for (const t of [STALE_PNPM_ENOENT_TEXT, TYPERT_133_ENOENT_TEXT]) {
+    const r = classifyInstallError(sig({ stderrTail: t }));
+    assert.equal(r.errorClass, "unknown", "ENOENT 缓存残留应归 unknown：" + t.slice(0, 50));
+  }
+  // ELIFECYCLE 但无原生包名（非 native 模块的脚本失败）：无特征 → unknown
+  const lifecycleOnly = classifyInstallError(
+    sig({ stderrTail: "ELIFECYCLE some-pure-js-pkg@1.0.0 install: node scripts/x.js" }),
+  );
+  assert.equal(lifecycleOnly.errorClass, "unknown");
+  // 完全无特征文本
+  const gibberish = classifyInstallError(
+    sig({ stderrTail: "frobnicate widget 崩溃（0xDEADBEEF）" }),
+  );
+  assert.equal(gibberish.errorClass, "unknown");
+});
+
+test("容错：input 缺字段 / 非对象 / 空信号 → unknown 不抛异常", () => {
+  const cases = [
+    undefined, // 无参数
+    null,
+    {},
+    { exitCode: 1 }, // 只有退出码（文本全空，退出码不参与归类）
+    { exitCode: 1, stderrTail: "", stdoutTail: undefined, milestoneLog: null },
+    42,
+    "ENOTFOUND registry.npmjs.org", // 非对象输入整体按空串兜底（结构化信号约定）
+    [],
+  ];
+  for (const input of cases) {
+    const r = classifyInstallError(input);
+    assert.equal(r.errorClass, "unknown");
+    assert.equal(r.guidance, ERROR_CLASS_GUIDANCE.unknown);
+  }
+});
+
+test("大小写与换行形态：特征文本大小写不敏感、跨 CRLF/多行可命中", () => {
+  // install.js pnpmErrorTail 产出的文本经行规范化后为 \n 分隔；真实错误码恒大写，
+  // 但外部工具链输出可能小写——分类器统一 /i 匹配
+  const mixed = classifyInstallError(
+    sig({
+      stderrTail:
+        "> koffi@2.9.1 install\r\n> node scripts/build.js\r\nelifecycle: command failed\r\n",
+    }),
+  );
+  assert.equal(mixed.errorClass, "native-toolchain");
+  const lowerNetwork = classifyInstallError(
+    sig({ stderrTail: "getaddrinfo enotfound registry.npmjs.org" }),
+  );
+  assert.equal(lowerNetwork.errorClass, "network");
+});


### PR DESCRIPTION
关联 spec：[dsh-deps-zero-intervention](specs/current/dsh-deps-zero-intervention/spec.md) T1（tasks.md 拆解），零干预自动链的前置：错误分类器把 install/boot 失败从「只看 exit 1」升级为可引导的 errorClass + guidance。

## 改动

- **新增 `src/tools/lib/errclass.js`**：纯函数 `classifyInstallError({ exitCode, stderrTail, stdoutTail, milestoneLog }) → { errorClass, guidance }`。六类特征表与 spec 逐行对应：network / macos-signature / native-toolchain / declaration / environment（EBUSY/ENOSPC/权限细类分句）/ unknown。匹配优先级从具体到一般（network > macos-signature > environment > native-toolchain > declaration > unknown），注释写明理由。ENOENT（回归样本②③）落 unknown 并给出归属论证：非 environment 的权限/空间/锁特征，属缓存残留、用户无操作面，走保守重试 + 诊断标记。
- **`src/tools/lib/install.js`** 失败路径接入：
  - `run()` pnpm 失败改为结构化 throw（message 保持原可读文本，原始 stdout/stderr 尾 + 退出码附在 Error 上）
  - 外层 catch 组信号喂分类器，产出存 `g.deps.errorClass`（`g.deps.error` 原文保留）
  - 声明非法提前返回分支同步产出 declaration 分类
  - 新一次安装尝试起点清空旧分类（与 error 同生命周期）
- **`src/tools/lib/state.js`**：`g.deps` 兜底初始化补 `errorClass` 默认 `null`（热更新兼容）
- **新增 `tests/errclass.test.mjs`**：Node 内置 node:test（零新依赖），12 用例

## 验证记录

- `node --test tests/` → 12 tests, 12 pass, 0 fail（Node v26.8.1）
- 回归样本覆盖：① koffi ELIFECYCLE（含网络特征 → network；非网络段 → native-toolchain）② 旧 .pnpm ENOENT 缓存残留 → unknown ③ typert 133 contributor ENOENT → unknown ④ registry 不可达 → network
- 容错：input 缺字段 / 非对象 / 空信号 → unknown 不抛；大小写与 CRLF/多行形态可命中
- 四个改动文件 `node --check` 通过；working tree clean

T1 范围外未动：不涉及 T2 状态机/退避重试、不退役任何人工入口、无 bump/build。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer dependency-installation error classification for network, macOS signing, native toolchain, declaration, environment, and unknown failures.
  - Added tailored guidance for each error type, including recommendations for busy files, insufficient disk space, and permission issues.
  - Installation failures now retain relevant diagnostic details to improve troubleshooting.
  - Dependency state now records the applicable installation error classification.

- **Bug Fixes**
  - Improved handling of malformed, incomplete, and previously misclassified installation errors.
  - Classification now prioritizes diagnostics from the final failed registry attempt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->