### PR TITLE
feat: T2 自动链状态机 + 退避重试调度器

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,12 +13,14 @@
 //     回环调用 dsh web host，存在才存，与 bus 同模式）
 //  3. onload 时异步拉起 dsh web host（fire-and-forget：随插件加载即后台启动，不等首次工具调用；
 //     tools 文件可能晚于 onload 被宿主加载，做一次 <1s 简短轮询等单例方法就绪后触发启动，
-//     不 await 端口就绪，避免拖住宿主启动；失败记 webLastError，工具调用时重试）
+//     不 await 端口就绪，避免拖住宿主启动；失败记 webLastError，工具调用时重试）。
+//     T2 起启动链为持久状态机（spec：dsh-deps-zero-intervention）：依赖检查/安装 →
+//     web host boot → ready，失败按 errorClass 退避重试或停等待条件，见 onload 内自动链注释）
 //  4. 插件卸载/重载时回收常驻 web host 子进程。
 // 单例挂在 globalThis.__dshHanako（tools/dsh-run.js 的 rspack bundle 内联 app/lifecycle.js，
 // mountLifecycle 挂 closeProcess/collectDiagnostics/updateDsh/startWebHost/installDeps/verifyDeps/
 // checkDshUpdate）。本文件为 bundle 收敛入口：静态 import 全部插件模块（单 bundle 内无模块缓存问题）。
-import { existsSync, mkdirSync, appendFileSync } from "node:fs";
+import { existsSync, mkdirSync, appendFileSync, watch } from "node:fs";
 import { join, dirname } from "node:path";
 // 日志生命周期（vX 起独立于 migrate 体系）：旧日志归档压缩 + 时间戳日志文件命名
 import { archiveOldLogs, logFileStamp, nextTimestampLogPath } from "./log-archive.js";
@@ -26,6 +28,12 @@ import { archiveOldLogs, logFileStamp, nextTimestampLogPath } from "./log-archiv
 // ---- bundle 收敛 ----（单 bundle 形态）
 // 生命周期能力：src/lifecycle.js 顶层 mountLifecycle() 在 import 时即挂单例
 import "./lifecycle.js";
+// T1 错误分类器（spec：dsh-deps-zero-intervention）——T2 自动链状态机（本文件 onload）对
+// install/boot 失败归类决策（可恢复退避重试 / 不可恢复停等待条件）与指引文案，纯函数复用
+import {
+  classifyInstallError,
+  ERROR_CLASS_GUIDANCE,
+} from "./tools/lib/errclass.js";
 // 5 个工具模块（ESM 导出 name/description/parameters/execute(+sessionPermission)；
 // dsh_update 已并入 dsh_install 四合一，见 tools/dsh-install.js）
 import * as dshInstall from "./tools/dsh-install.js";
@@ -192,36 +200,427 @@ export default class DshHanakoPlugin {
         );
       }
     }
-    // 卸载/重载标记：runStartupAutoChain 可能挂起数十秒至数分钟（等待挂载/等并发安装/
-    // 安装本身），期间插件可能被卸载/重载。卸载清理（closeProcess）执行后自动链若继续
-    // 会重新拉起 web host，残留悬挂服务；此标记在清理回调置位，自动链在依赖安装前与
-    // startWebHost 前各查一次（CodeRabbit），卸载即放弃。
+    // 卸载/重载标记：自动链状态机（见下）可能挂起数十秒至数分钟（等待挂载/等并发安装/
+    // 安装本身/退避定时等待），期间插件可能被卸载/重载。卸载清理（closeProcess）执行后
+    // 自动链若继续会重新拉起 web host，残留悬挂服务；此标记在清理回调置位，自动链在每个
+    // 异步边界前检查（依赖安装前、startWebHost 前、退避定时回调、config 续跑），卸载即
+    // 放弃：同时清掉挂起的退避定时器（g.boot.timer）与 config 续跑 watch（定时句柄/watch
+    // 不跨会话有效，新 onload 会重新评估/调度）。
     let unloaded = false;
     this.register(() => {
       unloaded = true;
+      // 防御：辅助函数在下方声明（同作用域 const），清理可能在极早期被宿主触发时未初始化
+      if (typeof clearBootTimer === "function") clearBootTimer();
+      if (typeof stopConfigWatch === "function") stopConfigWatch();
       if (g && typeof g.closeProcess === "function") {
         Promise.resolve(g.closeProcess()).catch(() => {});
       }
     });
 
