### PR TITLE
refactor: verify 去 spawn——静态核对取代运行级冒烟

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -268,7 +268,7 @@ export default class DshHanakoPlugin {
               "hana",
               r.skipped
                 ? "依赖已就绪（与声明一致，跳过安装）"
-                : "依赖安装完成（pnpm install --prod，registry 兜底 + 运行级重验）",
+                : "依赖安装完成（pnpm install --prod，registry 兜底 + 自动核对）",
             );
           } else if (r && r.state === "installing") {
             // 并发窗口：他人路径（dsh_install 工具/标签页）正在安装，等其落终态

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -471,8 +471,9 @@ export function ensureDshanaProfile(cfg) {
 // dsh-pkg/ 优先（Agent npm i @deepseek-ai/dsh 部署的轻量分发形态），插件安装目录
 // node_modules 兑底（现役 zip 自带形态）。DSH_HOME 恒在数据目录。
 // 唯一形态 = 宿主进程内 runProfile() boot dshana（webserver 保留在进程内 bind 端口）。
-// 诊断/安装面仍保留 spawn（verifyDepsSmoke 冒烟 + pnpm install 子进程——D6 解耦：
-// 诊断与工具包不 import cordis/pnpm，见 lib/install.js / lib/pnpm.js）。
+// 子进程面收敛（2026-09-02 去 spawn）：仅 pnpm install 保留子进程（D6 解耦——安装需
+// 独立进程跑 pnpm；依赖完整性验证已静态化（见 lib/install.js verifyDepsSmoke），运行
+// 级裁决由进程内 boot 承担）。
 
 // ---- T7b 进程内 boot：dsh 模块动态定位（解耦 D6）----
 // dsh 包位置 = 插件 node_modules（vY T7d：dsh-pkg 独立安装区已退役，依赖收进插件
@@ -1278,24 +1279,24 @@ function buildDepsDiagCheck(g, cfg) {
       (checked.length > 1 ? "（已检查 " + checked.join("、") + "）" : "");
     if (installError) check.detail += "\n[上次安装失败] " + installError;
     check.fix =
-      "依赖缺失：点击本卡片「安装依赖」按钮自动按插件声明安装依赖（完成后自动运行级验证）；或确认插件目录 node_modules 解压完整";
+      "依赖缺失：点击本卡片「安装依赖」按钮自动按插件声明安装依赖（完成后自动核对）；或确认插件目录 node_modules 解压完整";
   } else if (!smoke) {
     // 未检测过（进标签页自动检测一次 / 手动「检测依赖」；ok 暂算 installed）
-    check.detail = "DSH 包已就绪，点击「检测依赖」验证依赖完整性";
+    check.detail = "DSH 包已就绪，点击「检测依赖」核对完整性";
   } else if (verifyRunning) {
-    // 检测进行中：ok 暂 true，结果由检测接口返回后刷新
-    check.detail = "正在检测依赖完整性…";
+    // 检测进行中（静态核对瞬时完成，此分支实际罕见；保留兼容 running 语义）
+    check.detail = "正在检测依赖…";
   } else if (!smoke.ok) {
-    // 存在但验证失败：依赖图不完整（ERR_MODULE_NOT_FOUND 等真实错误）
+    // 存在但核对失败（cliBin 缺失 / 版本与声明不一致，error 为原因）
     check.detail =
-      "DSH 包存在但依赖不完整：" +
-      (verifyError ? "\n" + verifyError : "运行级验证失败");
+      "DSH 包核对失败：" +
+      (verifyError || smoke.error || "未知原因（版本与声明不一致？）");
     check.fix =
-      "点击本卡片「重新安装依赖」按钮重新按插件声明安装（完成后自动运行级验证）";
+      "点击本卡片「重新安装依赖」按钮重新按插件声明安装（完成后自动核对）";
   } else {
-    // 存在 + 验证通过：能跑 = 依赖图完整
+    // 存在 + 核对通过（静态：磁盘版本 === 插件声明）——能跑与否由 boot 进程内裁决
     check.detail =
-      "DSH 包已就绪（运行级验证通过，版本 v" +
+      "DSH 包已就绪（与插件声明一致，版本 v" +
       (currentVersion || smoke?.version || "?") +
       "）：" +
       cliBin;
@@ -1430,7 +1431,7 @@ function pickProcessFix(lastError, stderr, port, depsOk) {
     return "检测到 dsh 已跨版本升级，当前 Hana 进程仍持有升级前的旧模块缓存：请重启 Hana 加载新版本（dsh 升级后需重启为既定流程，无需其它操作）";
   }
   if (/dsh 包未就绪|DSH 包未就绪|cliBin|npm i/i.test(text)) {
-    return "依赖未就绪：自动安装链会按插件声明补齐并运行级验证，完成后自动重试启动 web host；若持续失败请查看上方依赖诊断详情";
+    return "依赖未就绪：自动安装链会按插件声明补齐并核对，完成后自动重试启动 web host；若持续失败请查看上方依赖诊断详情";
   }
   if (/EADDRINUSE|address already in use|占用|bind/i.test(text)) {
     return "检查端口 " + port + " 是否被占用（释放后重启 Hana）";

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -1183,7 +1183,7 @@ function buildDepsDiagCheck(g, cfg) {
   const installError = String(g.deps.error || "").slice(0, 300);
   const installLog = String(g.deps.log || "").slice(-800);
   const installAt = g.deps.time || null; // 最近一次 npm i 输出时间（实时进度）
-  // 运行级验证状态（verifyDepsSmoke 缓存于 g.deps.result；非敏感：布尔/版本号/截断错误文本）
+  // 依赖核对状态（verifyDepsSmoke 静态核对缓存于 g.deps.result；非敏感：布尔/版本号/截断错误文本）
   const smoke = g.deps.result || null;
   const verifyRunning = Boolean(smoke?.running);
   const verified = installed && smoke ? Boolean(smoke.ok) : null; // null = 未安装/未验证过（暂通过）
@@ -1203,7 +1203,7 @@ function buildDepsDiagCheck(g, cfg) {
   const pnpmError = smoke?.pnpmError
     ? String(smoke.pnpmError).slice(0, 300)
     : null;
-  // 当前版本（运行级验证缓存优先，无则直读 dsh-pkg package.json）+ 版本检查
+  // 当前版本（核对缓存优先，无则直读 dsh 包 package.json）+ 版本检查
   // 状态（g.check.result 缓存：最近一次 checkDshUpdate 结果）+ 更新状态（g.update.status /
   // g.update.error + 内存态 updateResult，v0.24 起不再读 update-result.json）。
   // 只回非敏感布尔/版本号/截断文本。

--- a/src/routes/webui.js
+++ b/src/routes/webui.js
@@ -12,7 +12,7 @@
 //                         （probeHost 逻辑仅诊断路径使用；事件化后仅兑底/手动刷新）
 //   POST /webui/start        手动启动 web host（process 卡片「手动启动」按钮；ready/starting/触发启动三态）
 //   POST /webui/install-deps 自动安装 dsh 依赖（deps 卡片「安装依赖」按钮；installing/触发安装）
-//   GET  /webui/verify-deps  运行级依赖检测（node cliBin --version；进标签页自动一次 + 手动「检测依赖」按钮）
+//   GET  /webui/verify-deps  依赖完整性静态核对（cliBin + 磁盘版本 vs 声明；进标签页自动一次 + 手动「检测依赖」按钮）
 //   GET  /webui/check-update 版本检查（经宿主能力层 g.checkDshUpdate；deps 卡片「检查更新」
 //                            按钮已移除——版本管理归设置页「检查与更新 DSH」卡片 + dsh_install 工具，路由保留）
 //   POST /webui/update-dsh   更新 DSH（经宿主能力层 g.updateDsh，异步触发，更新会重启
@@ -440,9 +440,9 @@ export default function registerWebuiRoutes(app, ctx) {
     }
   });
 
-  // 运行级依赖检测（deps 卡片「检测依赖」按钮 + 进标签页自动一次；GET 只读）：
-  // 检测中（g.deps.status === "running"）→ {ok:true,running:true}；否则 await
-  // verifyDepsSmoke(cfg)（dsh 冒烟 ≤10s + pnpm 引导检查并行；自愈下载可能更久）→
+  // 静态完整性核对（deps 卡片「检测依赖」按钮 + 进标签页自动一次；GET 只读，去 spawn
+  // 2026-09-02：无子进程秒回）：核对中/安装中 → {ok:true,running:true}；否则 await
+  // verifyDepsSmoke(cfg)（cliBin 存在 + 磁盘版本 === 插件声明；pnpm 引导检查并行）→
   // {ok:true, verified, version, error, running:false, pnpmReady, pnpmVersion, pnpmError}。
   // pnpm 引导状态为独立子项（不进 verified 判定）：未就绪时 pnpmError 为原因，自愈
   // 路径（缺缓存自动重下）恢复就绪。结果写入 g.deps.result，前端随后经 health 读取

--- a/src/routes/webui.js
+++ b/src/routes/webui.js
@@ -28,7 +28,7 @@
 // （hana.api.fetch / hana.panel.*，与 SDK 同协议 hana.plugin.ui v1），浏览器侧 fetch 一律
 // 走 hana.api.fetch（自动带 pluginSurfaceSession 头），面板内容经 hana.panel.set 推送）。
 //
-// 连接失败自检：web host 未就绪时逐项检查 ① dsh 依赖（存在性 + 运行级验证）
+// 连接失败自检：web host 未就绪时逐项检查 ① dsh 依赖（存在性 + 版本与声明核对）
 // ② DSH 进程状态（t1/t2，见 lifecycle.js collectWebDiagnostics），明确指出哪一项坏了、
 // 为什么、怎么修。诊断由服务端收集（Node 侧才能读 config.json、进程单例与 fs 状态；
 // 浏览器 iframe 读不到插件进程）——收集函数挂在 globalThis 单例（tools/dsh-run.js 的

--- a/src/routes/webui.js
+++ b/src/routes/webui.js
@@ -471,7 +471,7 @@ export default function registerWebuiRoutes(app, ctx) {
       });
     } catch (e) {
       ctx.log?.warn?.(
-        "[dsh-hanako] 运行级依赖检测失败:",
+        "[dsh-hanako] 依赖核对失败:",
         e?.message || String(e),
       );
       return c.json({ ok: false, error: "检测请求失败，请稍后重试" });

--- a/src/tools/dsh-install.js
+++ b/src/tools/dsh-install.js
@@ -7,7 +7,7 @@
 // g.installDeps / g.verifyDeps 调用）的 Agent 入口：
 //   action=install（默认）：按插件根 package.json 声明版本 pnpm install --prod（
 //     dsh-pkg 退役——依赖装进插件根 node_modules；registry 官方源失败自动重试
-//     npmmirror + 自动运行级重验）→ 完成后 autoStart（默认 true：
+//     npmmirror + 自动静态核对）→ 完成后 autoStart（默认 true：
 //     web host 未起时经 g.startWebHost 拉起，失败不阻断结果上报；已起跳过）→
 //     { installed: true, version, autoStart 结果 }。
 //   action=verify：检测依赖完整性（g.verifyDeps 静态核对：cliBin 存在 + 磁盘版本 === 插件
@@ -62,7 +62,7 @@ function buildInstallText(r) {
 export const name = "dsh_install";
 
 export const description =
-  "安装/验证 DeepSeek Harness（DSH）依赖两合一：action=install（默认）按插件声明版本 pnpm install --prod（dsh-pkg 退役——依赖装进插件根 node_modules，无 version/tag 逃生门；registry 兜底 + 自动运行级重验 + autoStart 拉起 web host，渲染安装卡片）；" +
+  "安装/验证 DeepSeek Harness（DSH）依赖两合一：action=install（默认）按插件声明版本 pnpm install --prod（dsh-pkg 退役——依赖装进插件根 node_modules，无 version/tag 逃生门；registry 兜底 + 自动静态核对 + autoStart 拉起 web host，渲染安装卡片）；" +
   "action=verify 只做静态完整性核对（cliBin 存在 + 磁盘版本与声明一致，只读秒回）。" +
   "版本严格锁插件 package.json 声明（更新 dsh = 更新插件发版，无独立升级通道）。" +
   "适用场景：dsh_session create 报「DSH 包未就绪」、DSHana 标签页依赖缺失。" +
@@ -269,7 +269,7 @@ async function doExecute(input, ctx) {
     content: [
       {
         type: "text",
-        text: "DSH 依赖安装已在后台执行（" + pkgTargetText() + "，registry 兜底 + 自动运行级重验），完成后后台消息带回结果；进度与实时日志见上方安装卡片",
+        text: "DSH 依赖安装已在后台执行（" + pkgTargetText() + "，registry 兜底 + 自动静态核对），完成后后台消息带回结果；进度与实时日志见上方安装卡片",
       },
     ],
     details: {

--- a/src/tools/dsh-install.js
+++ b/src/tools/dsh-install.js
@@ -10,8 +10,9 @@
 //     npmmirror + 自动运行级重验）→ 完成后 autoStart（默认 true：
 //     web host 未起时经 g.startWebHost 拉起，失败不阻断结果上报；已起跳过）→
 //     { installed: true, version, autoStart 结果 }。
-//   action=verify：检测依赖完整性（g.verifyDeps：node cliBin --version 冒烟，能跑 =
-//     依赖图完整）→ { verified, version, error? }。
+//   action=verify：检测依赖完整性（g.verifyDeps 静态核对：cliBin 存在 + 磁盘版本 === 插件
+//     声明，秒回无子进程——去 spawn 2026-09-02，运行级裁决由 boot 进程内承担）→ { verified,
+//     version, error? }。
 // 默认异步：立即返回 + 渲染「安装卡片」（/card/dep，见 routes/card.js /ops/dep-stream，
 // 数据源 = 宿主单例 g.depTasks + g.deps.log 实时日志），完成/失败经宿主 deferred
 // 通道唤醒 Agent 带回结果；wait=true 同步等待直接返回。
@@ -37,7 +38,7 @@ function pkgTargetText() {
 
 function buildVerifyText(r) {
   if (r?.ok) {
-    return "DSH 依赖检测：通过（能跑 = 依赖图完整），版本 v" + (r.version || "?") + "。";
+    return "DSH 依赖检测：通过（磁盘版本与插件声明一致），版本 v" + (r.version || "?") + "。";
   }
   return "DSH 依赖检测：失败" + (r?.error ? "（" + r.error + "）" : "") + "。可执行 dsh_install(action='install') 安装依赖，或查看 DSHana 标签页 deps 卡片。";
 }
@@ -62,7 +63,7 @@ export const name = "dsh_install";
 
 export const description =
   "安装/验证 DeepSeek Harness（DSH）依赖两合一：action=install（默认）按插件声明版本 pnpm install --prod（dsh-pkg 退役——依赖装进插件根 node_modules，无 version/tag 逃生门；registry 兜底 + 自动运行级重验 + autoStart 拉起 web host，渲染安装卡片）；" +
-  "action=verify 只检测依赖完整性（运行级冒烟，只读）。" +
+  "action=verify 只做静态完整性核对（cliBin 存在 + 磁盘版本与声明一致，只读秒回）。" +
   "版本严格锁插件 package.json 声明（更新 dsh = 更新插件发版，无独立升级通道）。" +
   "适用场景：dsh_session create 报「DSH 包未就绪」、DSHana 标签页依赖缺失。" +
   "默认异步：后台执行 + 完成回调，wait=true 同步；安装进行中重复调用返回状态不重复执行。" +
@@ -75,7 +76,7 @@ export const parameters = {
       type: "string",
       enum: ["install", "verify"],
       description:
-        "install=安装依赖（默认，按插件声明版本 pnpm install --prod 到插件 node_modules，registry 兜底 + 自动重验 + autoStart）；verify=只检测依赖完整性（运行级冒烟，只读）",
+        "install=安装依赖（默认，按插件声明版本 pnpm install --prod 到插件 node_modules，registry 兜底 + 自动核对 + autoStart）；verify=只做静态完整性核对（cliBin + 版本 vs 声明，只读）",
     },
     wait: {
       type: "boolean",

--- a/src/tools/lib/install.js
+++ b/src/tools/lib/install.js
@@ -15,7 +15,6 @@
 // 容错纪律：函数内部失败返回 { ok:false, error } 结构不抛出（调用方按需降级）；
 // 日志/写入失败静默（不阻断主流程）。注释风格保持宿主侧（中文/双引号/分号）。
 
-import { spawn } from "node:child_process";
 import {
   readFileSync,
   existsSync,
@@ -500,8 +499,9 @@ export async function installDepsFromPlugin(ctxConfig, ctxDataDir, opts = {}) {
       declaredVersion &&
       installedVersion === declaredVersion
     ) {
-      // 幂等跳过前必须运行级重验（CodeRabbit：cliBin 存在 ≠ 依赖图完整——声明版本一致
-      // 但运行时包缺失时不能报「已安装成功」；smoke 失败 fall through 走重装流程）。
+      // 幂等跳过前经 verifyDepsSmoke 确认（去 spawn 2026-09-02 后为静态核对：cliBin +
+      // 磁盘版本与声明一致——与上方幂等条件同源，实为 result/pnpm 状态刷新 + pnpm 引导
+      // 自愈检查；核对不过 fall through 走重装流程）。
       const smoke = await verifyDepsSmoke(cfg, { force: true });
       if (smoke && smoke.ok) {
         milestone("已安装 dsh@" + installedVersion + "（与声明一致），跳过安装");
@@ -710,8 +710,8 @@ export async function installDepsFromPlugin(ctxConfig, ctxDataDir, opts = {}) {
     }
     g.deps.error = null;
     milestone("[完成] " + cliBin);
-    // 部署成功后强制运行级重验（清旧缓存，await 刷新——安装流程本身就是等待场景）；
-    // verifyDepsSmoke 会把 g.deps.result 刷新为最新 smoke（含 status running→ok/error）
+    // 部署成功后强制静态核对（刷新 result/pnpm 状态——安装流程本身就是等待场景）；
+    // verifyDepsSmoke 会把 g.deps.result 刷新为最新核对结果（含 status → ok/error）
     g.deps.result = null;
     await verifyDepsSmoke(cfg, { force: true });
     // 安装链路终态 ok（终态保留；verify 若失败其详情在 g.deps.result，不影响安装结论）——
@@ -756,23 +756,24 @@ export async function installDepsFromPlugin(ctxConfig, ctxDataDir, opts = {}) {
   }
 }
 
-// ---- 依赖运行级完整性验证（deps 存在性之外的加载冒烟）----
-// dsh 是 cordis 生态，模块图挂大量 peer 依赖（dsh-agent/dsh-llm-deepseek/dsh-tool-* 等）：
-// pnpm add 中断 / install script 失败未回滚 / --omit=peer 误用都会造成「入口文件在、依赖缺」
-// 的假就绪，运行时才抛 ERR_MODULE_NOT_FOUND。文件存在 ≠ 依赖完整。
-// 可靠检测 = 运行级验证「node <cliBin> --version」：node 沿 import 图加载整个 cordis 模块树，
-// 任何依赖缺失都会抛错且退出码非 0（技能文档「部署后验证 node lib/bin.js --version 应输出
-// 0.1.0-rc.6」同款逻辑）。能跑 = 依赖图完整。
-// 防并发/防轮询风暴：结果缓存到单例分组 g.deps.result = { ok, version, error, stderr, at,
-// running, pnpm* }（v0.24 状态收敛：旧 g.depsSmoke 平铺字段并入 g.deps.result 复合对象）；
-// running 标志映射进 g.deps.status === "running"，进行中直接返回当前缓存不重复 spawn
-// （spawn 一次 --version 数百 ms，3s 轮询 × 每次 spawn 不可接受，必须缓存 + running 标志）。
-// 触发时机：进标签页自动一次 +
-// 手动「检测依赖」按钮（经 GET /webui/verify-deps 驱动）/ installDeps 部署成功后强制重验。
-// v0.18.2: 叠加 pnpm 引导检查（独立子项）——与 dsh 冒烟并行调 ensurePnpm（幂等：缓存
-// 完整直接返回，缺失/损坏自动重新下载自愈），结果记 pnpmReady / pnpmVersion / pnpmError。
-// 不进 smoke.ok 的 dsh 依赖就绪判定（web host 启动不依赖 pnpm，patch 已降级）；仅作
-// deps 卡片「pnpm 引导：就绪/未就绪」独立展示行。
+// ---- 依赖完整性核对（静态：存在性 + 版本与声明一致；去 spawn 2026-09-02）----
+// 历史：v0.8.7 起为运行级冒烟（spawn node cliBin --version 验依赖图可加载）。退役理由：
+// ① 冒烟 spawn 独立进程、绕开宿主 ESM 缓存，验的是「干净进程可加载」——与真实故障
+//    （进程内缓存命中旧版、boot 读已删 .pnpm 路径）不同路：验过 ≠ 能跑，实装验证多次
+//    出现「验证通过（依赖绿）+ boot 失败 ENOENT（升级残留）」的两张皮；
+// ② 磁盘完整性由 pnpm install 退出 0 保证（事务性；历史假就绪均来自 pnpm 异常中断，
+//    现已被 install 失败路径 + errorClass 分类捕获）；可运行性由 boot（进程内同路，
+//    命中缓存与否如实反映）裁决——运行级验证夹在中间无独立价值，spawn 面收敛只留
+//    pnpm install（D6：诊断/工具不 import cordis/pnpm）。
+// 现职责：静态核对 cliBin 存在 + 磁盘版本 === 插件声明（秒回，无子进程、无 running
+// 窗口）。pnpm 引导检查保留（ensurePnpm 幂等自愈，文件下载/校验不 spawn）。
+// 结果缓存到单例分组 g.deps.result = { ok, version, error, at, running, pnpm* }（
+// v0.24 状态收敛：旧 g.depsSmoke 平铺字段并入）；防并发守卫保留（兼容 running/installing
+// 语义，静态后 running 窗口消失）。
+// 触发时机：进标签页自动一次 + 手动「检测依赖」按钮（GET /webui/verify-deps）/ installDeps
+// 部署成功后强制重验（opts.force）。
+// pnpm 引导状态（pnpmReady/pnpmVersion/pnpmError）为独立子项，不进 ok 判定（web host
+// 启动不依赖 pnpm）；仅作 deps 卡片「pnpm 引导：就绪/未就绪」独立展示行。
 export async function verifyDepsSmoke(cfg, opts = {}) {
   const g = getSingleton();
   // 防并发：验证进行中直接返回当前缓存（不重复 spawn）——running 标志映射进 g.deps.status
@@ -827,8 +828,7 @@ export async function verifyDepsSmoke(cfg, opts = {}) {
   g.deps.result = smoke;
   g.deps.status = "running";
   notifyDepsChanged();
-  // pnpm 引导检查（与 dsh 运行级验证并行，互不拖累）：verifyDepsSmoke 虽是运行级
-  // 只读检测，但 pnpm 检查允许自愈——ensurePnpm 幂等：缓存完整（sha256 一致）直接
+  // pnpm 引导检查（与静态核对并行，互不拖累）：pnpm 检查允许自愈——ensurePnpm 幂等：缓存完整（sha256 一致）直接
   // 返回（快速路径），缺失/损坏自动重新下载（网络操作无副作用）。dataDir 显式传入
   // （与 installDepsFromPlugin 同约定，见 pnpm.js resolveDataDir；patch 渲染已不再
   // 依赖 pnpm——v0.18.2 起版本检查改 HTTP 直查 npm registry）。
@@ -849,60 +849,41 @@ export async function verifyDepsSmoke(cfg, opts = {}) {
     }
   })();
   try {
+    // 静态核对（去 spawn）：cliBin 存在 + 磁盘版本 === 插件声明。磁盘完整性由 pnpm
+    // install 保证、可运行性由 boot 裁决（见函数头注释），这里只核对「装没装对」。
     if (!existsSync(cliBin)) throw new Error("cliBin 不存在：" + cliBin);
-    slog("开始（cliBin=" + cliBin + "）");
-    // spawn node cliBin --version，10s 超时兜底（child.kill）；capture stdout+stderr
-    // node 执行体每次 spawn 前解析（自定义 nodejsPath 或默认 Electron node）
-    const child = spawn(resolveNodeExec(diagCfg), [cliBin, "--version"], {
-      cwd: dirname(cliBin),
-      stdio: ["ignore", "pipe", "pipe"],
-      env: resolveNodeExecEnv(diagCfg),
-      windowsHide: true,
-    });
-    let out = "";
-    let err = "";
-    child.stdout.on("data", (d) => {
-      out = (out + String(d)).slice(-800);
-    });
-    child.stderr.on("data", (d) => {
-      err = (err + String(d)).slice(-800);
-    });
-    const timer = setTimeout(() => {
-      try {
-        child.kill();
-      } catch {
-        /* 已退出 */
-      }
-    }, 10000);
-    const code = await new Promise((res) => child.once("close", res));
-    clearTimeout(timer);
-    const stdout = out.trim();
-    // 提取完整版本（含 -rc.x 预发布后缀）：旧正则只抓 major.minor.patch，
-    // 把 0.1.1-rc.1 截断成 0.1.1，与最新版 0.1.1-rc.2 比较时被当作「正式版已最新」，
-    // 导致 rc 版永远判不到可更新（回归过两次，勿再截断）
-    const version =
-      (stdout.match(/^\s*(\d+\.\d+\.\d+(?:-[\w.]+)?)/) || [])[1] || null;
-    if (code === 0 && version) {
-      smoke.ok = true;
-      smoke.version = version;
-      smoke.error = "";
-      smoke.stderr = err.slice(-400);
-      slog("通过（version=" + version + "）");
+    slog("静态核对（cliBin=" + cliBin + "）");
+    const declared = readDeclaredDshVersion();
+    const installed = readDshInstalledVersion(diagCfg);
+    if (!declared)
+      throw new Error(
+        "插件声明缺少合法 dsh 版本（dependencies 未声明或非法）",
+      );
+    if (!installed) throw new Error("dsh 包版本读取失败：" + cliBin);
+    // 声明若是合法 dist-tag（非 semver 形态）则无法版本对账——存在即视为一致（安装按
+    // 声明拉取由 install 保证）；固定版本声明（现役形态）做严格比对
+    const declaredIsSemver = /^\d+\.\d+\.\d+(?:-[\w.]+)?$/.test(declared);
+    if (declaredIsSemver && installed !== declared) {
+      smoke.error =
+        "磁盘 dsh@" +
+        installed +
+        " ≠ 插件声明 " +
+        declared +
+        "（需重新安装依赖）";
+      slog("不一致（磁盘 " + installed + " ≠ 声明 " + declared + "）");
     } else {
-      // 真实错误（ERR_MODULE_NOT_FOUND 等）截断 ≤400 存入 error
-      smoke.ok = false;
-      smoke.error = String(err || out || "退出码 " + code).slice(0, 400);
-      smoke.stderr = String(err || out).slice(-400);
-      slog("失败（exit=" + code + "）：" + String(smoke.error).slice(0, 200));
+      smoke.ok = true;
+      smoke.version = installed;
+      slog("通过（version=" + installed + ", 与声明一致）");
     }
   } catch (e) {
     smoke.ok = false;
     smoke.error = String(e?.message || e).slice(0, 400);
     slog("异常：" + String(smoke.error).slice(0, 200));
   } finally {
-    // 等 pnpm 检查收尾（自愈下载可能比 dsh 冒烟慢；pnpmTask 内部已 catch，不抛）。
-    // 若只 await dsh 冒烟，冷启动首次 verify 会带着 pnpmReady=false 返回，前端展示
-    // 「未就绪」误导——自愈路径（删缓存后 verify）须等下载完成再定格结果。
+    // 等 pnpm 检查收尾（自愈下载可能比静态核对慢；pnpmTask 内部已 catch，不抛）。
+    // 若不等它，首次 verify 会带着 pnpmReady=false 返回，前端展示「未就绪」误导——
+    // 自愈路径（删缓存后 verify）须等下载完成再定格结果。
     await pnpmTask;
     smoke.at = new Date().toISOString();
     smoke.running = false;

--- a/src/tools/lib/install.js
+++ b/src/tools/lib/install.js
@@ -6,7 +6,7 @@
 // + semver 比较辅助（parseSemver / compareSemver）+ 本地版本直读（readDshInstalledVersion）。
 // 状态经 lib/state.js 的 getSingleton 访问分组对象 g.deps = { status, result, error,
 // time, log }（v0.24 状态收敛：旧平铺 g.depsInstalling/g.depsInstallLog/g.depsSmoke 等
-// 全废；status 值域 idle/installing/ok/error，result = 运行级验证缓存复合对象，log =
+// 全废；status 值域 idle/installing/ok/error，result = 依赖核对缓存复合对象，log =
 // 内存尾环字符串，time = 最近一次 npm i 输出时间）。
 // 消费方：dsh-run.js（updateDsh / buildDepsDiagCheck 等组合）、lib/check.js
 // （checkDshUpdate 依赖 verifyDepsSmoke 缓存 + 本地版本直读）、tools/dsh-install.js
@@ -21,6 +21,7 @@ import {
   writeFileSync,
   copyFileSync,
   rmSync,
+  statSync,
 } from "node:fs";
 import { join, dirname, delimiter } from "node:path";
 import {
@@ -849,9 +850,18 @@ export async function verifyDepsSmoke(cfg, opts = {}) {
     }
   })();
   try {
-    // 静态核对（去 spawn）：cliBin 存在 + 磁盘版本 === 插件声明。磁盘完整性由 pnpm
-    // install 保证、可运行性由 boot 裁决（见函数头注释），这里只核对「装没装对」。
-    if (!existsSync(cliBin)) throw new Error("cliBin 不存在：" + cliBin);
+    // 静态核对（去 spawn）：cliBin 存在且为常规文件 + 磁盘版本 === 插件声明。磁盘完整
+    // 性由 pnpm install 保证、可运行性由 boot 裁决（见函数头注释），这里只核对「装没装
+    // 对」。cliBin 必须是常规文件（existsSync 对目录也返回 true——目录损坏时核对不能过，
+    // 否则幂等跳过不修复、boot 加载路径失败。CodeRabbit PR #54）
+    let cliStat = null;
+    try {
+      cliStat = statSync(cliBin);
+    } catch {
+      /* 不存在/不可读 */
+    }
+    if (!cliStat || !cliStat.isFile())
+      throw new Error("cliBin 不存在或非文件：" + cliBin);
     slog("静态核对（cliBin=" + cliBin + "）");
     const declared = readDeclaredDshVersion();
     const installed = readDshInstalledVersion(diagCfg);


### PR DESCRIPTION
verifyDepsSmoke 去 spawn 化：依赖验证不再 spawn `node cliBin --version`，改为静态核对（cliBin 存在 + 磁盘版本 === 插件声明，秒回无子进程）。子进程面收敛为只剩 pnpm install。

## 动机（实装验证 2026-09-02 定论）

运行级冒烟 spawn 独立进程、**绕开宿主 ESM 缓存**，验的是「干净进程可加载」——与真实故障（进程内缓存命中旧版、boot 读已删 .pnpm 路径）**不同路**：多次实装出现「验证通过（依赖绿）+ boot 失败 ENOENT（升级残留）」两张皮。验过 ≠ 能跑。职责重新划分：

| 层 | 职责 | 手段 |
|---|---|---|
| 磁盘完整性 | pnpm install 退出 0 = 树完整（事务性） | pnpm install（唯一保留 spawn） |
| 实际可运行 | 宿主进程内真实加载（含缓存路径） | boot（进程内同路）裁决 |
| 依赖核对 | cliBin 存在 + 磁盘版本 === 声明 | verifyDepsSmoke 静态核对（秒回） |

## 改动

**src/tools/lib/install.js**
- `verifyDepsSmoke` 重写：删 spawn 段（node cliBin --version / 超时 / 退出码 / stdout 版本提取），改静态核对——cliBin 存在 + `readDshInstalledVersion` === `readDeclaredDshVersion`（声明为 dist-tag 非 semver 时无法对账，存在即视为一致）；不一致报「磁盘 dsh@X ≠ 插件声明 Y（需重新安装依赖）」
- pnpm 引导检查保留（ensurePnpm 幂等自愈，文件下载/校验不 spawn）
- 防并发守卫/返回结构 `{ ok, version, error, at, running, pnpm* }` 全保留（running 窗口实际消失，语义兼容）
- 删除死代码 `spawn` import（install.js 内已无 spawn 调用，pnpm 子进程在 lib/pnpm.js）
- 幂等跳过路径注释更新（verify 实为 result/pnpm 状态刷新）；头部注释块重写（退役理由）
- 安装完成路径注释「运行级重验」→「静态核对」

**src/lifecycle.js**
- `buildDepsDiagCheck` detail 文案：运行级语义 → 静态语义（「DSH 包已就绪（与插件声明一致，版本 vX）」、「DSH 包核对失败：原因」）；verifyRunning 分支保留兼容
- `pickProcessFix` 依赖分支文案「补齐并运行级验证」→「补齐并核对」
- 文件头 D6 注释更新（子进程面收敛：仅 pnpm install）

**src/routes/webui.js**：verify-deps 端点注释 → 静态核对（无 ≤10s await 语义）

**src/tools/dsh-install.js**：verify action 注释 + 参数 description + buildVerifyText 文案（「能跑 = 依赖图完整」→「磁盘版本与插件声明一致」）

**src/index.js**：启动链日志「运行级重验」→「自动核对」

## 验证

- 5 文件 `node --check` 通过
- 行为：verify 秒回无子进程；diagnosis 不再有 running 瞬时窗口（此前 verified 门控的 running 态问题根除）；升级残留判定（deps.ok 门控）语义更干净——磁盘好 + boot 挂 = 残留
- 待实装：装包后「检测依赖」秒回、deps 卡显示「与插件声明一致」

## 范围外

- 不涉及 boot 进程内化（早已完成）；不涉及错误分类器（T1 已合）；skills/dsh-install SKILL 文档同步留 T6 一起做


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changes**
  - Dependency verification now uses static checks to confirm the CLI is present as a readable file and matches the declared plugin version.
  - Valid package distribution tags are accepted without strict version comparison.
  - Verification no longer runs the CLI as a runtime smoke test.
  - Dependency installation and bootstrap checks complete before results are finalized.
  - Updated status messages and documentation to describe the revised verification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->