### PR TITLE
fix: 诊断卡错误改日志尾部滚动区（不截断、不存内存副本）

### DIFF
--- a/src/assets/webui-shell.jinja2
+++ b/src/assets/webui-shell.jinja2
@@ -175,6 +175,13 @@
       overflow: auto
     }
 
+    /* 进程错误全文滚动区（诊断第一手材料不截断——错误首行特征与完整堆栈需可读，实装 2026-09-02） */
+    .diag-errorlog {
+      max-height: 200px;
+      color: var(--danger, #A03028);
+      background: var(--accent-light, rgba(83, 125, 150, 0.08))
+    }
+
     .diag-progress-time {
       font-size: 11px;
       color: var(--text-muted, #6B6158);
@@ -463,6 +470,7 @@
           + (d.key === "deps" && d.version ? '<div class="diag-detail">' + escHtml(versionLine(d)) + '</div>' : "") // deps 版本行（当前已装版本；最新版本/可更新状态见设置页「检查与更新 DSH」卡片）
           + (d.key === "deps" && d.pnpmChecked ? '<div class="diag-detail">' + escHtml(pnpmLine(d)) + '</div>' : "") // deps 卡片 pnpm 引导状态行（独立子项，不进依赖就绪判定）
           + (d.detail ? '<div class="diag-detail">' + escHtml(d.detail) + '</div>' : "")
+          + (d.key === "process" && d.errLog ? '<pre class="diag-progress diag-errorlog">' + escHtml(d.errLog) + '</pre>' : "") // 进程错误全文滚动区（不截断：错误首行特征可诊断，实装 2026-09-02）
           + (d.key === "deps" && d.installing ? progressHtml(d) : "") // 安装实时进度
           + (d.key === "deps" && d.updating ? updateProgressHtml(d) : "") // 更新进度/结果（更新由设置页触发，web host 停机期间被动展示）
           + (d.key === "process" && d.logPath ? '<div class="diag-logpath">本次会话日志：' + escHtml(d.logPath) + '</div>' : "") // 时间戳会话日志路径件路径

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -54,6 +54,10 @@ import {
   rmSync,
   rmdirSync,
   readdirSync,
+  statSync,
+  openSync,
+  readSync,
+  closeSync,
 } from "node:fs";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
@@ -1306,6 +1310,29 @@ function buildDepsDiagCheck(g, cfg) {
 /** ② DSH 进程：单例 web 状态（child/exitCode/ready/stderr 尾部）+ webLastError/webLastErrorAt + webLastExit
  * v0.8.5: webLastExit 为单例持久退出记录（进程被外部杀掉时 g.web 已摘除，凭它区分
  * 「已退出」而非误报「尚未启动」）；只在 ensureWebHost 成功拉起新进程（ready）时清掉。 */
+// 会话日志尾部读取（诊断滚动区数据源）：错误行/堆栈本来就逐行写进会话日志文件
+// （emitLog 行规范化，见文件头「统一日志」）——单一事实源 = 日志文件，不为 UI 在
+// 内存另存副本（实装 2026-09-02 指示）。失败态诊断读尾部 ≤maxBytes 供界面滚动渲染：
+// openSync + readSync 只读尾部（不整文件读入）；路径缺失/读失败静默返回 ""（无滚动区）。
+function readLogTail(logPath, maxBytes) {
+  try {
+    if (!logPath || !existsSync(logPath)) return "";
+    const st = statSync(logPath);
+    if (!st || st.size <= 0) return "";
+    const len = Math.min(st.size, maxBytes || 16384);
+    const fd = openSync(logPath, "r");
+    try {
+      const buf = Buffer.alloc(len);
+      readSync(fd, buf, 0, len, st.size - len);
+      return buf.toString("utf8");
+    } finally {
+      closeSync(fd);
+    }
+  } catch {
+    return "";
+  }
+}
+
 function buildProcessDiagCheck(g, out) {
   const web = g.web || null;
   const child = web?.child || null;
@@ -1320,6 +1347,10 @@ function buildProcessDiagCheck(g, out) {
   const exitCode = inproc ? null : child?.exitCode ?? lastExit?.code ?? null;
   const stderr = String(web?.stderr || lastExit?.stderr || "").slice(-800); // stderr 尾部截断 ≤800
   const lastError = String(g.webLastError || "").slice(-800);
+  // 完整错误原文（不截断，供修复指引匹配）：存储端已限 message≤1500 + stderr≤800（见
+  // startWebHostFromPlugin catch）。匹配不依赖截断窗口——长错误被 slice(-800) 截尾会丢
+  // 掉首行的错误特征（错误码/路径在头部），实装验证 2026-09-02 曾因此落兑底文案误导。
+  const lastErrorFull = String(g.webLastError || "");
   const lastErrorAt = g.webLastErrorAt || "";
   // 本次会话日志路径（当前 web / 退出记录 / 失败记录，三级兜底）
   const logPath = web?.logPath || lastExit?.logPath || g.webLastLogPath || null;
@@ -1383,22 +1414,28 @@ function buildProcessDiagCheck(g, out) {
       lastExit.at +
       "）" +
       (lastExit.stderr ? "\n[stderr 尾部] " + lastExit.stderr : "");
+    // 进程退出现场：日志尾部滚动查看（stderr 展示截断 ≤800，全文在会话日志）
+    check.errLog = readLogTail(logPath, 16384);
     check.fix = "点击本卡片「手动启动 web host」按钮重新拉起，或重启 Hana";
   } else {
-    // 启动失败（webLastError）：展示失败原因（其已含 stderr 尾部）+ 修复指引。
+    // 启动失败（webLastError）：detail 摘要取错误首行（错误码在头部，一眼可读）；
+    // errLog = 会话日志尾部（错误行与堆栈本来逐行写进日志，滚动区直接显示日志，不为
+    // UI 另存内存副本）；完整日志路径 logPath 已展示，可跳全文。
     // depsOk 传入 pickProcessFix：升级缓存残留判定需依赖「当前可用」为前提——取本次诊断
     // deps 项的 ok（= installed && 无明确验证失败，见 buildDepsDiagCheck），而非 verified：
     // verified（installed && smoke.ok）在 verify 进行中会被瞬时置 false（running 窗口
     // smoke 重置为 ok:false），此时 boot 失败 ENOENT 会误落兑底；ok 含当前 installed 硬
     // 条件（包被移除不判残留，CodeRabbit PR #51）且 running/未验证暂通过不误杀
-    check.detail = lastError
-      ? "启动失败：" + lastError
+    const errHead = (lastErrorFull.split("\n")[0] || lastError || "").slice(0, 300);
+    check.detail = lastErrorFull || lastError
+      ? "启动失败：" + errHead
       : "进程已退出（code=" +
         (exitCode ?? "?") +
         "）" +
         (stderr ? "\n[stderr 尾部] " + stderr : "");
+    check.errLog = readLogTail(logPath, 16384);
     check.fix = pickProcessFix(
-      lastError,
+      lastErrorFull || lastError,
       stderr,
       port,
       out.checks.find((c) => c.key === "deps")?.ok === true,

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -682,6 +682,10 @@ export async function ensureWebHost(cfg) {
     }
     g.web = null;
   }
+  // 新启动尝试开始：作废旧退出记录（webLastExit 只反映「最近一次进程退出」；本次尝试
+  // 失败会更新 webLastError，诊断应走启动失败分支而非旧退出分支——否则 lastExit 遮蔽
+  // 当前失败，pickProcessFix 指引丢失。CodeRabbit PR #53）
+  g.webLastExit = null;
   if (!cfg.dshPkgDir) cfg.dshPkgDir = resolveDshPkgDir(cfg);
 
   const pkgDir = cfg.dshPkgDir;


### PR DESCRIPTION
实装验证（跨 dsh 版本升级 boot 失败）暴露的诊断体验问题：进程卡错误详情只有截断尾巴（webLastError message 或 stderr ≤800 字符），完整错误与堆栈看不到，用户无法诊断；且截断文本可能丢掉错误首行特征导致修复指引匹配落空。

## 改动

**src/lifecycle.js**
- `buildProcessDiagCheck`：新增 `lastErrorFull`（webLastError 完整原文，不截断）——`pickProcessFix` 修复指引匹配改用完整错误（匹配不依赖截断窗口：长错误被 slice(-800) 截尾会丢首行的错误码/路径特征）
- 新增 `readLogTail(logPath, maxBytes)`：从会话日志文件读尾部（openSync + readSync 只读尾部 ≤16KB，不整文件读入）——错误行与堆栈本来就逐行写进会话日志（emitLog 行规范化），滚动区直接显示日志，**不为 UI 在内存另存副本**
- 启动失败分支（webLastError）：detail 摘要取错误首行（错误码在头部一眼可读）；`errLog` = 日志尾部滚动区内容
- 进程已退出分支（lastExit）：同样补 `errLog` 日志尾部

**src/assets/webui-shell.jinja2**
- process 卡新增 errLog 滚动渲染（`<pre class="diag-progress diag-errorlog">`，任务卡片日志滚动同款模式）
- `.diag-errorlog` 样式：max-height 200px + overflow auto，错误色文字

## 验证

- `node --check` 通过；readLogTail 对真实会话日志（23:14 boot 失败现场）读尾部 16KB：含 ENOENT 首行 + 堆栈帧 + 后续 verify 日志，82 行
- UI：失败态卡内滚动区显示日志全文（可滚动查看完整堆栈），detail 摘要 + 修复指引不变
- 不截断、不放内存副本（日志文件为单一来源）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Diagnostic entries now display full process error logs when available.
  * Long error logs can be viewed in a scrollable panel, with up to 16 KiB shown.
  * Startup failures now include relevant session-log details for easier troubleshooting.

* **Bug Fixes**
  * Corrected startup diagnostics to avoid showing stale exit information.
  * Repair guidance now matches against the complete error details, improving suggested resolutions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->