-    // 拉起 dsh web host（随插件生命周期：加载即启动，卸载即回收）——异步 fire-and-forget：
-    // onload 立即返回，不 await 端口就绪（ensureWebHost 有 60s 端口就绪等待，onload 不能被拖住）。
-    // tools 模块由宿主在激活期间 import（注册工具），可能晚于本 onload；这里先做一次简短（<1s）
-    // 轮询等单例方法挂上，再触发启动；触发后不 await 其结果（fire-and-forget，内部 try/catch
-    // 记 g.webLastError / g.webLastLogPath，不抛到 onload）。启动失败不阻塞加载——首次工具调用
-    // （dsh_run execute 内 ensureWebHost）或 /webui/start 手动启动时仍会可靠重试。
+    // ---- 启动自动链状态机（T2 spec：dsh-deps-zero-intervention 新增设计 2）----
+    // 旧一次性启动链（runStartupAutoChain：依赖幂等装 → startWebHost，失败静默降级）升级为
+    // 持久状态机，phase 流转：ensure-deps（依赖幂等检查/安装，install 失败按 g.deps.errorClass
+    // 决策）→ waiting（失败停等：不可恢复类等条件变化 / 可恢复类退避等下一尝试）→ booting
+    // （startWebHost）→ ready（收敛）。状态存单例 g.boot（state.js 兜底初始化，字段说明见
+    // state.js；跨热更新保留，旧对象缺字段逐个兜底）。
+    // 触发点（无常驻轮询）：① onload 挂载后首跑一次；② 可恢复失败 → 后台 setTimeout 退避
+    // 链（30s→2m→10m→30m cap，插件生命周期内持续）到点自动重新评估；③ 停等类中配置引导
+    // 类（macos-signature：nodejsPath 配置）→ fs.watch config.json 变化即重新评估（设置保存
+    // 后自动续跑）；④ 宿主重启/插件重载 → 新 onload 重新评估（g.web?.ready 快速路径收敛）。
+    // 手动/工具路径（dsh_install autoStart、/webui/start、诊断卡按钮）与状态机并存：
+    // installDepsFromPlugin 的 installing/running 守卫 + ensureWebHost 的 readyPromise 幂等
+    // ——他人路径先装/先起时状态机让路（等落终态或直接收敛），互不冲突。
     //
