### PR TITLE
fix: boot 失败提示识别跨 dsh 版本升级需重启

### DIFF
--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -1386,8 +1386,10 @@ function buildProcessDiagCheck(g, out) {
     check.fix = "点击本卡片「手动启动 web host」按钮重新拉起，或重启 Hana";
   } else {
     // 启动失败（webLastError）：展示失败原因（其已含 stderr 尾部）+ 修复指引。
-    // depsVerified 传入 pickProcessFix：升级缓存残留判定需依赖运行级验证通过为前提
-    // （CodeRabbit：安装不完整也报 ENOENT，只提示重启会留下坏安装；见函数内注释）
+    // depsVerified 传入 pickProcessFix：升级缓存残留判定需依赖「当前已装 + 运行级验证
+    // 通过」为前提——取本次诊断 deps 项的 verified（= installed && smoke.ok，见
+    // buildDepsDiagCheck），而非 g.deps.result.ok 裸缓存（缓存不证明 cliBin 当前仍在，
+    // 包被移除/路径变化后仍可能误判升级残留；CodeRabbit PR #51）
     check.detail = lastError
       ? "启动失败：" + lastError
       : "进程已退出（code=" +
@@ -1398,7 +1400,7 @@ function buildProcessDiagCheck(g, out) {
       lastError,
       stderr,
       port,
-      g.deps?.result?.ok === true,
+      out.checks.find((c) => c.key === "deps")?.verified === true,
     );
   }
   return check;

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -1385,36 +1385,48 @@ function buildProcessDiagCheck(g, out) {
       (lastExit.stderr ? "\n[stderr 尾部] " + lastExit.stderr : "");
     check.fix = "点击本卡片「手动启动 web host」按钮重新拉起，或重启 Hana";
   } else {
-    // 启动失败（webLastError）：展示失败原因（其已含 stderr 尾部）+ 修复指引
+    // 启动失败（webLastError）：展示失败原因（其已含 stderr 尾部）+ 修复指引。
+    // depsVerified 传入 pickProcessFix：升级缓存残留判定需依赖运行级验证通过为前提
+    // （CodeRabbit：安装不完整也报 ENOENT，只提示重启会留下坏安装；见函数内注释）
     check.detail = lastError
       ? "启动失败：" + lastError
       : "进程已退出（code=" +
         (exitCode ?? "?") +
         "）" +
         (stderr ? "\n[stderr 尾部] " + stderr : "");
-    check.fix = pickProcessFix(lastError, stderr, port);
+    check.fix = pickProcessFix(
+      lastError,
+      stderr,
+      port,
+      g.deps?.result?.ok === true,
+    );
   }
   return check;
 }
 
 /** 进程失败修复指引：按失败原因内容匹配（依赖 / 升级缓存残留 / 端口占用），兜底通用建议。
  * 同时匹配 webLastError 与 stderr 尾部——端口占用等错误常只出现在 stderr（进程退出时
- * webLastError 可能未携带 stderr 尾部，见「进程已退出」分支）。 */
-function pickProcessFix(lastError, stderr, port) {
+ * webLastError 可能未携带 stderr 尾部，见「进程已退出」分支）。
+ * depsVerified：依赖运行级验证是否通过（调用方从 g.deps.result.ok 取）——升级缓存残留
+ * 判定以此为门控，见下方注释。 */
+function pickProcessFix(lastError, stderr, port, depsVerified) {
   const text = (lastError || "") + "\n" + (stderr || "");
   // 跨 dsh 版本升级缓存残留（spec「升级 dsh = 装新插件包 + 重启宿主」既定流程，无豁免层）：
   // 宿主进程内 ESM import 缓存 key 跨版本稳定，热加载新插件后仍命中旧 dsh 模块，boot 读
-  // 已删旧 .pnpm 路径 ENOENT。特征 = 错误含 ENOENT/no such file/Cannot find 且路径指向
-  // .pnpm/@deepseek-ai+dsh@（真实样本 2026-09-02：alpha.10 热加载 boot ENOENT 旧 .pnpm 目录）。
-  // 重启即愈——提示说人话，不给「检查依赖项/重装」误导（依赖其实已就绪）。
+  // 已删旧 .pnpm 路径 ENOENT。特征 = 依赖已验证就绪（depsVerified）+ 错误含 ENOENT/no
+  // such file/Cannot find + 路径指向 .pnpm/@deepseek-ai+dsh@（真实样本 2026-09-02：alpha.10
+  // 热加载 boot ENOENT 旧 .pnpm 目录）。depsVerified 门控必须：安装不完整/依赖图缺失同样
+  // 报 ENOENT + .pnpm 路径，那种情况重启不愈（磁盘仍坏），只给重启提示会误导——验证不
+  // 过时落下方依赖分支（自动补齐）。
   if (
+    depsVerified === true &&
     /(?:ENOENT|no such file|cannot find)/i.test(text) &&
     /\.pnpm[\\/]@deepseek-ai\+dsh@/i.test(text)
   ) {
     return "检测到 dsh 已跨版本升级，当前 Hana 进程仍持有升级前的旧模块缓存：请重启 Hana 加载新版本（dsh 升级后需重启为既定流程，无需其它操作）";
   }
   if (/dsh 包未就绪|DSH 包未就绪|cliBin|npm i/i.test(text)) {
-    return "按上方「DSH 依赖安装」项修复（依赖自动按插件声明安装并验证，完成后自动重试启动 web host）";
+    return "依赖未就绪：自动安装链会按插件声明补齐并运行级验证，完成后自动重试启动 web host；若持续失败请查看上方依赖诊断详情";
   }
   if (/EADDRINUSE|address already in use|占用|bind/i.test(text)) {
     return "检查端口 " + port + " 是否被占用（释放后重启 Hana）";

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -475,8 +475,9 @@ export function ensureDshanaProfile(cfg) {
 // 诊断与工具包不 import cordis/pnpm，见 lib/install.js / lib/pnpm.js）。
 
 // ---- T7b 进程内 boot：dsh 模块动态定位（解耦 D6）----
-// dsh 包不在插件 node_modules（数据目录 dsh-pkg），且 profile-boot-*.js 是带构建
-// hash 的产物名（bin.js 按 hash 动态 import）——不能硬编码文件名，枚举 lib 目录试出
+// dsh 包位置 = 插件 node_modules（vY T7d：dsh-pkg 独立安装区已退役，依赖收进插件
+// node_modules，resolveDshPkgDir 唯一形态）；profile-boot-*.js 是带构建 hash 的
+// 产物名（bin.js 按 hash 动态 import）——不能硬编码文件名，枚举 lib 目录试出
 // 导出 runProfile 的候选（probe-inproc 验证过的定位方式）。
 // app-boot 经 createRequire 从 dsh 包视角解析：pnpm 严格结构下 @deepseek-ai/dsh-app-boot
 // 是 dsh 的间接依赖，不在顶层 node_modules——createRequire 沿 dsh 包的 .pnpm 依赖链
@@ -492,7 +493,7 @@ async function loadInprocDsh(pkgDir) {
   const libDir = join(dshPkg, "lib");
   if (!existsSync(join(dshPkg, "package.json"))) {
     throw new Error(
-      `DSH 包未就绪：${dshPkg} 不存在。请在 DSHana 标签页执行「安装依赖」（pnpm install 按声明拉取到 dsh-pkg），或手动在插件数据目录 dsh-pkg 执行 pnpm install`,
+      `DSH 包未就绪：${dshPkg} 不存在。依赖自动安装链会按插件声明补齐并自动重试，无需手动操作；若持续未就绪请查看上方依赖诊断（自动安装失败原因与重试状态）`,
     );
   }
   // ① profile-boot：枚举 lib 下 profile-boot-*.js，逐个 import 试 runProfile
@@ -1266,7 +1267,7 @@ function buildDepsDiagCheck(g, cfg) {
   if (installing) {
     // 安装中（含重装场景 installed 仍可能为 true）优先——实时进度
     // installLog 尾部由前端 .diag-progress 展示（随轮询刷新）
-    check.detail = "正在安装依赖…（npm i，进度见下方）";
+    check.detail = "正在安装依赖…（进度见下方）";
     check.fix = "";
   } else if (!installed) {
     // 未安装：保持现有文案
@@ -1277,7 +1278,7 @@ function buildDepsDiagCheck(g, cfg) {
       (checked.length > 1 ? "（已检查 " + checked.join("、") + "）" : "");
     if (installError) check.detail += "\n[上次安装失败] " + installError;
     check.fix =
-      "依赖缺失：点击本卡片「安装依赖」按钮自动在插件数据目录 dsh-pkg 执行 pnpm install（按声明拉取，完成后自动验证）；或确认插件目录 node_modules 解压完整";
+      "依赖缺失：点击本卡片「安装依赖」按钮自动按插件声明安装依赖（完成后自动运行级验证）；或确认插件目录 node_modules 解压完整";
   } else if (!smoke) {
     // 未检测过（进标签页自动检测一次 / 手动「检测依赖」；ok 暂算 installed）
     check.detail = "DSH 包已就绪，点击「检测依赖」验证依赖完整性";
@@ -1290,7 +1291,7 @@ function buildDepsDiagCheck(g, cfg) {
       "DSH 包存在但依赖不完整：" +
       (verifyError ? "\n" + verifyError : "运行级验证失败");
     check.fix =
-      "点击本卡片「重新安装依赖」按钮重新执行 pnpm install（按声明拉取，自动部署到 dsh-pkg，完成后自动验证）";
+      "点击本卡片「重新安装依赖」按钮重新按插件声明安装（完成后自动运行级验证）";
   } else {
     // 存在 + 验证通过：能跑 = 依赖图完整
     check.detail =

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -1396,13 +1396,24 @@ function buildProcessDiagCheck(g, out) {
   return check;
 }
 
-/** 进程失败修复指引：按失败原因内容匹配（依赖 / 端口占用），兜底通用建议。
+/** 进程失败修复指引：按失败原因内容匹配（依赖 / 升级缓存残留 / 端口占用），兜底通用建议。
  * 同时匹配 webLastError 与 stderr 尾部——端口占用等错误常只出现在 stderr（进程退出时
  * webLastError 可能未携带 stderr 尾部，见「进程已退出」分支）。 */
 function pickProcessFix(lastError, stderr, port) {
   const text = (lastError || "") + "\n" + (stderr || "");
+  // 跨 dsh 版本升级缓存残留（spec「升级 dsh = 装新插件包 + 重启宿主」既定流程，无豁免层）：
+  // 宿主进程内 ESM import 缓存 key 跨版本稳定，热加载新插件后仍命中旧 dsh 模块，boot 读
+  // 已删旧 .pnpm 路径 ENOENT。特征 = 错误含 ENOENT/no such file/Cannot find 且路径指向
+  // .pnpm/@deepseek-ai+dsh@（真实样本 2026-09-02：alpha.10 热加载 boot ENOENT 旧 .pnpm 目录）。
+  // 重启即愈——提示说人话，不给「检查依赖项/重装」误导（依赖其实已就绪）。
+  if (
+    /(?:ENOENT|no such file|cannot find)/i.test(text) &&
+    /\.pnpm[\\/]@deepseek-ai\+dsh@/i.test(text)
+  ) {
+    return "检测到 dsh 已跨版本升级，当前 Hana 进程仍持有升级前的旧模块缓存：请重启 Hana 加载新版本（dsh 升级后需重启为既定流程，无需其它操作）";
+  }
   if (/dsh 包未就绪|DSH 包未就绪|cliBin|npm i/i.test(text)) {
-    return "按上方「DSH 依赖安装」项修复（数据目录 dsh-pkg 执行 pnpm install，按声明拉取，完成后自动验证）";
+    return "按上方「DSH 依赖安装」项修复（依赖自动按插件声明安装并验证，完成后自动重试启动 web host）";
   }
   if (/EADDRINUSE|address already in use|占用|bind/i.test(text)) {
     return "检查端口 " + port + " 是否被占用（释放后重启 Hana）";


### PR DESCRIPTION
实装 alpha.10 时发现的诊断体验问题：跨 dsh 版本升级后热加载（宿主未重启），进程内 ESM import 缓存命中旧 dsh 模块，boot 读已删旧 `.pnpm` 路径 ENOENT——这正是 spec「升级 dsh = 装新插件包 + 重启宿主」既定流程（无豁免层），但 UI 只给兜底文案「检查上方依赖项；仍失败请重启 Hana 后重试」，没说人话。

## 真实错误样本（2026-09-02 实装日志）

```
Error: ENOENT: no such file or directory, open '...\node_modules\.pnpm\@deepseek-ai+dsh@0.1.2-alph_85829f33...\node_modules\@deepseek-ai\dsh\package.json'
    at readModuleFallbackManifest (dsh-app-boot@0_16017.../lib/index.js)
    at composeProfile (dsh@0.1.2-alph_85829f33.../profile-boot-BTzzdrGY.js)
```

堆栈显示运行的是旧 dsh（85829f33…）profile-boot，其 `.pnpm` 目录已被 pnpm install 清理。重启 Hana 即愈。

## 改动（src/lifecycle.js pickProcessFix）

- **新增检测分支**：错误含 `ENOENT / no such file / cannot find` 且路径指向 `.pnpm/@deepseek-ai+dsh@` → 判定跨版本升级缓存残留，指引明确为「请重启 Hana 加载新版本（dsh 升级后需重启为既定流程，无需其它操作）」。放依赖分支前（升级残留错误里依赖其实已就绪，不给「重装」误导）。
- **修正过时文案**：依赖分支原文案引用已退役的 dsh-pkg（「数据目录 dsh-pkg 执行 pnpm install」在 T7d 后不再成立），改为「依赖自动按插件声明安装并验证，完成后自动重试启动 web host」。

## 验证

- 检测逻辑对真实样本（Windows 反斜杠）与 POSIX 变体均命中
- 负例无误伤：端口占用 / 依赖缺失（无 .pnpm dsh 路径）/ 网络错误 / 普通 ENOENT / 非 .pnpm require.resolve 均不命中
- `node --check src/lifecycle.js` 通过


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of stale module-cache errors after DSH upgrades by recommending a Hana restart only after successful dependency verification.
  * Clarified dependency-failure guidance, including automatic installation, verification, and startup retry steps.
  * Added remediation guidance when runtime dependency verification fails.
  * Updated dependency location information to reflect installation within the plugin environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->