-    // 启动前依赖自动安装（onStartUp 自动装一次，类 pn i -P）：web host 进程内 boot 会动态
-    // import 插件根 node_modules 的 dsh 依赖树（bootInproc → loadInprocDsh），依赖缺失/版本
-    // 漂移/依赖图不完整时 boot 必失败——此前只能靠人工 dsh_install 或 DSHana 标签页自装。
-    // 自动链把 installDepsFromPlugin（幂等：cliBin 在且已装版本 === 声明 + 运行级冒烟通过 →
-    // skipped 快速返回；缺失/不一致/不完整才真跑 pnpm install --prod，官方源失败自动重试
-    // npmmirror）提到 web host 启动（WebUI/总线就绪点）之前：装好再拉起，首次启动即装完即用。
-    // 安装可能数分钟：在后台链执行，onload 早已返回，不阻塞宿主；安装失败不阻断启动尝试
-    // （依赖缺失时 startWebHost 失败记 webLastError，工具调用/标签页仍可靠重试）。
-    // 挂载探测失败（1s 内未挂上）不放弃自动链：转入后台延后等待（60s 兜底、1s 间隔），
-    // 单例方法挂上后补跑同一启动链——不让短暂探测窗口丢失「启动自动安装 + web host 自启」
-    // 承诺（否则延迟挂载的冷启动只能等工具调用才自愈）；仍未挂载才降级随工具调用启动。
+    // 失败决策（errorClass → 策略；install 分类由 T1 产出存 g.deps.errorClass，boot 失败在
+    // 本文件经 classifyBootFailure 归类）：
+    //   可恢复（自动退避重试）：network / environment / unknown / native-toolchain——前两者
+    //     的 T1 guidance 明示「插件会自动重试」、unknown 保守可重试（spec 表）；native-toolchain
+    //     等用户装好编译工具链后由退避链自动续跑（T1 guidance「完成后插件会自动重试」即此语义）。
+    //   不可自动恢复（停 + 通知一次，不设退避定时器，等条件变化）：macos-signature（配置引导
+    //     类 → config.json 变化续跑）/ declaration（声明或上游问题，等插件更新）/ restart-needed
+    //     （boot 升级缓存残留，等重启宿主）——重载/重启后 onload 重新评估自动续跑。
+    // 通知纪律：同一失败原因（阶段+errorClass+错误首行）只主动通知一次（会话日志一行 + 状态
+    // 呈现 g.boot/g.deps/g.web，供 T3 快照端点消费）；后续重试只打「第 N 次 / 下次时间」进度
+    // 日志，重试继续挂后台不打扰。
+    const BACKOFF_MS = [30000, 120000, 600000, 1800000]; // 30s → 2m → 10m → 30m（cap）
+    const IRRECOVERABLE_CLASSES = new Set([
+      "macos-signature",
+      "declaration",
+      "restart-needed",
+    ]);
+    // 停等类中「配置变化即可续跑」的子集（挂 config.json watch；其余停等类只等重载/重启）
+    const CONFIG_CONTINUE_CLASSES = new Set(["macos-signature"]);
+    // boot 升级缓存残留特征（与 lifecycle.js pickProcessFix 判定同源）：跨 dsh 版本升级后
+    // 宿主进程仍持旧模块缓存，boot 读已删 .pnpm 路径必败——重启宿主前重试无意义，归
+    // restart-needed 停等
+    const ENOENT_TEXT_RE = /(?:ENOENT|no such file|cannot find)/i;
+    const STALE_PNPM_RE = /\.pnpm[\\/]@deepseek-ai\+dsh@/i;
+    // 时刻/间隔可读化（会话日志展示下次重试时间）
+    const pad2 = (n) => String(n).padStart(2, "0");
+    const fmtClock = (t) => {
+      const d = new Date(t);
+      return `${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}`;
+    };
+    const fmtDelay = (ms) =>
+      ms < 60000
+        ? Math.round(ms / 1000) + " 秒"
+        : ms < 3600000
+          ? Math.round(ms / 60000) + " 分钟"
+          : Math.round(ms / 3600000) + " 小时";
+    // 状态机互斥：一次只跑一个评估（含长安装/等 settle 期间不响应新触发，避免重入打架）
+    let machineBusy = false;
+    // 主动通知去重键（同一失败原因只通知一次，见上面「通知纪律」；每次 onload 重置）
+    let lastNotifiedKey = "";
+    // config 续跑 watch（仅 CONFIG_CONTINUE_CLASSES 停等时挂载；卸载/离开停等时清理）
+    let configWatch = null;
+    let configWatchTimer = null;
+
+    const clearBootTimer = () => {
+      if (g.boot && g.boot.timer) {
+        try {
+          clearTimeout(g.boot.timer);
+        } catch {
+          /* 已触发/已清 */
+        }
+        g.boot.timer = null;
+      }
+    };
+    const stopConfigWatch = () => {
+      if (configWatchTimer) {
+        try {
+          clearTimeout(configWatchTimer);
+        } catch {
+          /* 已触发/已清 */
+        }
+        configWatchTimer = null;
+      }
+      if (configWatch) {
+        try {
+          configWatch.close();
+        } catch {
+          /* 已关闭 */
+        }
+        configWatch = null;
+      }
+    };
+    // 退避定时：到点自动重新评估状态机（回调先查 unloaded；卸载清理已清 timer）
+    const scheduleRetry = (delayMs) => {
+      clearBootTimer();
+      if (unloaded) return;
+      g.boot.timer = setTimeout(() => {
+        g.boot.timer = null;
+        if (unloaded) return;
+        g.appendLog?.("hana", "[自动链] 退避到点，自动重新评估…");
+        kickAutoChain();
+      }, delayMs);
+    };
+    // 状态机入口：串行化 + 兜底错误日志（不抛到 onload；内部各阶段另有决策）
+    const kickAutoChain = () => {
+      if (unloaded) return;
+      if (machineBusy) return; // 已有评估在跑（含长安装/等待），让路
+      machineBusy = true;
+      Promise.resolve(runMachineEval())
+        .catch((e) => {
+          try {
+            g.appendLog?.(
+              "hana",
+              "自动链状态机异常：" + (e?.message || String(e)),
+            );
+          } catch {
+            /* 日志失败不阻断 */
+          }
+        })
+        .finally(() => {
+          machineBusy = false;
+        });
+    };
+    // 收敛（ready）：清退避定时/config watch、重置尝试计数与失败记录
+    const convergeReady = () => {
+      clearBootTimer();
+      stopConfigWatch();
+      g.boot.phase = "ready";
+      g.boot.attempt = 0;
+      g.boot.nextRetryAt = null;
+      g.boot.errorClass = null;
+      g.boot.lastError = null;
+    };
+    // 读最近 install 失败分类（T1 落 g.deps.errorClass = { errorClass, guidance }；
+    // 缺失/未分类 → 保守 unknown：宁可退避重试不可误停）
+    const readDepsErrorClass = () => {
+      const ec = g.deps && g.deps.errorClass;
+      if (ec && typeof ec === "object" && typeof ec.errorClass === "string") {
+        return { errorClass: ec.errorClass, guidance: ec.guidance || null };
+      }
+      return { errorClass: "unknown", guidance: null };
+    };
+    // boot 失败分类：升级缓存残留 → restart-needed（需重启宿主，停等）；其余文本经错误
+    // 分类器归类（多为 unknown → 保守退避；含网络/环境/声明特征时正确归类）
+    const classifyBootFailure = (text) => {
+      const t = String(text || "");
+      if (ENOENT_TEXT_RE.test(t) && STALE_PNPM_RE.test(t)) {
+        return {
+          errorClass: "restart-needed",
+          guidance:
+            "检测到 dsh 跨版本升级缓存残留：请重启 Hana 加载新版本（重启后插件会自动续跑，无需其它操作）",
+        };
+      }
+      return classifyInstallError({ milestoneLog: t });
+    };
+    // 失败处理（状态记录 + 决策 + 通知/日志；见机器头注释「失败决策」「通知纪律」）。
+    // stage: "deps" | "boot"；返回 false = 本次评估到此为止（已退避定时或停等）
+    const handleFailure = (stage, cls, errText, guidance) => {
+      const klass = cls || "unknown";
+      const text = String(errText || "未知原因").slice(0, 600);
+      const stageLabel = stage === "deps" ? "依赖安装" : "web host 启动";
+      g.boot.attempt += 1;
+      g.boot.phase = "waiting";
+      g.boot.errorClass = klass;
+      g.boot.lastError = text;
+      const head = text.split("\n")[0].slice(0, 160);
+      // 通知纪律：同一失败原因（阶段+类别+错误首行）只主动通知一次；后续重试只打进度日志
+      const notifyKey = stage + ":" + klass + ":" + head;
+      const guide = guidance || ERROR_CLASS_GUIDANCE[klass] || "";
+      if (notifyKey !== lastNotifiedKey) {
+        lastNotifiedKey = notifyKey;
+        g.appendLog?.(
+          "hana",
+          `[自动链] ${stageLabel}失败（第 ${g.boot.attempt} 次尝试）：${head}（errorClass=${klass}）`,
+        );
+        if (guide) g.appendLog?.("hana", "[自动链] 指引：" + guide);
+      }
+      if (IRRECOVERABLE_CLASSES.has(klass)) {
+        // 不可自动恢复：停 + 等条件变化（不设退避定时器；重载/重启/配置变化后自动续跑）
+        stopConfigWatch();
+        g.boot.nextRetryAt = null;
+        g.appendLog?.(
+          "hana",
+          `[自动链] ${stageLabel}失败属不可自动恢复类（${klass}）：自动链停等，${
+            CONFIG_CONTINUE_CLASSES.has(klass)
+              ? "配置（nodejsPath 等）保存后自动续跑"
+              : "插件更新或重启宿主后自动续跑"
+          }，无需手动操作`,
+        );
+        if (CONFIG_CONTINUE_CLASSES.has(klass)) watchConfigForContinue();
+        return false;
+      }
+      // 可恢复：退避重试（后台 setTimeout 链；attempt 递增取档，超出取 30m cap）
+      const idx = Math.min(g.boot.attempt - 1, BACKOFF_MS.length - 1);
+      const delayMs = BACKOFF_MS[idx];
+      stopConfigWatch();
+      g.boot.nextRetryAt = Date.now() + delayMs;
+      g.appendLog?.(
+        "hana",
+        `[自动链] ${stageLabel}失败（第 ${g.boot.attempt} 次，${klass}）：将于 ${fmtClock(g.boot.nextRetryAt)}（${fmtDelay(delayMs)} 后，第 ${g.boot.attempt + 1} 次）自动重试`,
+      );
+      scheduleRetry(delayMs);
+      return false;
+    };
+    // 停等续跑：监听 dataDir/config.json 变化（fs.watch 目录 + 防抖）→ 变化即重新评估。
+    // 目录级 watch 对「直接改写 / 原子替换落盘」两种形态都报文件名，过滤 config.json 即可
+    // （日志写子目录不命中）；watch 建立失败降级（退化为等重载/重启续跑，不阻断）。
+    const watchConfigForContinue = () => {
+      stopConfigWatch();
+      try {
+        configWatch = watch(dataDir, (eventType, filename) => {
+          const base = String(filename || "")
+            .replace(/\\/g, "/")
+            .split("/")
+            .pop();
+          if (base !== "config.json") return;
+          if (unloaded) return;
+          if (configWatchTimer) clearTimeout(configWatchTimer);
+          configWatchTimer = setTimeout(() => {
+            configWatchTimer = null;
+            if (unloaded) return;
+            g.appendLog?.("hana", "[自动链] config.json 变化，重新评估自动链…");
+            kickAutoChain();
+          }, 500);
+        });
+      } catch (e) {
+        configWatch = null;
+        g.appendLog?.(
+          "hana",
+          "[自动链] config 续跑 watch 建立失败（等重载/重启续跑）：" +
+            (e?.message || e),
+        );
+      }
+    };
+    // installDepsFromPlugin 的并发守卫在依赖操作进行中（g.deps.status 为 installing/
+    // running，他人路径已触发）直接返回占位不等待其完成——自动链需要等它落终态再启动
+    // web host，否则 boot 撞上未装完的依赖图白白失败一次。轮询 g.deps.status（2s 间隔，
+    // 上限 300s 覆盖极端长安装）——仅在此等待窗口轮询（机器常态无轮询）；超时返回 false
+    // 不抛（调用方按未知可恢复退避，等安装真正结束后下一轮续跑）。
+    const waitDepsSettled = async () => {
+      const deadline = Date.now() + 300000;
+      for (;;) {
+        const st = g.deps && g.deps.status;
+        if (st !== "installing" && st !== "running") return true;
+        if (Date.now() > deadline) return false;
+        await new Promise((r) => setTimeout(r, 2000));
+        // 等待期间卸载/重载：提前退出免空转（调用方同样在日志前拦截，见下）
+        if (unloaded) return false;
+      }
+    };
+    // ---- phase ensure-deps：依赖幂等检查/安装（g.installDeps 现状语义保留：cliBin 在且
+    // 版本===声明 → skipped 秒回；缺失/漂移/不完整才 pnpm install --prod）----
+    // 返回 true = 依赖就绪可进 booting；false = 失败已决策（退避定时/停等）或已卸载
+    const ensureDepsStage = async () => {
+      g.boot.phase = "ensure-deps";
+      if (unloaded) return false;
+      try {
+        if (typeof g.installDeps !== "function") {
+          // 能力缺失（installDeps 与 startWebHost 同在 lifecycle 顶层挂载，正常挂载后不
+          // 可能；防御分支）：跳过自动安装直接尝试 boot（旧链同语义，boot 失败按分类决策）
+          g.appendLog?.(
+            "hana",
+            "installDeps 能力未挂载，跳过启动前依赖自动安装（随首次工具调用启动）",
+          );
+          return true;
+        }
+        g.appendLog?.("hana", "启动前依赖自动安装：检查 dsh 依赖就绪…");
+        const r = await g.installDeps(config, dataDir);
+        if (unloaded) return false;
+        if (r && r.ok) {
+          g.appendLog?.(
+            "hana",
+            r.skipped
+              ? "依赖已就绪（与声明一致，跳过安装）"
+              : "依赖安装完成（pnpm install --prod，registry 兜底 + 自动核对）",
+          );
+          return true;
+        }
+        if (r && r.state === "installing") {
+          // 并发窗口：他人路径（dsh_install 工具/标签页）正在安装，等其落终态再续
+          g.appendLog?.(
+            "hana",
+            "依赖安装已在其他路径进行中，等待完成后再启动 web host…",
+          );
+          const settled = await waitDepsSettled();
+          // 等待期间卸载/重载：静默退出，不打「超时/继续」误导日志
+          if (unloaded) return false;
+          const st = g.deps && g.deps.status;
+          if (!settled) {
+            // 300s 仍未落终态（极端长安装/他人路径挂起）：不盲目 boot 撞未装完依赖图——
+            // 按未知可恢复退避，等安装真正结束后下一轮自动续跑
+            g.appendLog?.(
+              "hana",
+              "依赖安装等待超时（300s，当前未就绪），自动链稍后重新检查",
+            );
+            return handleFailure(
+              "deps",
+              "unknown",
+              "依赖安装等待超时（300s）未落终态",
+              null,
+            );
+          }
+          if (st === "error") {
+            // 他人路径安装失败：errorClass 已由 install 失败路径落 g.deps.errorClass
+            const ec = readDepsErrorClass();
+            g.appendLog?.("hana", "依赖安装已结束（error），按失败分类决策");
+            return handleFailure(
+              "deps",
+              ec.errorClass,
+              g.deps?.error || "依赖安装失败（其他路径）",
+              ec.guidance,
+            );
+          }
+          g.appendLog?.(
+            "hana",
+            "依赖安装已结束（" + (st || "?") + "），继续启动 web host",
+          );
+          return true;
+        }
+        // 本次调用失败（ok:false state:error 或未知返回形态）：errorClass 决策
+        const ec = readDepsErrorClass();
+        return handleFailure(
+          "deps",
+          ec.errorClass,
+          (r && (r.error || r.state)) || "依赖自动安装未成功（未知原因）",
+          ec.guidance,
+        );
+      } catch (e) {
+        // installDeps 内部异常（契约上不抛；防御）：无分类依据 → 未知保守退避
+        g.appendLog?.(
+          "hana",
+          "启动前依赖自动安装异常：" + (e?.message || String(e)),
+        );
+        return handleFailure("deps", "unknown", String(e?.message || e), null);
+      }
+    };
+    // ---- phase booting：startWebHost（进程内 boot dsh；fire-and-forget 语义保留——不
+    // await 端口就绪拖住宿主启动，startWebHostFromPlugin 内部已 try/catch 记 webLastError
+    // 返回布尔）---- 返回 true = 就绪收敛；false = 失败已决策（退避定时/停等）
+    const bootStage = async () => {
+      g.boot.phase = "booting";
+      if (unloaded) return false;
+      try {
+        const ok = await Promise.resolve(g.startWebHost(config, dataDir)).then(
+          (v) => v === true,
+          (e) => {
+            // startWebHost 内部 catch 不应 reject；双兜底（旧链同款）
+            log.warn?.(
+              "[dsh-hanako] web host 启动异常:",
+              e?.message || String(e),
+            );
+            g.appendLog?.(
+              "hana",
+              `web host 启动异常：${e?.message || String(e)}`,
+            );
+            return false;
+          },
+        );
+        if (unloaded) return false;
+        if (ok) {
+          log.info("[dsh-hanako] DSH web host 已随插件异步启动");
+          g.appendLog?.("hana", "DSH web host 启动成功，自动链收敛（ready）");
+          convergeReady();
+          return true;
+        }
+        // 启动失败：g.webLastError 已由 startWebHostFromPlugin 记录（message + stderr 尾 +
+        // 日志路径，boot 诊断就位）；按失败文本归类决策
+        const cls = classifyBootFailure(
+          String(g.webLastError || "web host 启动未就绪"),
+        );
+        g.appendLog?.("hana", "DSH web host 启动未就绪，按失败分类决策");
+        return handleFailure(
+          "boot",
+          cls.errorClass,
+          String(g.webLastError || "web host 启动未就绪"),
+          cls.guidance,
+        );
+      } catch (e) {
+        // 防御兜底（startWebHost 不应抛）
+        g.appendLog?.(
+          "hana",
+          "web host 启动异常：" + (e?.message || String(e)),
+        );
+        return handleFailure("boot", "unknown", String(e?.message || e), null);
+      }
+    };
+    // ---- 状态机一次推进：ensure-deps → booting → ready；失败由 handleFailure 决策并停止
+    // 本次评估（退避定时/停等）。由 kickAutoChain 串行调用（machineBusy 互斥）。
+    const runMachineEval = async () => {
+      if (unloaded) return;
+      // 快速路径：web host 已就绪（前次成功 / 手动·工具路径已拉起）→ 直接收敛（重入安全）
+      if (g.web && g.web.ready) {
+        g.appendLog?.("hana", "[自动链] web host 已就绪，自动链收敛");
+        convergeReady();
+        return;
+      }
+      const depsReady = await ensureDepsStage();
+      if (!depsReady || unloaded) return; // ensureDepsStage 已决策或卸载中止
+      // 依赖段（含并发等待）期间他人路径可能已拉起 web host：再查一次快速路径
+      if (g.web && g.web.ready) {
+        convergeReady();
+        return;
+      }
+      await bootStage();
+    };
+    // 挂载探测：<1s 等工具模块挂上（tools 模块由宿主在激活期间 import，可能晚于本 onload；
+    // 单例方法挂上后才触发自动链）。挂载探测失败（1s 内未挂上）不放弃自动链：转入后台延后
+    // 等待（60s 兜底、1s 间隔），单例方法挂上后补跑同一自动链——不让短暂探测窗口丢失
+    // 「自动安装 + web host 自启」承诺（否则延迟挂载的冷启动只能等工具调用才自愈）；
+    // 仍未挂载才降级随工具调用启动。
     const waitMount = (async () => {
       for (let i = 0; i < 20; i++) {
         // 最多约 1s 等工具模块挂载（远小于旧的 5s 轮询与 60s 端口就绪等待）
@@ -230,114 +629,13 @@ export default class DshHanakoPlugin {
       }
       return false;
     })();
-    // installDepsFromPlugin 的并发守卫在依赖操作进行中（g.deps.status 为 installing/
-    // running，他人路径已触发）直接返回占位不等待其完成——自动链需要等它落终态再启动
-    // web host，否则 boot 撞上未装完的依赖图白白失败一次。轮询 g.deps.status（2s 间隔，
-    // 上限 300s 覆盖极端长安装）；超时返回 false 不抛（继续启动尝试，语义与失败一致）。
-    const waitDepsSettled = async () => {
-      const deadline = Date.now() + 300000;
-      for (;;) {
-        const st = g.deps && g.deps.status;
-        if (st !== "installing" && st !== "running") return true;
-        if (Date.now() > deadline) return false;
-        await new Promise((r) => setTimeout(r, 2000));
-        // 等待期间卸载/重载：提前退出免空转（调用方在打日志前同样拦截，见下）
-        if (unloaded) return false;
-      }
-    };
-    // 启动自动链：依赖安装（幂等，见上方注释）→ web host 启动。installDeps 与
-    // startWebHost 在 lifecycle.js 顶层同批挂载（mountLifecycle），调用方已确认
-    // startWebHost 挂载；installDeps 缺失时单独跳过自动安装降级为现状（web host
-    // 随首次工具调用启动）。依赖安装段 catch 全部错误不抛出（记日志），web host
-    // 启动段双参 .then 吞掉 reject，本函数不向外抛——waitMount 链永不因启动失败炸。
-    const runStartupAutoChain = async () => {
-      // 插件已卸载/重载（清理回调已置位）：放弃自动链，不再装依赖/起 host
-      if (unloaded) return;
-      // 启动前依赖自动安装（与 startWebHost 同一后台链，先后执行）
-      try {
-        if (typeof g.installDeps !== "function") {
-          g.appendLog?.(
-            "hana",
-            "installDeps 能力未挂载，跳过启动前依赖自动安装（随首次工具调用启动）",
-          );
-        } else {
-          g.appendLog?.("hana", "启动前依赖自动安装：检查 dsh 依赖就绪…");
-          const r = await g.installDeps(config, dataDir);
-          if (r && r.ok) {
-            g.appendLog?.(
-              "hana",
-              r.skipped
-                ? "依赖已就绪（与声明一致，跳过安装）"
-                : "依赖安装完成（pnpm install --prod，registry 兜底 + 自动核对）",
-            );
-          } else if (r && r.state === "installing") {
-            // 并发窗口：他人路径（dsh_install 工具/标签页）正在安装，等其落终态
-            g.appendLog?.(
-              "hana",
-              "依赖安装已在其他路径进行中，等待完成后再启动 web host…",
-            );
-            const settled = await waitDepsSettled();
-            // 等待期间卸载/重载：静默退出，不打「超时/继续尝试启动」误导日志
-            if (unloaded) return;
-            const st = g.deps && g.deps.status;
-            g.appendLog?.(
-              "hana",
-              settled
-                ? "依赖安装已结束（" + (st || "?") + "）"
-                : "依赖安装等待超时（300s），继续尝试启动 web host",
-            );
-          } else {
-            g.appendLog?.(
-              "hana",
-              "依赖自动安装未成功：" +
-                ((r && (r.error || r.state)) || "未知原因") +
-                "，继续尝试启动 web host（失败将记入诊断，可工具/标签页重试）",
-            );
-          }
-        }
-      } catch (e) {
-        g.appendLog?.(
-          "hana",
-          "启动前依赖自动安装异常：" + (e?.message || String(e)),
-        );
-      }
-      // 依赖工作（含并发等待/长安装）期间可能已卸载：清理回调已回收 web host，
-      // 这里不再启动（否则卸载后残留悬挂服务）。
-      if (unloaded) {
-        g.appendLog?.("hana", "插件已卸载/重载，跳过 web host 启动");
-        return;
-      }
-      // fire-and-forget：不 await 端口就绪（避免 ensureWebHost 60s 等拖住宿主启动）。
-      // startWebHostFromPlugin 内部已 try/catch 记 webLastError 返回布尔，这里双兜底。
-      await Promise.resolve(g.startWebHost(config, dataDir)).then(
-        (ok) => {
-          log.info(
-            `[dsh-hanako] DSH web host ${ok ? "已随插件异步启动" : "启动未就绪（工具调用时将重试）"}`,
-          );
-          g.appendLog?.(
-            "hana",
-            `DSH web host 启动${ok ? "成功（已随插件异步启动）" : "未就绪（工具调用时将重试）"}`,
-          );
-        },
-        (e) => {
-          log.warn?.(
-            "[dsh-hanako] web host 启动异常:",
-            e?.message || String(e),
-          );
-          g.appendLog?.(
-            "hana",
-            `web host 启动异常：${e?.message || String(e)}`,
-          );
-        },
-      );
-    };
     // 挂载确认：initial=true（waitMount 已挂上）直接通过；否则后台延后等待（60s 兜底、
     // 1s 间隔）直到 startWebHost 挂载。超时返回 false（调用方降级随工具调用启动）。
     const ensureMounted = async (initial) => {
       if (initial) return true;
       const deadline = Date.now() + 60000;
       while (Date.now() < deadline) {
-        // 卸载/重载：放弃等待（runStartupAutoChain 入口同样拦截，这里提前退出免空转）
+        // 卸载/重载：放弃等待（自动链入口同样拦截，这里提前退出免空转）
         if (unloaded) return false;
         await new Promise((r) => setTimeout(r, 1000));
         if (g && typeof g.startWebHost === "function") return true;
@@ -355,7 +653,7 @@ export default class DshHanakoPlugin {
           );
           g.appendLog?.(
             "hana",
-            "1s 内未等到工具模块加载，转入后台等待挂载（最长 60s），挂载后自动补跑依赖安装与 web host 启动",
+            "1s 内未等到工具模块加载，转入后台等待挂载（最长 60s），挂载后自动补跑自动链",
           );
         }
         const ready = await ensureMounted(mounted);
@@ -370,7 +668,9 @@ export default class DshHanakoPlugin {
           );
           return;
         }
-        await runStartupAutoChain();
+        // 挂载就绪：启动自动链状态机首跑（fire-and-forget，onload 不等待其落终态；后续由
+        // 退避定时/条件变化续跑，无常驻轮询——详见上面自动链注释）
+        kickAutoChain();
       })
       .catch((e) => {
         log.warn?.("[dsh-hanako] web host 启动异常:", e?.message || String(e));

--- a/src/tools/lib/state.js
+++ b/src/tools/lib/state.js
@@ -29,6 +29,10 @@
 //     update 任一进行中另一动作拒绝；tools/dsh-install.js 同步段检查/置位、操作完成
 //     释放；能力层守卫 g.deps.status / g.update.status 保留为 webui 路由等其他调用
 //     路径双保险；verify/check 不占用）
+//   g.boot   = { phase, attempt, nextRetryAt, errorClass, lastError, timer? }
+//     启动自动链状态机（T2 spec：dsh-deps-zero-intervention 新增设计 2；index.js onload
+//     维护：ensure-deps/waiting/booting/ready + 失败退避重试，见 index.js 自动链注释）——
+//     本函数只做兜底初始化，不驱动状态（与 g.update/g.deps 同款热更新兼容语义）
 // status 值域统一：idle / running(installing) / ok / error，由各链路定义模块在状态
 // 变化点显式维护。g.update.log 定义为 getter 投影 g.deps.log（updateDsh 内部走
 // installDepsFromPlugin 写同一日志尾环，同源实时可见，不复制字符串）。
@@ -180,6 +184,26 @@ export function getSingleton() {
   // 进行中另一动作拒绝（install ↔ update 互斥）；null = 无进行中依赖操作。热更新
   // 兼容：旧 globalThis 对象可能缺该字段，逐字段兜底为 null。
   if (g.depBusy === undefined) g.depBusy = null;
+  // T2 启动自动链状态机（spec：dsh-deps-zero-intervention 新增设计 2）——g.boot 兜底初始化。
+  // index.js 把启动自动链（旧一次性链）状态机化后的持久状态（index.js 经 globalThis 访问
+  // 本对象，见文件头「非 bundle 侧」纪律；本函数只兜底字段不驱动）：
+  //   phase        值域 ensure-deps | waiting | booting | ready（流转见 index.js 自动链注释）
+  //   attempt      连续失败尝试计数（可恢复退避取档用；收敛 ready 时归零）
+  //   nextRetryAt  下次自动重试时刻（Date.now() ms；停等类 = null = 不自动重试，等条件变化）
+  //   errorClass   最近失败分类（install 六类 network/macos-signature/native-toolchain/
+  //                declaration/environment/unknown；boot 升级缓存残留另归 restart-needed；
+  //                成功收敛/从未失败 = null）
+  //   lastError    最近失败可读文本（截断；成功收敛/从未失败 = null）
+  //   timer        后台退避 setTimeout 句柄（index.js 维护：调度置位、到点/卸载/收敛清理；
+  //                句柄不跨会话有效——卸载即清，重载后新 onload 重新调度）
+  // 热更新兼容同款（见「分组状态」注释）：旧 globalThis 对象缺该对象/字段时逐个兜底，
+  // 不重置已存在的运行期值（终态跨热更新可见，下次自动链入口才覆盖）。
+  if (!g.boot || typeof g.boot !== "object") g.boot = {};
+  if (g.boot.phase === undefined) g.boot.phase = "ensure-deps";
+  if (g.boot.attempt === undefined) g.boot.attempt = 0;
+  if (g.boot.nextRetryAt === undefined) g.boot.nextRetryAt = null;
+  if (g.boot.errorClass === undefined) g.boot.errorClass = null;
+  if (g.boot.lastError === undefined) g.boot.lastError = null;
   if (!g.check || typeof g.check !== "object") g.check = {};
   if (g.check.status === undefined) g.check.status = "idle";
   if (g.check.result === undefined) g.check.result = null;


### PR DESCRIPTION
T2 自动链状态机 + 退避重试（spec: dsh-deps-zero-intervention tasks.md T2）。把 onload 的一次性启动链升级为持久状态机：依赖失败按 errorClass 决策、可恢复类退避重试、不可恢复类停等 + 条件续跑。

## 改动

**src/index.js**（runStartupAutoChain → 状态机，+421/-97）
- 状态 `g.boot = { phase, attempt, nextRetryAt, errorClass, lastError, timer }`，phase 流转 ensure-deps → waiting → booting → ready
- **ensure-deps**：g.installDeps 幂等语义保留；并发 installing 沿用 waitDepsSettled 等待；300s 超时不再盲目 boot（改 unknown 退避，等安装真正结束后续跑）；他人路径失败按 g.deps.errorClass 决策
- **booting**：startWebHost fire-and-forget 保留；失败经 classifyBootFailure 归类——升级缓存残留（ENOENT + .pnpm/@deepseek-ai+dsh@，与 pickProcessFix 同源特征）→ `restart-needed` 停等；其余喂 classifyInstallError
- **waiting**：可恢复（network/environment/unknown/native-toolchain）→ 退避 30s→2m→10m→30m cap（attempt 取档，日志记第 N 次 + 下次时间）；不可恢复（macos-signature/declaration/restart-needed）→ 停 + 通知一次；macos-signature 额外挂 fs.watch dataDir/config.json（防抖 500ms）→ 设置保存即自动续跑
- **ready**：convergeReady 清 timer/watch、attempt/errorClass/lastError 归零；g.web.ready 快速路径重入安全
- 通知纪律：notifyKey（stage+errorClass+错误首行）去重，同一原因只通知一次；后续重试只打进度日志
- unload/重载全路径覆盖（install/boot 前、退避回调、config 防抖、等待窗口），卸载清理 clearBootTimer + stopConfigWatch；machineBusy 互斥串行
- 无常驻轮询：onload 首跑 + 退避 setTimeout 链 + config 事件续跑

**src/tools/lib/state.js**（+24）：g.boot 兜底初始化（热更新兼容，不重置运行期值）

## 验证

- `node --check` 两文件通过；errclass 14 单测全绿
- `node scripts/build.mjs` rspack 单 bundle 构建通过（静态断言 ok）
- 未引入新 spawn/子进程；未动 package.json；未触碰前端/路由（T3/T4/T5 范围外）

## 待实装验证

断网启动 → 自动链退避挂起（日志可见第 N 次/下次时间）；网络恢复自动完成；不可恢复类（declaration）停等不空转；升级缓存残留归 restart-needed 提示重启（与 boot 诊断指引同源）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a persistent startup process that installs required dependencies, launches the web host, and waits until it is ready.
  * Added automatic retries with backoff for recoverable startup errors.
  * Startup now responds to configuration changes and avoids duplicate notifications.
  * Stopping or unloading the app cancels pending startup work.

* **Bug Fixes**
  * Startup no longer proceeds after dependency installation failures.
  * Improved handling and reporting of unrecoverable startup errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->