### PR TITLE
feat: 依赖零干预 T3-T6——自举快照端点 + Bootstrap 壳页 + 入口退役 + 文档

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.0.0-beta.2（2026-09-02）
+
+- **自动链状态机化 T2**（PR #55，spec：dsh-deps-zero-intervention）：一次性启动链升级为持久状态机，状态存单例 `g.boot`——phase 流转 ensure-deps（依赖幂等安装，失败按 errorClass 决策）→ waiting（退避等下一尝试 / 不可恢复停等条件变化）→ booting（startWebHost）→ ready（收敛）。可恢复失败（network/environment/unknown/native-toolchain）后台退避重试 30s→2m→10m→30m（cap，插件生命周期内持续）；不可恢复类（macos-signature/declaration/restart-needed）停等 + 通知一次，macos-signature 挂 config.json watch（保存即自动续跑）；同一失败原因只通知一次。卸载/重载安全（unloaded 标记覆盖全部异步边界 + 清退避定时/config watch）。
+- **自举状态快照端点 T3**：新增 `GET /webui/boot-state`——g.boot 状态机 + g.deps（T1 errorClass/guidance）+ g.web 就绪收敛成单一状态出口 `{ phase, ready, deps:{status,errorClass,guidance,error,version,logTail}, boot:{attempt,nextRetryAt,errorClass,guidance,lastError}, web:{ready,lastError} }`（字段全显式空值兜底）；失败决策 guidance 随 `g.boot.guidance` 持久（index.js/state.js 极小联动）。
+- **Bootstrap 自举壳页重写 T4**：DSHana 标签页从「诊断壳 + 手动操作面板」重写为三态自举页——booting（阶段时间线 + 安装实时日志尾滚动 + 退避倒计时）/ action-needed（errorClass 人话 + 明确操作步骤 + 自动续跑/停等说明，原始错误折叠详情）/ ready（iframe 直嵌现状保留）。数据源 = boot-state 快照 + /webui/events 事件流；删除功能面板 actions 段、t1/t2 诊断卡片、门禁链与全部手动按钮。
+- **手动入口退役 + 路由清理 T5**：删除 `/webui/start`、`/webui/install-deps`、`/webui/verify-deps`、`/webui/health` 路由；`collectWebDiagnostics` / `buildDepsDiagCheck` / `buildProcessDiagCheck` / `pickProcessFix` / `readLogTail` 及挂载/readDiagnostics/probeHost 整体退役删除（浏览器侧 checks 展示层废弃，日志诊断保留会话文件）；/webui/events 的 diagnostics 载荷事件收敛为 `diag-changed` 信号（无载荷，壳页刷新 boot-state）。
+- **文档同步 T6**：README 安装引导改全自动（无手动按钮/人工 pnpm 指引移除）、排错按 errorClass/三态；dsh-hanako/dsh-install SKILL 同步现状（verify 静态核对语义、自动链、页面三态）；DESIGN 依赖生命周期章节 + 已知限制补「dsh 升级需重启宿主」。
+
 ## v1.0.0-beta.1（2026-09-02）
 
 - **依赖零干预 T1：错误分类器**（PR #50，spec：dsh-deps-zero-intervention）：新增 `src/tools/lib/errclass.js` 纯函数 `classifyInstallError`——install 失败从「只看 exit 1」升级为六类 errorClass（network / macos-signature / native-toolchain / declaration / environment / unknown）+ 一句中文 guidance，匹配优先级从具体到一般。`run()` 失败结构化 throw（message 可读、原始 stdout/stderr 尾 + 退出码附 Error）；外层 catch 归类存 `g.deps.errorClass`；声明非法分支同步产出 declaration；新尝试起点清旧分类。回归样本四类全收（koffi ELIFECYCLE / ENOENT 缓存残留 / typert 133 / 网络断），ENOENT 归属 unknown 已论证。引入项目首个单测（Node 内置 node:test，零新依赖），14 用例覆盖特征/优先级/回归/容错。CodeRabbit 两轮闭环：分类器分层判定（tail 决定性 + milestoneLog 兜底），最终 registry 尝试决定分类。

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -30,7 +30,7 @@ Hana 宿主进程
 | 工具 | 用途 | 调用手册 |
 | --- | --- | --- |
 | `dsh_session` | 会话全生命周期：list（清单）/ get（凭 sessionId 取内容）/ create（新建+提交）/ send（续会话，resume）/ cancel（取消）。合并原 dsh_run / dsh_cancel | [dsh-session](skills/dsh-session/SKILL.md) |
-| `dsh_install` | 依赖安装/验证两合一（action=install 按声明 pnpm install --prod 到插件根 + autoStart + 安装卡片；verify 运行级冒烟）。版本严格锁声明 | [dsh-install](skills/dsh-install/SKILL.md) |
+| `dsh_install` | 依赖安装/验证两合一（action=install 按声明 pnpm install --prod 到插件根 + autoStart + 安装卡片；verify 静态核对，无子进程）。版本严格锁声明 | [dsh-install](skills/dsh-install/SKILL.md) |
 | `dsh_approve` | 应答 DSH 任务挂起的权限审批（allowed-once / rejected）——独立保留（权限应答语义正交，非会话操作） | [dsh-approve](skills/dsh-approve/SKILL.md) |
 
 任务提交链路（dsh_session create/send）：`session.create`（新建 `{cwd, agentPreset?}`；send 沿用会话 cwd）→ `selectModel`（仅显式传 provider/model/effort 时）→ `session.prompt`（mode=queue）→ 经总线 events 频道（bus 插件订阅 `$events` 转发）→ 终态（`api-session/status false` = end_turn）。deferred taskId = 任务 rpcId，完成宿主唤醒。
@@ -39,8 +39,8 @@ Hana 宿主进程
 
 配置 `webPort`（默认 3080）时插件加载即**进程内 boot**，DSHana 以整页卡片注册（manifest `contributes.cards[]`，id `dshana`，route `/webui`），卡片 iframe 内嵌 `http://127.0.0.1:<webPort>/`（根路径，免鉴权）：
 
-- **就绪事件化**：按总线连接状态判定——已连接直接渲染 iframe；未连接渲染加载态并订阅 `GET /webui/events` 就绪事件流（bus ready → 挂载；启动失败推 diagnostics；停机推 pending）。30s 超时兜底引导看诊断
-- **功能面板（functionPanel）**：status 段（web host 状态）+ actions 段（手动启动/安装依赖/检测依赖/复制日志路径）+ meta 段（日志路径），经 `hana.panel` 原语渲染
+- **三态自举页（Bootstrap 壳，T4）**：按总线连接状态判定——已连接直接渲染 iframe；未连接渲染自举页，数据源 = `GET /webui/boot-state`（T3 单一状态出口）+ `GET /webui/events` 事件流（ready/pending/diag-changed/theme-pref）：booting（阶段时间线 + 安装实时日志 + 退避信息）/ action-needed（errorClass 人话 + 操作步骤 + 自动续跑/停等说明）/ ready（iframe 直嵌）。**页面无任何手动按钮**
+- **功能面板（functionPanel）**：仅 status 段（web host 状态：运行中/自举中/需要处理），actions 段已随手动入口退役（T5）
 - **iframe 主题桥**：壳页 postMessage 回传宿主主题 vars → 注入的 theme 插件写 body 层 `!important` 覆盖（`--dsw-alias-*` + `--dsw-specific-*` token 映射，无静态主题表）；DSH 偏好 `system`（默认）跟随宿主明暗 + 配色，`light`/`dark` 用原生；偏好变更经 3s 轻量轮询 `settings/describe` 实时重评（旧 events.host WS 端点已随 DSH 0.1.2 退役）
 
 ### DSHana 设置分页
@@ -56,15 +56,18 @@ DSH 设置页「DSHana 设置」分页（settings.section slot，id `dshana-sett
 
 `@dsh-hanako/theme` 经 tapIndex 注入 index 响应：静态 fallback（DEFAULT_THEME）+ 动态脚本（postMessage 向壳页索取 `{ themeId, vars }` → 写 body 层 `!important` 覆盖）。DSH 偏好经 `settings/describe` 读取（加载一次 + 3s 轻量轮询，`document.hidden` 时暂停），`system` 应用壳桥 vars、`light`/`dark` 完全原生。
 
-## 连接失败自检与自愈
+## 启动自动链与错误分类（T1-T5）
 
-web host 未就绪时 DSHana 标签页展示自检诊断：t1 依赖（cliBin 存在性 + 部署状态 + 运行级验证）、t2 进程（进程内形态——ready=boot 结果，无子进程 PID）。操作：手动启动 / 安装依赖 / 检测依赖 / 复制日志路径。
+- **自动链状态机（T2）**：插件 onload 后后台推进 `ensure-deps → booting → ready`（状态存单例 `g.boot = { phase, attempt, nextRetryAt, errorClass, guidance, lastError, timer }`）：依赖幂等安装（按插件根声明 pnpm install --prod，npmmirror 兜底）→ 进程内启动 web host → 收敛。失败退避 30s→2m→10m→30m 自动重试；不可恢复类（macos-signature / declaration / restart-needed）停等条件变化（config 保存 / 插件更新 / 重启宿主），config 类挂 fs.watch 自动续跑
+- **错误分类（T1）**：install/boot 失败经 `classifyInstallError` 归六类 errorClass + 一句中文 guidance（存 `g.deps.errorClass` / `g.boot.guidance`）；restart-needed = dsh 跨版本升级缓存残留
+- **自举状态快照（T3）**：`GET /webui/boot-state` = `{ phase, ready, deps:{status,errorClass,guidance,error,version,logTail}, boot:{attempt,nextRetryAt,errorClass,guidance,lastError}, web:{ready,lastError} }`——页面/Agent 唯一状态出口
+- **Bootstrap 壳页（T4/T5）**：三态渲染见上；旧诊断壳（t1/t2 checks 展示、手动按钮、门禁链）与手动路由（/webui/start、/webui/install-deps、/webui/verify-deps、/webui/health）及 `collectWebDiagnostics` 家族整体退役删除
 
 ## 依赖部署与解耦（D6）
 
 - **pnpm 运行时引导**：`lib/pnpm.js` `ensurePnpm` 下载单文件 pnpm.mjs 到数据目录 pnpm-dist/（工具包不 import pnpm）；安装经子进程跑（`pnpm install --prod --reporter=ndjson` 到插件根）
-- **诊断不 import cordis**：`verifyDepsSmoke` spawn `node cliBin --version` 冒烟（只读，能跑 = 依赖图完整）；`readDshInstalledVersion` 直读插件 node_modules/@deepseek-ai/dsh/package.json
-- **node 代理**：数据目录 `pnpm-proxy/`（node.cmd/node 指向解析后的 node 执行体），PATH 首部指向它让 install script 找到宿主 node
+- **诊断不 import cordis**：`verifyDepsSmoke` 静态核对（cliBin 为常规文件 + 磁盘版本 === 插件声明，无子进程秒回；磁盘完整性由 pnpm install 保证、可运行性由 boot 裁决）；`readDshInstalledVersion` 直读插件 node_modules/@deepseek-ai/dsh/package.json
+- **node 代理**：插件根 node.cmd（与部署物同目录——历史数据目录 pnpm-proxy 漂移教训，PATH 与代理同源绑定），指向解析后的 node 执行体（默认宿主 electron node，配置 nodejsPath 时用系统 node），让 koffi/node-pty 的 install script 找到宿主 node
 - **进程内 boot 解耦**：`loadInprocDsh` 运行时动态 import（webpackIgnore 保留原生 import；枚举 profile-boot-*.js 试 runProfile；app-boot 定位 createRequire + .pnpm 枚举双保险）——插件 bundle 零 @deepseek-ai 静态引用，DSH 缺失时诊断/安装引导仍可用
 
 ## 进程间消息总线（dshana.bus）
@@ -77,6 +80,7 @@ web host 未就绪时 DSHana 标签页展示自检诊断：t1 依赖（cliBin �
 
 ## 已知限制
 
+- **升级 dsh = 装新插件包 + 重启宿主**：插件侧无法豁免宿主进程内 ESM 模块缓存（spec 决策，勿重走弯路）；跨版本升级后 boot 撞旧 .pnpm 路径 ENOENT → errorClass=restart-needed 停等，重启宿主后自动链自动续跑
 - **bash 工具在 Windows 上可能 `E_ACCESSDENIED`**（dsh-bash-sandbox 创建 bash 服务实例失败，属 DSH 沙箱环境限制）。文件系统工具正常，Windows 上优先用文件系统工具
 - **HMR 降级**：进程内 boot 无 `--expose-internals`，dshana profile 的 patchReload live 依赖 HMR 可能静默降级（patch 静态/重启生效，插件升级时 dispose+reboot 重载）
 - 越界权限请求默认走审批自动化：插件捕获 approval/requested → 通知 Agent → `dsh_approve` 应答；无人应答超时自动拒绝

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 
 1. **拖入 zip 包**：把插件的 release zip（`dsh-hanako-v<version>.zip`，从 GitHub Releases 下载）拖进 Hana 插件安装界面（或解压到插件目录），插件即完成装载
 
-2. **无需手动装依赖（自动）**：插件加载（onStartUp）时自动安装一次 DSH 依赖（幂等：已装且与插件声明版本一致 + 运行级验证通过则秒过跳过；缺失/版本漂移/依赖不完整才真跑 pnpm install --prod，官方源失败自动重试 npmmirror），装好后自动拉起 web host，首次启动即装完即用。**仅当自动安装失败（如离线/网络受限）时**才需人工介入：打开 DSHana 标签页（未就绪显示 t1/t2 自检）→ deps 卡片点「安装依赖」——页面自动完成部署，完成后去 t2 点「手动启动 web host」；**也可让 Agent 调 `dsh_install` 工具**（异步默认，渲染安装卡片显示实时 pnpm 日志，安装完成自动拉起 web host；`dsh_install(action="verify")` 只检测依赖完整性）。
+2. **全自动自举，无需手动**：插件加载（onStartUp）即启动自动链——依赖幂等检查/安装（已装且与插件声明版本一致 → 秒过；缺失/漂移才按声明 `pnpm install --prod`，官方源失败自动重试 npmmirror）→ 自动拉起 DSH web host（依赖装进插件根 node_modules，版本随插件声明）。DSHana 标签页是**三态自举页**（booting 进度 / action-needed 指引 / ready 直嵌 Web UI），**没有任何手动安装/启动/检测按钮**——自动链失败会按 errorClass 退避重试或停等给指引：需要用户动作时页面显示明确步骤（如 macOS 配 `nodejsPath`、装编译工具链、清理磁盘、dsh 升级后重启宿主），完成后**自动续跑**。Agent 需要显式安装/验证时可调 `dsh_install` 工具（action=install，渲染安装卡片实时 pnpm 日志并自动拉起 web host；action=verify 静态核对）。
 
 3. **验证**：装完让 Agent 跑一次 `dsh_session(action="create", task="…", cwd="<项目沙箱目录>")` 最小试任务验证，卡片不报 web host 错误即安装成功。
 
 **无需配置 API Key / 模型**：DSH 凭据由 @dsh-hanako/provider 插件直读 Hana 宿主 `provider-catalog.json`，模型跟随宿主 `models.json`。任务模型默认 = DSH 默认模型（`settings.yaml` 的 `agent-default-model`），可在 **DSH 设置页「DSHana 设置」分页**直接配置（页头下方「默认模型」卡片：Provider/模型/思考强度三级联动，保存即生效）；同分页的 **「DSH 版本」卡片**显示本地 DSH 版本（版本严格锁插件声明——更新 DSH = 更新插件发版）。`dsh_session` 工具参数 `provider` / `model` / `reasoningEffort` 可显式覆盖。
 
-安装遇到问题，把报错丢给 Agent 即可（技能里有完整排错表）。
+安装/启动遇到问题：DSHana 标签页会给出 errorClass 人话指引与自动续跑状态；排查细节把现象丢给 Agent（技能里有按 errorClass/三态组织的排错表）。
 
 ## 配置
 

--- a/skills/dsh-hanako/SKILL.md
+++ b/skills/dsh-hanako/SKILL.md
@@ -1,140 +1,84 @@
 ---
 name: dsh-hanako
-description: "dsh-hanako 插件（把 DeepSeek Harness 接进 Hana 的进程内嵌 subagent 执行器）的配置辅助与使用指南。触发场景：dsh-hanako 刚装好需要配置依赖/模型、依赖缺失需要安装（DSHana 标签页自装 / Agent 用 dsh_install 工具 / 手动 pnpm install）、标签页自检/自愈（安装依赖/手动启动/检测依赖/检查更新/更新 DSH）、web host 起不来（先看标签页自检 t1/t2）、DSH 任务失败排查、审批怎么应答、dsh_run/dsh_install/dsh_approve/dsh_cancel/dsh_session 怎么用（dsh_install 为 install/verify/check/update 四合一，vX 起合并原 dsh_update）、默认模型怎么配（DSH 设置页「DSHana 设置」分页，provider/model/思考三级联动）、DSH 版本检查与更新（dsh_install 工具 action=check/update / 设置页 DSH 版本块 / 标签页 deps 卡片）、安装/升级卡片（dsh_install 异步渲染 /card/dep 实时日志）、DeepSeek Harness 相关。遇到 dsh-hanako 相关需求优先读本技能再动手。"
+description: "dsh-hanako 插件（把 DeepSeek Harness 接进 Hana 的进程内嵌 subagent 执行器）的配置辅助与使用指南。触发场景：dsh-hanako 刚装好需要配置（默认即可，无需手动装依赖/配 Node）、DSHana 标签页显示自举中/需要处理（errorClass 人话指引）、web host 起不来（先开标签页看三态自举页：booting 阶段/action-needed 指引/ready 直嵌）、依赖缺失需安装或验证（Agent 用 dsh_install 工具 action=install/verify，页面无任何手动按钮）、DSH 任务失败排查、审批怎么应答、dsh_session/dsh_install/dsh_approve 怎么用、默认模型怎么配（DSH 设置页「DSHana 设置」分页，provider/model/思考三级联动）、DSH 版本（更新 DSH = 更新插件发版 + 重启宿主）、安装卡片（dsh_install 异步渲染 /card/dep 实时日志）、DeepSeek Harness 相关。遇到 dsh-hanako 相关需求优先读本技能再动手。"
 ---
 
 # dsh-hanako 配置辅助与使用指南
 
-把 DeepSeek Harness（DSH）接进 Hana：加载即拉起 DSH web host（--profile web），dsh_run 交任务给 DSH agent 执行，Web UI（http://127.0.0.1:3080）可见全部会话。
+把 DeepSeek Harness（DSH）接进 Hana：插件加载即启动**自动链状态机**（依赖自举 → 进程内拉起 DSH web host），DSH Web UI（http://127.0.0.1:3080）以 **DSHana 标签页**（Bootstrap 三态自举页）内嵌可见全部会话。
 
 ## 首次安装配置（Agent 辅助用户完成）
 
-config.json 由宿主设置界面生成、**不随包分发**。按序完成：
+config.json 由宿主设置界面生成、**不随包分发**，缺省全部可用，无需人工预配置：
 
-**0. 先看现状**：配置在 <宿主插件数据目录>/dsh-hanako/config.json（Windows 常见 %USERPROFILE%\.hanako\plugin-data\dsh-hanako\config.json）。**全新安装**：插件初始化自动生成默认配置（ensureConfigJson：无 config.json 时按 manifest 默认值生成 `{ schemaVersion, global, agents, sessions }`，已存在则不动，原子写 + 失败静默），无需手动保存，装完即可在设置界面看到默认值。**无需配置 API Key / 模型 / Node 路径**：凭据由 @dsh-hanako/provider 插件直读宿主 `provider-catalog.json`，模型跟随宿主 `models.json`（DSH models 页设置默认）；web host 默认使用宿主 electron 进程自身的 Node 运行时（`process.execPath`，`ELECTRON_RUN_AS_NODE=1`），**无需用户单独安装 Node.js**。可选配置 `nodejsPath`：macOS 上 Electron 内嵌 node 跑 pnpm 会触发签名校验失败（Electron 的 node 二进制非标准 node 签名），此时填系统 node 绝对路径（如 /opt/homebrew/bin/node），配置后 pnpm / web host 子进程改用自定义 node（下一次 spawn 生效）；已生成的 node 代理脚本（wrapper）在下次依赖安装时更新为新的 node 执行体；路径不存在、指向目录或不可执行时均发出警告并回退 Electron node。
+- **无需手动装依赖 / 无需 Node 路径**：插件加载（onStartUp）自动链会幂等检查并按插件声明（插件根 package.json 的 dependencies，固定版本）自动 `pnpm install --prod` 装进**插件根 node_modules**，装好自动拉起 web host——全程无手动按钮。web host 默认用宿主 electron 自身 Node 运行时（`process.execPath`，`ELECTRON_RUN_AS_NODE=1`）。
+- **可选配置 `nodejsPath`**：macOS 上 Electron 内嵌 node 跑 pnpm 触发签名校验失败（macos-signature）时，在 **DSH 设置页「DSHana 设置」→ 自定义 NodeJS 路径**（或 config.json `global.nodejsPath`）填系统 node 绝对路径（如 /opt/homebrew/bin/node）；保存 config.json 后自动链会**自动续跑**（config watch），无需重启、无需手动操作页面。
+- **无需配置 API Key / 模型**：凭据由 @dsh-hanako/provider 直读宿主 `provider-catalog.json`，模型跟随宿主 `models.json`。任务默认模型 = DSH 默认模型，可在「DSHana 设置」分页「默认模型」卡片配置（provider/model/思考三级联动）。
+- **DSH 版本卡片**：只显示本地 DSH 版本 + 「更新 DSH = 更新插件发版」说明；**升级 dsh = 装新插件包 + 重启宿主**（进程内 ESM 缓存豁免不可行，见已知限制）。
+- `dsh_session(action="create")` 每次调用**必须显式传 `cwd`**（defaultCwd 已删除）。
 
-**cwd 无配置回退**：`dsh_session create` 每次调用必须显式传 `cwd` 指定沙箱工作目录（defaultCwd 配置已删除）。
+**配置生效（实时）**：nodejsPath 等配置运行期直读 config.json/单例（resolveNodeExec 每次 spawn 前解析），保存即对下一次子进程生效；停等类失败（macos-signature）保存 config.json 后自动链续跑。仅「进程内 boot 的旧模块缓存」类问题需要重启宿主（restart-needed，见下）。
 
-**1. 其余项默认可用**：approvalTimeoutSec（config.json `global.approvalTimeoutSec` 可配；未配置时回落 0 = 禁用自动拒绝）/ webPort（3080）/ defaultTimeoutSec（1800，秒）。agentPreset / reasoningEffort 不需要配置：工具不显式传时用 DSH 默认（DSH Web UI 可调 agent 预设与思考强度）。任务模型不需要配置：默认用 DSH 默认模型（settings.yaml `agent-default-model`），可在 **DSH 设置页「DSHana 设置」分页 → 「默认模型」卡片**直接配置（Provider/模型/思考强度三级联动，选项 = DSH 全部可用 provider，保存即生效），`dsh_run` 工具参数 `provider`/`model`/`reasoningEffort` 可显式覆盖（显式时 selectModel，DSH 会把所选模型写回全局默认 settings.yaml——显式指定即成为新默认）。**DSH 版本**：同分页「DSH 版本」卡片可检查 `@deepseek-ai/dsh` 版本并一键更新（卡片检查直查远端 latest，更新走宿主能力层；Agent 用 `dsh_install` 工具 action=check/update，未显式传 version/tag 时按配置基线 dshTag（默认 latest）执行）。
+## 启动自动链（T2 状态机，全自动，页面无手动入口）
 
-**2. 配置生效铁律（实时）**：「改完都要重启 Hana」不成立：t1 依赖/t2 进程状态直读 config.json/单例实时；t2 手动启动链路 resolveDshPkgDir → spawn，直写后无需重启；仅旧进程存活（g.web.ready=true）需先杀进程或重启。
+插件 onload 后自动链在后台推进（无常驻轮询，失败退避重试），阶段持久状态存单例 `g.boot`：
 
-## 依赖自主部署（页面自装首选，Agent pnpm install 兜底）
+1. **ensure-deps**：幂等检查/安装 dsh 依赖（cliBin 在且版本===声明 + 静态核对通过 → 秒过跳过；否则 pnpm install --prod，官方源失败自动切 npmmirror）→
+2. **booting**：进程内启动 DSH web host（`g.startWebHost`）→
+3. **ready**：收敛（web host 就绪，标签页直嵌 iframe）
 
-**启动自动安装（加载即自愈）**：插件加载（onStartUp）时在拉起 web host（WebUI/总线就绪点）**之前**自动装一次依赖——幂等：cliBin 在且已装版本 === 插件声明 + 运行级冒烟通过 → 秒过跳过；缺失/版本漂移/依赖不完整才真跑 `pnpm install --prod`（官方源失败自动重试 npmmirror），完成后自动拉起 web host，冷启动即装完即用，通常无需人工介入（自动链在后台 fire-and-forget 执行，不阻塞宿主启动；安装失败如离线时不阻断 web host 启动尝试，失败信息进诊断，工具调用/标签页仍可靠重试）。下方页面自装 / 手动命令是自动安装失败时的兑底路径。
+**失败决策（errorClass 分类，T1）**：install/boot 失败先分类再行动——
 
-DSH 依赖（@deepseek-ai/dsh + @deepseek-ai/cordis + node-pty/koffi）位置：**数据目录 dsh-pkg/**（优先，升级不丢依赖）→ 插件目录 node_modules（zip 自带，兑底）。部署 = 在 pkgDir 写入**声明 package.json**（dependencies 来自插件根 package.json 的 dependencies——T7a 起 DSH/cordis 固定版本声明进插件根，版本随插件发版，单一事实源；不复制 devDeps，插件根的 devDeps 是 rspack 构建树）+ 复制插件根 `pnpm-workspace.yaml`（`allowBuilds` 白名单放行 DSH 树 build scripts）→ 在 pkgDir 下创建指向解析后 node 执行体的代理脚本（node.cmd/node，优先有效 nodejsPath 配置，缺省 Electron 自带 node）→ 清理旧依赖残留（`package-lock.json` / `pnpm-lock.yaml` / 扁平 node_modules，npm 体系升级兼容）→ `node <pnpm 入口> install --reporter=ndjson`（按声明拉取）。pnpm 入口 = **运行时引导**（插件 `tools/lib/pnpm.js` `ensurePnpm`：下载 `pnpm-{version}` 的 `pnpm.mjs`（入口 CLI）+ `worker.js`（导入 worker，pnpm install/add 必需）到数据目录 `pnpm-dist/`，缓存独立于 dsh-pkg，zip 不再内置 node_modules/pnpm）。pnpm 11 的 `install` 命令不支持 `--omit` 旗标，声明 package.json 无 devDeps 即天然只装 DSH 运行时树。
+- **可恢复自动退避重试**（network / environment / unknown / native-toolchain）：退避 30s → 2m → 10m → 30m（cap），插件生命周期内持续，网络/工具链/环境恢复后**自动完成**，无需操作。
+- **不可自动恢复 → 停等条件变化**（macos-signature 等配置类 / declaration 声明问题 / restart-needed 升级缓存残留）：页面给明确指引；条件满足后自动续跑（配置保存 / 插件更新 / 重启宿主）。
 
-**页面自装（首选，v0.8.6+，无需 Agent）**：打开 DSHana 标签页（未就绪显示 t1/t2）→ deps 卡片点「安装依赖」→ 插件自动完成（部署目录就绪 → **幂等检查**（cliBin 存在且已装版本 === 声明版本 → 跳过安装直接运行级重验）→ 停 web host（版本不一致才需）→ 写声明 package.json + 复制 pnpm-workspace.yaml 到 dsh-pkg → 创建 node 代理脚本（pkgDir/node.cmd → 解析后的 node 执行体：优先 nodejsPath，缺省 Electron node）→ 清旧 npm 残留 → `pnpm install --reporter=ndjson`（pnpm 入口为运行时引导产物，见上），PATH 首部指向 pkgDir 让 install script 找到宿主 node，官方源失败自动重试 npmmirror → 校验 cliBin → 自动运行级重验 `node cliBin --version`）。安装中显示实时进度（--reporter=ndjson 结构化事件流解析为可读进度行 + 更新时间，3s 轮询刷新）；完成后无需重启，去 t2 点「手动启动」。验证失败（「存在但依赖不完整」）→ 点「重新安装依赖」；可随时点「检测依赖」重验。**t1→t2 门禁**：t1 未过（缺失/验证失败/安装中/检测中）时 t2 按钮禁用（msg「依赖未就绪，请先安装/重新安装依赖」）。
+状态快照单一出口 `GET /webui/boot-state`（T3）：`{ phase, ready, deps:{ status,errorClass,guidance,error,version,logTail }, boot:{ attempt,nextRetryAt,errorClass,guidance,lastError }, web:{ ready,lastError } }`——标签页只消费它渲染三态（见下），Agent 排查也直接读它。
 
-**手动兜底仅用于标签页不可访问的情况**。手动命令详见下方。
+## DSHana 标签页（Bootstrap 三态自举页，T4）
 
-#### Agent 手动 pnpm install（兜底）
+标签页（`/webui`）按 `boot-state` 渲染三态，**无任何可点的启动/安装/检测按钮**（手动入口已随 T5 退役）：
 
-```powershell
-# 部署目录（数据目录 dsh-pkg）
-$pkgDir = <数据目录>/dsh-pkg
-# pnpm 入口 = 运行时引导产物（插件 tools/lib/pnpm.js ensurePnpm 下载的 pnpm.mjs；
-# 首次会联网下载 pnpm.mjs + worker.js 到数据目录 pnpm-dist/）
-$pnpmCli = <数据目录>/pnpm-dist/pnpm-11.24.0/pnpm.mjs
+1. **booting（自举中）**：阶段时间线（依赖就绪 → 启动 Web Host → 就绪）+ 依赖安装实时日志尾滚动 + 重试信息（第 N 次 / 下次自动重试时刻）。自动推进中，等即可。
+2. **action-needed（需要处理）**：自动链暂停。页面给出 **errorClass 人话 + 明确操作步骤**（如配置 nodejsPath、装编译工具链、清理磁盘）+ 「自动续跑中/停等」说明（区分可恢复退避重试中 vs 需重启宿主/等条件）；原始错误折叠「详情」。用户只做页面所述环境动作，**完成后自动续跑**。
+3. **ready（就绪）**：iframe 直嵌 dsh Web UI。
 
-# 先写声明 package.json（dependencies 来自插件根 package.json 的 dependencies）
-# 优先用本机已安装的 Node；无则需先创建 node 代理脚本指向解析后的 node 执行体（优先 nodejsPath，缺省 Electron 自带 node）
-$node = <本机 node.exe 绝对路径，如 C:\Program Files\nodejs\node.exe>
-& $node $pnpmCli install --reporter=ndjson
-```
-
-> **注意**：koffi/node-pty 的 install script 会起子进程调用 `node`。本机 Node 已在 PATH 中时直接可用；若 PATH 缺 node，报 `'node' is not recognized` 时需要创建代理脚本。手动兜底前先停 web host（部署要删旧 node_modules，Windows 上被运行中进程加载的原生模块会锁文件）。
-
-- **无 --omit 旗标**：pnpm 11 的 install 命令不支持 `--omit`（报 Unknown option: 'omit'）；部署目录用声明 package.json（无 devDeps），pnpm install 天然只装 DSH 运行时树，不装 rspack 构建树（~40MB）。**不可用 --omit=peer**（跳过 DSH 的 peer → ERR_MODULE_NOT_FOUND）。allowBuilds 放行由 pnpm-workspace.yaml 提供（package.json 的 allowScripts 在 pnpm 11 不再读取）。pnpm 入口定位：运行时引导（`tools/lib/pnpm.js` `ensurePnpm` 下载 pnpm.mjs + worker.js 到数据目录 pnpm-dist/，zip 不再内置 pnpm；首次引导需联网，unpkg/jsdelivr 双源 + sha256 校验）。PATH 处理：代理脚本（pkgDir/node.cmd）将子进程 node 请求转发到解析后的 node 执行体（优先有效 nodejsPath 配置，缺省 Electron 自带 node），PATH 首部指向 pkgDir 即可。
-- **registry 镜像**：默认源失败切 `--registry=https://registry.npmmirror.com`（或持久化 `pnpm config set registry https://registry.npmmirror.com`）；镜像只影响 registry 层，koffi/node-pty 产物同源。重跑前残留不完整先 `Remove-Item node_modules -Recurse -Force`（会连带清 package-lock.json / pnpm-lock.yaml，全新构建）。
-- **部署后**：Agent 手动路径依赖就位后重启 Hana（tools 缓存）；页面自装无需重启。装完调一次 dsh_run 触发拉起。
-
-> **旧命令参考**：npm 时代部署为 `node npm-cli.js i @deepseek-ai/dsh --omit=dev --loglevel=http`（复制插件根 package.json，含 devDeps 需 --omit 剔除）；pnpm 迁移后弃用（pnpm 11 add 无 --omit，改最小 package.json + pnpm add）；T7a 起再改按声明 `pnpm install`（DSH/cordis 固定版本声明进插件根 package.json，版本随插件发版）。
-
-## 配置完成后验证
-
-1. 打开 DSHana 标签页看自检（t1 依赖 / t2 进程，每项 ✓/✗ + 修复指引），按序修：t1 ✗ → deps 卡片「安装依赖/重新安装依赖」；t2 ✗ → 点「手动启动 web host」
-2. 跑最小试任务，cwd 显式传项目沙箱目录：`dsh_session(action="create", task="用文件写入工具在沙箱工作目录内创建 hello.txt，内容 hi，然后读回确认", cwd="<项目沙箱目录>")`，异步提交后主动结束回合等待回调
-3. 卡片不报 web host 错误 → 起来；完成后看摘要；浏览器开 http://127.0.0.1:3080 可见会话（可选）
-4. 失败按排错表定位
+事件流 `GET /webui/events`（保留）：`ready`（挂载 iframe）/ `pending`（停机退回自举页）/ `diag-changed`（自举状态变化信号：deps 翻转或 web host 启动失败 → 刷新 boot-state）/ `theme-pref`。
 
 ## 工具速查
 
 | 工具 | 用途 | 关键点 | 详情 |
 |---|---|---|---|
 | `dsh_session(action, task?, cwd?, …)` | 会话全生命周期（含提交任务） | create 必传 task+cwd，异步提交后主动结束回合；send 续会话；cancel 取消；list/get 回看 | [dsh-session 技能](dsh-session) |
-| `dsh_install(action?, wait?, autoStart?, version?, tag?)` | 安装/验证依赖 + 检查/更新版本四合一 | action=install 安装（默认，按声明版本 pnpm install，可显式传 version/tag 覆盖，registry 兜底 + 自动运行级重验 + autoStart 自动拉起 web host，渲染安装卡片）；action=verify 只检测完整性；action=check 版本检查（本地 + 远端 dist-tags + 基线 tag，只读）；action=update 完整更新（停 web host → 按声明重装 → 起 web host，**正在执行的任务会中断**，渲染升级卡片）；version 优先于 tag，都不传用插件声明版本（config.json global.dshTag 仅作旧版兼容兜底）；异步默认 + 完成回调，wait=true 同步；安装/更新进行中重复调用返回状态 | [dsh-install 技能](dsh-install) |
+| `dsh_install(action?, wait?, autoStart?)` | 依赖安装/验证（action ∈ install/verify） | install 按插件声明 pnpm install --prod（幂等跳过 + registry 兜底 + 自动核对 + autoStart 拉起 web host，异步渲染安装卡片）；verify 只读静态核对 | [dsh-install 技能](dsh-install) |
 | `dsh_approve(rpcId, approvalId, outcome?)` | 应答审批 | allowed-once 放行 / rejected 拒绝；通知带 args 命令原文 | [dsh-approve 技能](dsh-approve) |
 
-**工具调用的完整参数语义、返回结构、错误码、审批通道、副作用分别见上述独立工具技能（均从源码 tools/*.js 核对）**——本表只是速查。dsh_cancel 已并入 dsh_session（action=cancel），不再单独注册。
-
-### 标签页自愈路由（浏览器按钮调用，Agent 一般不直接调）
-
-| 路由 | 用途 |
-|---|---|
-| `GET /webui` | 页面壳（就绪事件化 + 主题 + 首帧自检；按总线连接状态判定就绪） |
-| `GET /webui/events` | 就绪事件流（SSE 式 chunked：ready/pending/diagnostics 事件；壳页就绪事件化挂载通道，替代 3s 轮询） |
-| `GET /webui/health` | 纯诊断端点（readDiagnostics 自检 + web host 状态；30s 超时兜底/手动刷新数据源） |
-| `POST /webui/start` | 手动启动 web host（t3 按钮） |
-| `POST /webui/install-deps` | 安装依赖（按声明 pnpm install 到 dsh-pkg，幂等跳过 + 停 host + 清旧残留 + 创建 node 代理脚本，npmmirror 兜底；t1 按钮） |
-| `GET /webui/verify-deps` | 运行级依赖检测（node cliBin --version；进页自动一次 + 手动） |
-| `GET /webui/check-update` | 版本检查（**兼容端点**：deps 卡片「检查更新」按钮已移除，用户入口 = 设置页 DSH 版本卡片 / dsh_install 工具 action=check；HTTP 直查 npm registry，官方源失败重试 npmmirror） |
-| `POST /webui/update-dsh` | 更新 DSH（**兼容端点**：deps 卡片「更新 DSH」按钮已移除，用户入口 = 设置页 DSH 版本卡片 / dsh_install 工具 action=update；停 web host → 按声明重装 → 起 web host，**正在执行的任务中断**） |
-
-## DSH 检查与更新（v0.13.0；v0.18.1 设置页检查改 DSH 侧直查）
-
-`@deepseek-ai/dsh` 版本检查与更新收敛为**宿主能力层单一事实源**（tools/lib/ `checkDshUpdate` / `updateDsh` / `installDepsFromPlugin` / `verifyDepsSmoke`，经单例挂载），Agent 工具与标签页共用同一套逻辑；DSH 设置页「DSH 版本」卡片 v0.18.1 起**检查改 DSH 侧直查**（v0.18.2 起 HTTP 直查 npm registry，pnpm view 语义等价），更新仍走宿主能力层。**基线差异**：设置页卡片检查恒直查 `latest`；**安装/更新版本源 = 插件声明版本**（`installDepsFromPlugin` 优先读插件根 package.json 的 dependencies 声明，仅声明缺失/非法时才回退配置基线 dshTag——CodeRabbit 对齐：dshTag 是版本检查的默认基线，不是安装/更新的直接版本源），基线非 latest 时检查结果与安装版本可能不同：
-
-1. **Agent 工具 `dsh_install`**（vX 起四合一，合并原 dsh_update）：`action=check` 查 `{ localVersion, distTags, baselineTag, baselineVersion, updateAvailable, error? }`（基线 tag = 显式 tag / 配置 dshTag / latest，可传 version 对比指定版本），只读不改；`action=update` 执行完整更新（停 web host → 按声明重装（可显式 version/tag 覆盖）→ 起 web host），默认异步（后台执行 + **升级卡片**实时日志，完成后宿主唤醒带回结果），`wait=true` 同步等待；更新会重启 web host、正在执行的任务会中断，`update` 前确认无运行中任务；更新执行中重复调用返回状态不重复执行。
-2. **DSHana 标签页 deps 卡片**（web host 未就绪时可见）：版本行显示「当前版本 / 最新版本 / 可更新状态」（版本管理入口已迁移到设置页「DSH 版本」卡片与 dsh_install 工具，「检查更新」「更新 DSH」按钮已移除；`/webui/check-update`、`/webui/update-dsh` 路由保留为兼容端点）；更新中显示进度（内存态 g.update 状态），完成显示「更新完成 vX，请重启 DSHana 使完全生效」；更新/安装期间页面自动退到诊断页显示进度，完成后自动切回并刷新
-3. **DSH 设置页「DSHana 设置」分页 → 「DSH 版本」卡片**：本地版本直读 dsh-pkg package.json（挂载即显示），远端版本 **DSH 侧直查**（v0.18.2 起 HTTP 直查 npm registry——fetch `https://registry.npmjs.org/@deepseek-ai/dsh/latest` 的 JSON `version` 字段（pnpm view 语义等价），官方源失败重试 npmmirror，15s 超时，不再 spawn pnpm；v0.18.1 起不再经宿主桥接——修复了宿主 resources.watch 桥接不可靠导致检查永不完成的问题）；「更新到最新」→ 两段式确认 → 经 **dshana.bus 消息总线**（@dsh-hanako/bus 提供的 dshanaBus 服务）发 update.request 直投宿主（v0.22.1 起替代 update-request.json 文件桥与 POST /child/post 反向信道，均已退役；bus 未就绪时 request-update 返回「消息总线未连接」）→ 宿主执行更新 → **v0.22.1+ 事件化**：订阅 update-stream 事件流（update.progress/result 驱动）直到 done/error；事件缺失手动刷新（update-status 一次性查询兜底）
-4. **Agent 工具 `dsh_install`**（依赖缺失/安装场景，同工具 install/verify 动作）：`action=install`（默认）按声明版本 pnpm install 到 dsh-pkg（可显式 version/tag 覆盖，registry 兜底 + 自动运行级重验 + autoStart 自动拉起 web host），默认异步 + **安装卡片**实时日志 + 完成回调，`wait=true` 同步；`action=verify` 只检测依赖完整性（运行级冒烟）；安装中（`g.deps.status === "installing"`）重复调用返回状态不重复执行
-
-**并发与一致性**：检查 `g.check.status` / 更新 `g.update.status` / 安装 `g.deps.status` 进行中重复请求跳过（请求触发层 + 能力层双重防护）；检查结果缓存 `g.check.result`（内存，5s 时间窗防远端查询重复跑；不再写 check-result.json 桥接文件）；更新结果走内存态 `g.update`（v0.24 起 update-result.json 退役，设置页事件缓存优先 + update-status 一次性查询读）。
-
-**安装/升级卡片（v0.13.0）**：dsh_install 异步流程（action=install/update）渲染 iframe 卡片（`/card/dep`，与任务卡片同构）——登记宿主单例 `g.depTasks`（taskId → kind: install|update/state/log/at/result），SSE `/ops/dep-stream`（首帧快照 + 每 1s npm 日志实时滚动，终态关闭）+ 兜底 `/ops/dep-status`；显示标题（DSH 安装 / DSH 升级，按 kind 区分）+ 状态徽标 + 日志实时滚动 + 完成结果（「已安装 vX，web host 已自动启动」/「更新完成 vX，请重启 DSHana 使完全生效」/ 错误信息）。
-
-## 进程间消息总线（dshana.bus，v0.22.1+ 收敛）
-
-宿主插件与 DSH 进程之间的**双向消息总线**（`@dsh-hanako/bus` 在 DSH webserver 注册 `/api/dshana.bus` upgrade 路由，宿主 `src/lib/bus.js` 连 `ws://127.0.0.1:<webPort>/api/dshana.bus`），JSON 文本帧 `{ channel, payload }`——**进程间唯一通道**（`/child/post` 反向信道、`/api/hana-provider.refresh` HTTP push、update-request.json 文件桥、patch config/logPath 注入均已退役）：
-
-- **免鉴权（本机信任）**：首帧 `hello` 只作身份宣告，不再比对 token（总线与 mux、`/api/session.*` 同级）；patch 静态化后 bridge config 恒空
-- **config 通道**：宿主 bus ready 后发 `{ channel:"config", payload:{ dshPkgDir, dataDir } }`，bridge 缓存，`dshanaBus.getConfig()` 返回——settings/provider 子插件取 dshPkgDir/dataDir 的路径来源（替代 patch config 注入）；config 未下发时相关路由报「总线配置未就绪」
-- **log 通道**：DSH 内部日志经 `{ channel:"log", payload:{ src, line } }` 转发宿主写会话文件（`[ts] [src]` 行格式统一；`@dsh-hanako/logger` 提供 hanaLogger 服务，bus 未连接时有界环形缓冲 ≤500 行、连接后按序补发）
-- **update 通道**：`update.request`（设置页发起）→ 宿主 `updateDsh` → `update.progress`（开始）/ `update.result`（完成，`{ state, version?, error? }`）回投——设置页事件缓存 + update-stream 推送，替代 2s 轮询 update-status
-- **provider.refresh 通道**：宿主经总线推 `{ routes }`（替代 `/api/hana-provider.refresh` HTTP push；bus 未连接记待补推，bus.ready 后自动补推最新 routes）
-- **壳页就绪事件化**：宿主总线状态经 `GET /webui/events` 就绪事件流（SSE 式 chunked）推给 DSHana 标签页壳页——bus ready 推 `ready` 事件 → 壳页挂载 iframe（替代 3s health 轮询挂载）；web host 启动失败推 `diagnostics` 事件；30s 超时兜底引导刷新/看诊断
-
-## 审批流程（Agent 应答）
-
-DSH 请求越界权限时任务挂起，插件经 deferred 发 dsh-approval 通知（rpcId/approvalId/reason/**args 命令路径原文**）。应答：读 args 判断 → 合理 `dsh_approve(rpcId, approvalId, "allowed-once")`，危险 `"rejected"`；无人应答超时（approvalTimeoutSec，config.json `global.approvalTimeoutSec` 可配，未配置时回落 0 = 禁用自动拒绝，任务挂起后不会因超时被自动 rejected）自动拒绝；也可 DSH Web UI 人工处理。**决策看 args（执行了什么），不听 reason（model 自述）**。
+> Agent 排查/安装走 `dsh_install` 工具（能力层 `g.installDeps`/`g.verifyDeps`），**不调页面路由**；标签页只读展示。
 
 ## 排错表
 
-**web host 起不来先开 DSHana 标签页看自检**（t1 依赖存在性+运行级验证 / t2 进程状态）。**门禁链**：t1 未过（缺失/验证失败/安装中/检测中）→ t2「手动启动」锁（msg「依赖未就绪…」）。按 t1→t2 修。
-
-**诊断日志**：全部运行日志在会话日志文件 `<dataDir>/logs/<YYYYMMDD-HHmmss-SSS>.log`（DSHana 标签页 t2 诊断区显示路径；旧日志 onload 时 zstd 压缩为 `.log.zst` 全部保留）。行前缀 src：`out`/`err`（DSH web host stdout/stderr）、`provider`/`theme`/`settings`（内嵌插件诊断）、`hana`（插件生命周期 + 里程碑 `[依赖安装]`/`[依赖验证]`/`[版本检查]`/`[DSH 更新]`）、`pnpm`（pnpm install 原始输出**逐 chunk 实时落盘**，行规范化 `\r` 进度帧已折行）。pnpm install 失败 / 更新失败 / 依赖验证失败：先开会话日志看 `[pnpm]` 行 + 对应 `[hana]` 里程碑（含退出码/registry 重试/错误尾），再按下表处理。
+**web host 起不来 → 先开 DSHana 标签页看三态自举页**：booting 显示阶段/进度/重试；action-needed 直接给 errorClass 人话 + 操作步骤；原始错误折叠「详情」。对照：
 
 | 现象 | 原因 | 处理 |
 |---|---|---|
-| 报 `DSH 包未就绪：...bin.js 不存在` | 依赖缺失 | 首选标签页 deps「安装依赖」；或 Agent 调 `dsh_install`（默认 install，按声明 pnpm install，自动重试 registry + 自动重验 + autoStart 拉起 web host，异步渲染安装卡片）；或手动 pnpm install（目录需 package.json） |
-| deps「存在但依赖不完整：ERR_MODULE_NOT_FOUND」 | 依赖图缺 peer（--omit=peer/中断假就绪） | 点「重新安装依赖」重跑 pnpm install（自动重验）；或「检测依赖」重验 |
-| 显示「正在检测依赖完整性…」/「检测中…」 | 运行级验证中（数百 ms~10s） | 等待（进页自动一次）或手动点「检测依赖」 |
-| t2 按钮禁用（msg「依赖未就绪…」） | t1 未过（缺失/验证失败/安装中/检测中） | 先完成 t1 再点「手动启动 web host」 |
-| 升级/重装后 web host 起不来 | 升级清掉插件目录 node_modules | 依赖部署到**数据目录 dsh-pkg/**（升级不丢），页面自装或 pnpm install；装完调 dsh_run 重试拉起 |
-| 报 `DSH web 启动超时（...端口未就绪）` | 依赖未就绪或端口被占用 | 先确认 t1 依赖已安装；webPort 被占用时改端口 |
+| 页面 action-needed：macos-signature | Electron node 签名校验失败 | 配置 nodejsPath（设置页 → 自定义 NodeJS 路径），保存后自动续跑 |
+| 页面 action-needed：native-toolchain | koffi/node-pty 等原生模块编译失败 | 装编译工具链（macOS `xcode-select --install` / Windows VS Build Tools），自动链会重试 |
+| 页面 action-needed：environment（EACCES/EPERM/ENOSPC） | 权限/磁盘 | 清理磁盘或调整权限（EBUSY 属锁，自动重试） |
+| 页面 action-needed：restart-needed | dsh 已跨版本升级，宿主仍持旧模块缓存 | **重启宿主（Hana）**，重启后自动续跑 |
+| 页面 action-needed：declaration / unknown | 声明或上游问题 / 未知 | 无需手动；等插件更新或上报作者，自动链保守重试 |
+| booting 长时间无进展 / 事件丢失 | 事件流断或退避间隙 | 页面 30s 兜底/退避到点自动刷新；开会话日志看自动链里程碑 |
+| 页面 ready 但任务报 web host 错误 | 端口占用/进程异常 | 查 webPort 占用；`dsh_install(action="verify")` + 会话日志定位 |
+| `dsh_session` 报「DSH 包未就绪」 | 依赖缺失/漂移 | `dsh_install()`（默认 install）自动装（自动链通常已自愈） |
+| pnpm install 下载失败/超时 | registry 网络 | 已内置官方源 → npmmirror 自动重试；持续失败查代理/网络 |
 | bash 报 `E_ACCESSDENIED` | DSH bash 沙箱 Windows 限制 | 改用文件系统工具（write/read/edit） |
-| pnpm install 下载失败/超时 | registry 网络 | 切 `--registry=https://registry.npmmirror.com`（页面自装已内置重试），仍失败查代理 |
-| 版本检查显示「检查失败」/「最新版本 未知」 | 远端查询官方源 + npmmirror 都失败（网络/registry） | 稍后重试（能力层已自动重试镜像一次）；查代理/网络 |
-| 更新 DSH 后 web host 起不来 / 更新失败 | 按声明重装失败或 web host 重启失败 | 看 deps 卡片/设置页更新状态（内存态 g.update.error）；按 t1→t2 自检修复后「手动启动 web host」 |
-| 改了配置/代码不生效 | 宿主 tools 模块缓存 | 重启 Hana |
+| 改了配置/代码不生效 | 宿主模块缓存 / 需重启的缓存残留 | 配置类实时生效；升级/代码类重启 Hana |
+
+**诊断日志**：全部运行日志在会话日志文件 `<dataDir>/logs/<YYYYMMDD-HHmmss-SSS>.log`（旧日志 onload zstd 压缩 `.log.zst` 保留）。行前缀 src：`out`/`err`（web host）、`hana`（插件生命周期 + 里程碑 `[自动链]`/`[依赖安装]`/`[依赖验证]`）、`pnpm`（pnpm 原始输出逐 chunk 实时落盘）。pnpm/自动链失败先看 `[hana]` 自动链行（errorClass + 退避/停等决策）与 `[pnpm]` 行。
 
 ## 已知限制
 
-- 主题跟随：system 跟随宿主，light/dark 原生；宿主切 Hana 主题后壳页接 `hana.theme.changed` 广播**实时跟随**（无需重开），切 DSH 偏好也**实时生效**（经 `/api/events.host` WS 订阅 `settings/document-updated` 的 `ui-theme` 变更）
+- **升级 dsh = 装新插件包 + 重启宿主**：插件侧无法豁免宿主进程内 ESM 模块缓存（spec 决策，勿重走弯路）；跨版本升级后 boot 撞旧 .pnpm 缓存 → restart-needed 停等，重启宿主自动续跑
+- 主题跟随：system 跟随宿主，light/dark 原生；宿主切主题后壳页实时跟随（经 `hana.theme.changed` + `/webui/events` theme-pref）
 - bash 在 Windows 可能 E_ACCESSDENIED（DSH 沙箱限制）；文件工具正常，Windows 优先用
 - wait=true 同步模式无审批通知（只能 Web UI 或超时）；长任务建议异步
-- 越界权限默认走审批：deferred 通知 → dsh_approve 应答；`approvalTimeoutSec` 内无人应答自动拒绝（未配置时回落 0 = 禁用自动拒绝，不自动拒）
-- 任务默认新建会话；传 sessionId 复用（resume）
-- 会话/账本在插件数据目录 dsh-home/，不碰 ~/.DSH
+- 越界权限默认走审批：deferred 通知 → dsh_approve 应答；`approvalTimeoutSec` 内无人应答自动拒绝（未配置回落 0 = 禁用自动拒绝）
+- 任务默认新建会话；传 sessionId 复用（resume）；会话/账本在插件数据目录 dsh-home/，不碰 ~/.DSH

--- a/skills/dsh-install/SKILL.md
+++ b/skills/dsh-install/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dsh-install
-description: "dsh_install 工具手册（源码 tools/dsh-install.js + tools/lib/install.js 能力层核对）。触发场景：安装 DeepSeek Harness（DSH）依赖（action=install，按插件声明版本 pnpm install --prod 到插件根 node_modules——dsh-pkg 已退役，版本严格锁插件声明无 version/tag 逃生门；registry 兜底 + 自动运行级重验 + autoStart）、检测依赖完整性（action=verify，运行级冒烟只读）、dsh_session 报「DSH 包未就绪」、DSHana 标签页不可用/依赖缺失、安装卡片（/card/dep 实时 pnpm 日志）、安装进行中重复调用返回状态。需要安装或验证 DSH 前先读本技能。"
+description: "dsh_install 工具手册（源码 tools/dsh-install.js + tools/lib/install.js 能力层核对）。触发场景：安装 DeepSeek Harness（DSH）依赖（action=install，按插件声明版本 pnpm install --prod 到插件根 node_modules——dsh-pkg 已退役，版本严格锁插件声明无 version/tag 逃生门；registry 兜底 + 自动运行级重验 + autoStart）、检测依赖完整性（action=verify，静态核对只读，无子进程）、dsh_session 报「DSH 包未就绪」、DSHana 标签页不可用/依赖缺失、安装卡片（/card/dep 实时 pnpm 日志）、安装进行中重复调用返回状态。需要安装或验证 DSH 前先读本技能。"
 ---
 
 # dsh_install 工具手册
@@ -13,15 +13,15 @@ description: "dsh_install 工具手册（源码 tools/dsh-install.js + tools/lib
 
 | 参数 | 类型 | 语义 |
 |---|---|---|
-| `action` | string | `install`（默认）= 安装依赖（按插件声明版本 pnpm install --prod 到插件根 node_modules，官方源失败自动重试 npmmirror + 自动运行级重验 + autoStart；已装版本与声明一致时跳过）；`verify` = 只检测依赖完整性（node cliBin --version 运行级冒烟，能跑 = 依赖图完整，只读不改动） |
+| `action` | string | `install`（默认）= 安装依赖（按插件声明版本 pnpm install --prod 到插件根 node_modules，官方源失败自动重试 npmmirror + 自动运行级重验 + autoStart；已装版本与声明一致时跳过）；`verify` = 只检测依赖完整性（静态核对：cliBin 常规文件 + 磁盘版本 === 插件声明，秒回无子进程，只读不改动） |
 | `wait` | boolean | `false`（默认）= 异步：install 立即返回 + 渲染安装卡片（实时 pnpm 日志），完成后宿主唤醒、结果后台送达；`true` = 同步：等安装跑完直接返回（pnpm install 可能耗时数分钟，阻塞当前回合） |
 | `autoStart` | boolean | install 完成后是否自动启动 web host（默认 true：web host 未运行时经 g.startWebHost 拉起；失败不阻断结果上报）。verify 忽略 |
 
 ## 行为（源码核实）
 
-**install**：① 并发防护——依赖安装中（`g.deps.status === "installing"` 或 `"running"`）重复调用返回 `{ ok:false, state:'installing' }` 不重复执行；② `g.installDeps(cfg)`（版本单一事实源 = 插件根 package.json 的 dependencies）：部署目标 = **插件根**（pnpm install --prod 按插件根声明拉取到插件 node_modules，无部署声明副本）→ **幂等检查**（cliBin 存在且已装版本 === 声明版本 → 跳过安装直接运行级重验，verifyDepsSmoke 失败走重装）→ 停 web host（`closeProcess`，Windows 文件锁前提）→ **旧依赖清理**（删 `package-lock.json` / `pnpm-lock.yaml` / 扁平 `node_modules`；旧数据目录 dsh-pkg 整体删除）→ node 代理脚本（数据目录 `pnpm-proxy/`，指向解析后的 node 执行体——默认宿主 electron node；配置 `nodejsPath` 时用自定义系统 node，PATH 首部指向代理目录让 koffi/node-pty 的 install script 找到 node）→ `pnpm install --prod --reporter=ndjson`（按插件根声明拉取，官方源失败自动重试 `--registry=https://registry.npmmirror.com`）→ 校验 cliBin → 清缓存强制运行级重验（`verifyDepsSmoke`，`g.deps.result` 刷新）；③ 完成后 autoStart（默认 true）：`g.web.ready` 已就绪跳过（返回 null）/ 未起经 `g.startWebHost(ctx.config, dataDir)` 拉起（成功 true / 失败 false，**失败不阻断结果上报**）→ `{ ok:true, state:'installed', cliBin, version?, autoStart?, skipped? }`。
+**install**：① 并发防护——依赖安装中（`g.deps.status === "installing"` 或 `"running"`）重复调用返回 `{ ok:false, state:'installing' }` 不重复执行；② `g.installDeps(cfg)`（版本单一事实源 = 插件根 package.json 的 dependencies）：部署目标 = **插件根**（pnpm install --prod 按插件根声明拉取到插件 node_modules，无部署声明副本）→ **幂等检查**（cliBin 存在且已装版本 === 声明版本 → 跳过安装直接静态核对，verifyDepsSmoke 失败走重装）→ 停 web host（`closeProcess`，Windows 文件锁前提）→ **旧依赖清理**（删 `package-lock.json` / `pnpm-lock.yaml` / 扁平 `node_modules`；旧数据目录 dsh-pkg 与 pnpm-proxy 残留删除）→ node 代理脚本（插件根 node.cmd，与部署物同目录——指向解析后的 node 执行体：默认宿主 electron node；配置 `nodejsPath` 时用自定义系统 node；PATH 首部指向代理目录让 koffi/node-pty 的 install script 找到 node）→ `pnpm install --prod --reporter=ndjson`（按插件根声明拉取，官方源失败自动重试 `--registry=https://registry.npmmirror.com`）→ 校验 cliBin → 强制静态核对（`verifyDepsSmoke`，`g.deps.result` 刷新）；③ 完成后 autoStart（默认 true）：`g.web.ready` 已就绪跳过（返回 null）/ 未起经 `g.startWebHost(ctx.config, dataDir)` 拉起（成功 true / 失败 false，**失败不阻断结果上报**）→ `{ ok:true, state:'installed', cliBin, version?, autoStart?, skipped? }`。
 
-**verify**：`g.verifyDeps(cfg)`（node cliBin --version 冒烟，10s 超时，结果缓存 `g.deps.result`）→ `{ verified, version, error? }`。
+**verify**：`g.verifyDeps(cfg)`（静态核对：cliBin 为常规文件 + 磁盘版本 === 插件声明，秒回无子进程，结果缓存 `g.deps.result`；pnpm 引导检查并行独立子项）→ `{ verified, version, error? }`。
 
 **异步模式**：`install` 默认异步——立即返回 + 渲染**安装卡片**（`/card/dep`，见下节），经宿主 deferred 通道注册唤醒（taskId 统一 `dsh_install_*` 前缀；meta.type 统一 `"dsh-install"`），后台完成/失败后宿主唤醒带回结果。
 
@@ -44,8 +44,8 @@ description: "dsh_install 工具手册（源码 tools/dsh-install.js + tools/lib
 
 ## 使用场景
 
-- **依赖缺失**：dsh_session create 报「DSH 包未就绪：...bin.js 不存在」、DSHana 标签页不可用（t1 依赖 ✗）→ `dsh_install(action="install")` 或 `dsh_install()`（默认 install）
-- **验证依赖完整性**：deps 卡片「存在但依赖不完整：ERR_MODULE_NOT_FOUND」→ `dsh_install(action="verify")` 复检，或直接重装
+- **依赖缺失**：dsh_session create 报「DSH 包未就绪：...bin.js 不存在」、DSHana 标签页停在 booting/需要处理 → `dsh_install(action="install")` 或 `dsh_install()`（默认 install；自动链通常已自愈，工具为 Agent 显式通道）
+- **验证依赖完整性**：boot-state 的 deps.status=error / 页面 action-needed 显示依赖问题 → `dsh_install(action="verify")` 复检，或直接重装
 - **装即用**：默认 autoStart=true，安装完成自动拉起 web host
 
 ## 示例
@@ -59,6 +59,6 @@ dsh_install(action="verify")               # 只检测依赖完整性
 
 ## 关联
 
-- 安装进度/日志也可在 DSHana 标签页 deps 卡片查看（同一份 `g.deps.log`）。
-- 装完调一次 `dsh_session(action="create")` 触发任务；web host 未自动启动时可在 DSHana 标签页点「手动启动 web host」。
-- 依赖部署细节见 dsh-hanako 技能「依赖自主部署」。
+- 安装进度/日志与自动链同源（`g.deps.log` 尾环 / 会话日志 `[pnpm]` 行）；Agent 显式安装后由 `autoStart`/自动链拉起 web host。
+- 装完调一次 `dsh_session(action="create")` 触发任务验证；DSHana 标签页自动收敛 ready 直嵌 Web UI（页面无手动按钮）。
+- 依赖生命周期与自动链/错误分类现状见 dsh-hanako 技能「启动自动链」。

--- a/src/assets/webui-shell.jinja2
+++ b/src/assets/webui-shell.jinja2
@@ -280,7 +280,8 @@
   {{= it.iframe }}
   <script>
     // 自举壳页运行时：数据源 = GET /webui/boot-state（T3 单一状态出口）+ /webui/events
-    // 事件流（ready/pending/diagnostics/diag-changed/theme-pref 驱动刷新）。页面只消费
+    // 事件流（ready/pending/diag-changed/theme-pref 驱动刷新；diag-changed = 自举状态
+    // 变化信号：deps 翻转或 web host 启动失败）。页面只消费
     // 快照三段（phase/deps/boot/web），不拼装诊断；三态判定见 viewOf()。无任何手动操作
     // 入口（按钮全退役）；原始日志/错误折叠「详情」仅信息展示。
     window.parent.postMessage({ type: "ready" }, "*");
@@ -695,11 +696,10 @@
                     } else {
                       refreshBoot();
                     }
-                  } else if (ev.type === "diagnostics") {
-                    if (!readyReceived) refreshBoot();
                   } else if (ev.type === "theme-pref") {
                     sendPrefTo(frame && frame.contentWindow, ev);
                   } else if (ev.type === "diag-changed") {
+                    // 自举状态变化信号（deps 翻转 / web host 启动失败）：刷新快照（进度/终态/errorClass/waiting）
                     refreshBoot();
                   }
                 }

--- a/src/assets/webui-shell.jinja2
+++ b/src/assets/webui-shell.jinja2
@@ -345,8 +345,8 @@
           });
         }
         function hanaApiUrl(path) {
-          var base = String(api || "").replace(//+$/, "");
-          var p = String(path || "").replace(/^/+/, "");
+          var base = String(api || "").replace(/\/+$/, "");
+          var p = String(path || "").replace(/^\/+/, "");
           return location.origin + base + "/" + p;
         }
         return {
@@ -579,13 +579,16 @@
       }
       function startRetryClock() {
         if (retryClock) { clearInterval(retryClock); retryClock = null; }
-        if (!boot || boot.nextRetryAt == null) return;
+        var bb0 = boot && boot.boot ? boot.boot : null;
+        if (!bb0 || bb0.nextRetryAt == null) return;
         var el = document.getElementById("retryAtText");
         if (!el) return;
         retryRefreshed = false;
         function tick() {
-          if (!boot || boot.nextRetryAt == null) return;
-          var left = boot.nextRetryAt - Date.now();
+          var bb = boot && boot.boot ? boot.boot : null;
+          if (!bb || bb.nextRetryAt == null) return;
+          var at = bb.nextRetryAt;
+          var left = at - Date.now();
           if (left <= 0) {
             el.textContent = "（时间到，正在自动重试…）";
             if (!retryRefreshed) {
@@ -594,9 +597,8 @@
             }
             return;
           }
-          var bb = boot.boot || {};
           var n = bb.attempt || 0;
-          el.textContent = fmtClock(boot.nextRetryAt) + "（约 " + fmtDelay(left) + " 后，第 " + (n + 1) + " 次）";
+          el.textContent = fmtClock(at) + "（约 " + fmtDelay(left) + " 后，第 " + (n + 1) + " 次）";
         }
         tick();
         retryClock = setInterval(tick, 1000);

--- a/src/assets/webui-shell.jinja2
+++ b/src/assets/webui-shell.jinja2
@@ -8,6 +8,11 @@
   <title>DSHana</title>
   {{= it.hcLink }}
   <style>
+    /* Bootstrap 自举壳页（T4 spec：dsh-deps-zero-intervention，webui-bootstrap.md）。
+     * 三态：booting（自举中：阶段时间线 + 实时日志 + 重试信息）/ action-needed（等待用户：
+     * errorClass 人话 + 自动续跑/停等说明 + 原始错误折叠）/ ready（iframe 直嵌 dsh Web UI）。
+     * 页面无任何可点的启动/安装入口（手动入口退役的 UI 面，路由退役见 T5）。
+     * 主题全部走宿主 hana CSS 变量（hcLink 注入），fallback 纸张风色值，明暗随宿主主题。 */
     html,
     body {
       height: 100%;
@@ -15,24 +20,23 @@
     }
 
     html {
-      color-scheme: {
-          {
-          =it.colorScheme
-        }
-      }
+      color-scheme: {{= it.colorScheme }}
     }
 
     iframe#dsh-frame {
       width: 100%;
       height: 100%;
       border: 0;
+      display: none;
+      background: transparent
+    }
+
+    body[data-view="ready"] iframe#dsh-frame {
       display: block
     }
 
-    /* 诊断区全部改用宿主 hana 主题 CSS 变量（hcLink 注入样式表定义，变量清单见
- * 下方主题桥 postMessage 的 vars）；fallback 用纸张风色值，明暗随宿主主题，不再用
- * 硬编码色板与 prefers-color-scheme media query。 */
-    #dsh-pending {
+    /* 自举舞台：非 ready 时全屏覆盖（booting / action-needed 共用） */
+    #dsh-stage {
       position: fixed;
       inset: 0;
       display: none;
@@ -47,120 +51,146 @@
       overflow: auto
     }
 
-    body[data-pending="1"] #dsh-pending {
+    body:not([data-view="ready"]) #dsh-stage {
       display: flex
     }
 
-    body[data-pending="1"] iframe#dsh-frame {
-      display: none
-    }
-
-    .diag-box {
+    .boot-panel {
       max-width: 680px;
       width: 100%
     }
 
-    .diag-title {
+    .view-title {
       font-size: 18px;
       font-weight: 600;
       margin: 0 0 6px
     }
 
-    .diag-sub {
+    .view-sub {
       font-size: 13px;
       color: var(--text-muted, #6B6158);
       margin: 0 0 14px
     }
 
-    .diag-list {
-      list-style: none;
-      margin: 0 0 10px;
-      padding: 0;
+    .view-head {
       display: flex;
-      flex-direction: column;
-      gap: 10px
+      align-items: center;
+      gap: 8px
     }
 
-    .diag-item {
-      display: flex;
-      gap: 10px;
-      align-items: flex-start;
+    .view-head .view-title {
+      margin: 0
+    }
+
+    /* 轻量旋转指示（纯色，无渐变/阴影） */
+    .spin {
+      width: 14px;
+      height: 14px;
+      flex: none;
+      border: 2px solid var(--border, #D8CFBE);
+      border-top-color: var(--accent, #537D96);
+      border-radius: 50%;
+      animation: dsh-spin 0.9s linear infinite
+    }
+
+    @keyframes dsh-spin {
+      to {
+        transform: rotate(360deg)
+      }
+    }
+
+    .card {
       border: 1px solid var(--border, #D8CFBE);
       border-radius: 8px;
       background: var(--bg-card, #FBF7EE);
-      padding: 10px 12px
+      padding: 12px 14px;
+      margin: 0 0 10px
     }
 
-    .diag-mark {
-      font-size: 16px;
-      line-height: 20px;
-      width: 20px;
-      text-align: center;
-      flex: none
-    }
-
-    .diag-item.ok .diag-mark {
-      color: var(--green, #4A6B4A)
-    }
-
-    .diag-item.bad .diag-mark {
-      color: var(--danger, #8B2C1F)
-    }
-
-    .diag-body {
-      min-width: 0;
-      flex: 1
-    }
-
-    .diag-name {
-      font-weight: 600;
-      margin-bottom: 4px
-    }
-
-    .diag-detail {
-      white-space: pre-wrap;
-      word-break: break-all;
-      color: var(--text-light, #4A433C);
-      margin-bottom: 4px
-    }
-
-    .diag-fix {
-      color: var(--accent, #537D96);
-      background: var(--accent-light, rgba(83, 125, 150, 0.08));
-      border-radius: 4px;
-      padding: 6px 8px
-    }
-
-    .diag-btn {
-      font-family: inherit;
+    .card-label {
       font-size: 13px;
-      color: var(--accent, #537D96);
+      font-weight: 600;
+      margin: 0 0 8px
+    }
+
+    /* 阶段时间线（ensure-deps → booting → ready） */
+    .timeline {
+      list-style: none;
+      margin: 0;
+      padding: 0
+    }
+
+    .timeline li {
+      position: relative;
+      display: flex;
+      gap: 10px;
+      padding: 0 0 16px
+    }
+
+    .timeline li:last-child {
+      padding-bottom: 0
+    }
+
+    .timeline li::before {
+      content: "";
+      position: absolute;
+      left: 7px;
+      top: 20px;
+      bottom: 2px;
+      width: 1px;
+      background: var(--border, #D8CFBE)
+    }
+
+    .timeline li:last-child::before {
+      display: none
+    }
+
+    .tl-dot {
+      width: 14px;
+      height: 14px;
+      margin-top: 2px;
+      flex: none;
+      border-radius: 50%;
+      border: 2px solid var(--border, #D8CFBE);
       background: var(--bg-card, #FBF7EE);
-      border: 1px solid var(--accent, #537D96);
-      border-radius: 6px;
-      padding: 6px 12px;
-      margin-top: 6px;
-      cursor: pointer
+      box-sizing: border-box
     }
 
-    .diag-btn:hover:not(:disabled) {
-      color: var(--accent-hover, #3F6179);
-      border-color: var(--accent-hover, #3F6179)
+    .timeline li.done .tl-dot {
+      border-color: var(--green, #4A6B4A);
+      background: var(--green, #4A6B4A)
     }
 
-    .diag-btn:disabled {
-      color: var(--text-muted, #6B6158);
-      border-color: var(--border, #D8CFBE);
-      cursor: default
+    .timeline li.current .tl-dot {
+      border-color: var(--accent, #537D96);
+      background: var(--accent-light, rgba(83, 125, 150, 0.08))
     }
 
-    .diag-btn-msg {
-      display: block;
+    .tl-body {
+      min-width: 0
+    }
+
+    .tl-name {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text, #2A2622)
+    }
+
+    .tl-desc {
       font-size: 12px;
-      color: var(--danger, #8B2C1F);
-      margin-top: 4px
+      color: var(--text-light, #4A433C)
     }
 
+    .timeline li.done .tl-name,
+    .timeline li.done .tl-desc {
+      color: var(--text-muted, #6B6158)
+    }
+
+    .timeline li.current .tl-name {
+      color: var(--accent, #537D96)
+    }
+
+    /* 实时日志/原始错误滚动区（复用诊断进度样式） */
     .diag-progress {
       white-space: pre-wrap;
       word-break: break-all;
@@ -169,112 +199,112 @@
       color: var(--text-light, #4A433C);
       background: var(--accent-light, rgba(83, 125, 150, 0.08));
       border-radius: 4px;
-      padding: 6px 8px;
-      margin-bottom: 4px;
-      max-height: 120px;
+      padding: 8px 10px;
+      margin: 0;
+      max-height: 140px;
       overflow: auto
     }
 
-    /* 进程错误全文滚动区（诊断第一手材料不截断——错误首行特征与完整堆栈需可读，实装 2026-09-02） */
-    .diag-errorlog {
-      max-height: 200px;
-      color: var(--danger, #A03028);
-      background: var(--accent-light, rgba(83, 125, 150, 0.08))
+    .muted {
+      font-size: 12px;
+      color: var(--text-muted, #6B6158)
     }
 
-    .diag-progress-time {
-      font-size: 11px;
-      color: var(--text-muted, #6B6158);
-      margin-bottom: 4px
-    }
-
-    .diag-logpath {
-      font-family: ui-monospace, SFMono-Regular, Consolas, "Courier New", monospace;
+    .meta-line {
       font-size: 12px;
       color: var(--text-muted, #6B6158);
-      word-break: break-all;
-      margin-top: 4px
+      margin: 2px 0 0
     }
 
-    .diag-retry {
+    /* action-needed：问题人话指引 */
+    .guide {
+      border: 1px solid var(--border, #D8CFBE);
+      border-left: 3px solid var(--accent, #537D96);
+      border-radius: 6px;
+      background: var(--bg-card, #FBF7EE);
+      padding: 10px 12px;
       font-size: 13px;
-      color: var(--text-muted, #6B6158);
-      text-align: center
+      color: var(--text, #2A2622);
+      white-space: pre-wrap;
+      word-break: break-word;
+      margin: 0 0 10px
+    }
+
+    .guide-label {
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--accent, #537D96);
+      margin: 0 0 6px
+    }
+
+    /* 自动续跑/停等说明 */
+    .note {
+      border-radius: 6px;
+      padding: 8px 10px;
+      font-size: 12px;
+      margin: 0 0 10px
+    }
+
+    .note.auto {
+      background: var(--accent-light, rgba(83, 125, 150, 0.08));
+      color: var(--text-light, #4A433C)
+    }
+
+    .note.stop {
+      background: rgba(139, 44, 31, 0.08);
+      color: var(--danger, #8B2C1F)
+    }
+
+    /* 原始错误折叠（info disclosure，非操作入口） */
+    details.raw-details {
+      font-size: 12px;
+      color: var(--text-muted, #6B6158)
+    }
+
+    details.raw-details summary {
+      cursor: pointer;
+      color: var(--accent, #537D96)
+    }
+
+    details.raw-details .diag-progress {
+      margin-top: 8px;
+      max-height: 220px
     }
   </style>
 </head>
 
-<body data-hana-theme="{{= it.esc(it.theme) }}" data-surface="card" data-pending="{{= it.ready ? " 0" : "1" }}">
-  <div id="dsh-pending">
-    <div class="diag-box" id="loading-box">
-      <div class="diag-title">正在启动 DSH web host…</div>
-      <div class="diag-sub">等待 DSH 就绪（就绪后自动进入 DSH Web UI）</div>
-      <div class="diag-retry">正在连接…</div>
-    </div>
-    <div class="diag-box" id="diag-box" style="display:none">
-      <div class="diag-title">DSH web host 未就绪</div>
-      <div class="diag-sub">连接失败自检（就绪后自动进入；可「查看诊断」或刷新页面重试）</div>
-      <ul class="diag-list" id="diag-list"></ul>
-      <div class="diag-retry" id="diag-retry"></div>
-    </div>
+<body data-hana-theme="{{= it.esc(it.theme) }}" data-surface="card" data-view="{{= it.ready ? "ready" : "booting" }}">
+  <div id="dsh-stage">
+    <div class="boot-panel" id="boot-panel"></div>
   </div>
   {{= it.iframe }}
   <script>
+    // 自举壳页运行时：数据源 = GET /webui/boot-state（T3 单一状态出口）+ /webui/events
+    // 事件流（ready/pending/diagnostics/diag-changed/theme-pref 驱动刷新）。页面只消费
+    // 快照三段（phase/deps/boot/web），不拼装诊断；三态判定见 viewOf()。无任何手动操作
+    // 入口（按钮全退役）；原始日志/错误折叠「详情」仅信息展示。
     window.parent.postMessage({ type: "ready" }, "*");
     (function () {
-      var api = {{= JSON.stringify(it.api)
-    }};
-    var panelPort = {{= JSON.stringify(it.port) }};
-    var initDiag = {{= it.initDiag }};
-    var frame = document.getElementById("dsh-frame");
-    // dsh WebUI 剪贴板桥——dsh 前端复制被宿主插件 iframe 权限链拦截时
-    // （navigator.clipboard 抛 NotAllowedError，跨源继承 deny，详见 CHANGELOG），
-    // dsh 页面（跨源 iframe）postMessage 到这里，壳页面经宿主 capability clipboard.writeText
-    // 写剪贴板（参照 hana-remote-dev 卡片实现；manifest ui.hostCapabilities 声明后宿主才放行）。
-    // 宿主主窗口上下文执行 navigator.clipboard，不受插件 iframe Permissions-Policy 链限制。
-    var HOST_ORIGIN = "*";
-    var cbSeq = 0;
-    function hostRequest(type, payload) {
-      var id = "dsh-cb-" + (++cbSeq);
-      return new Promise(function (resolve, reject) {
-        var timer = setTimeout(function () { cleanup(); reject(new Error("host 请求超时: " + type)); }, 8000);
-        function onMsg(e) {
-          if (e.source !== window.parent) return;
-          var m = e.data;
-          if (!m || m.id !== id || m.type !== type) return;
-          cleanup();
-          if (m.kind === "response") resolve(m.payload);
-          else if (m.kind === "error") reject(new Error((m.error && m.error.message) || "host error"));
-        }
-        function cleanup() {
-          window.removeEventListener("message", onMsg);
-          clearTimeout(timer);
-        }
-        window.addEventListener("message", onMsg);
-        window.parent.postMessage(
-          { protocol: "hana.plugin.ui", version: 1, id: id, kind: "request", type: type, payload: payload },
-          HOST_ORIGIN
-        );
-      });
-    }
-    // ---- hana 桥（卡片表面宿主协议；与 @hana/plugin-sdk 同构：hana.plugin.ui v1）----
-    // 壳页为自包含单文件（构建期 doT 编译、零运行时依赖），不引入 SDK 包；这里按
-    // 协议手写最小实现：api.url/api.fetch（自动带 pluginSurfaceSession 头，替代旧
-    // surfaceHeaders 手动拼接）+ panel.set/onEvent/onRefresh（功能面板内容推送与
-    // 交互回传）。宿主未注入 window.hana 时用本实现；面板不可用时优雅降级不影响页面。
-    var hana = window.hana || (function () {
-      var hseq = 1000;
-      function hanaRequest(type, payload, timeoutMs) {
-        var id = "hana-" + (++hseq);
+      var api = {{= JSON.stringify(it.api) }};
+      var panelPort = {{= JSON.stringify(it.port) }};
+      var initBoot = {{= it.initBoot }};
+      var frame = document.getElementById("dsh-frame");
+      var boot = null; // 最近一次 /webui/boot-state 快照
+      var readyReceived = false;
+      // ---- 剪贴板桥（dsh iframe 复制请求 → 宿主 capability；见下 __dshCopy 监听）----
+      var HOST_ORIGIN = "*";
+      var cbSeq = 0;
+      function hostRequest(type, payload) {
+        var id = "dsh-cb-" + (++cbSeq);
         return new Promise(function (resolve, reject) {
-          var timer = setTimeout(function () { cleanup(); reject(new Error("hana 请求超时: " + type)); }, timeoutMs || 8000);
+          var timer = setTimeout(function () { cleanup(); reject(new Error("host 请求超时: " + type)); }, 8000);
           function onMsg(e) {
             if (e.source !== window.parent) return;
             var m = e.data;
             if (!m || m.id !== id || m.type !== type) return;
             cleanup();
             if (m.kind === "response") resolve(m.payload);
-            else if (m.kind === "error") reject(new Error((m.error && m.error.message) || "hana error"));
+            else if (m.kind === "error") reject(new Error((m.error && m.error.message) || "host error"));
           }
           function cleanup() {
             window.removeEventListener("message", onMsg);
@@ -287,821 +317,528 @@
           );
         });
       }
-      var panelListeners = { event: [], refresh: [] };
+      // ---- hana 桥（最小实现：api.url/api.fetch + panel.set）----
+      var hana = window.hana || (function () {
+        var hseq = 1000;
+        function hanaRequest(type, payload, timeoutMs) {
+          var id = "hana-" + (++hseq);
+          return new Promise(function (resolve, reject) {
+            var timer = setTimeout(function () { cleanup(); reject(new Error("hana 请求超时: " + type)); }, timeoutMs || 8000);
+            function onMsg(e) {
+              if (e.source !== window.parent) return;
+              var m = e.data;
+              if (!m || m.id !== id || m.type !== type) return;
+              cleanup();
+              if (m.kind === "response") resolve(m.payload);
+              else if (m.kind === "error") reject(new Error((m.error && m.error.message) || "hana error"));
+            }
+            function cleanup() {
+              window.removeEventListener("message", onMsg);
+              clearTimeout(timer);
+            }
+            window.addEventListener("message", onMsg);
+            window.parent.postMessage(
+              { protocol: "hana.plugin.ui", version: 1, id: id, kind: "request", type: type, payload: payload },
+              HOST_ORIGIN
+            );
+          });
+        }
+        function hanaApiUrl(path) {
+          var base = String(api || "").replace(//+$/, "");
+          var p = String(path || "").replace(/^/+/, "");
+          return location.origin + base + "/" + p;
+        }
+        return {
+          api: {
+            url: hanaApiUrl,
+            fetch: function (path, init) {
+              var params = new URLSearchParams(location.search);
+              var sess = params.get("pluginSurfaceSession");
+              var headers = new Headers((init && init.headers) || {});
+              if (sess) headers.set("X-Hana-Plugin-Surface-Session", sess);
+              return fetch(hanaApiUrl(path), Object.assign({}, init || {}, { headers: headers }));
+            },
+          },
+          panel: {
+            set: function (props) {
+              // 面板不可用（宿主无 functionPanel / 未响应）时静默降级
+              return hanaRequest("hana.panel.set", props, 4000).catch(function () { return { accepted: 0, dropped: [] }; });
+            },
+          },
+        };
+      })();
+      // ---- 功能面板（status 常驻；actions 段已退役——T4 无手动入口）----
+      function panelStatusView() {
+        var st = { word: "未就绪", tone: "danger", delta: "自动进行中" };
+        if (!boot) return st;
+        if (boot.ready) { st.word = "运行中"; st.tone = "success"; st.delta = "端口 " + panelPort; return st; }
+        if (viewOf(boot) === "action") { st.word = "需要处理"; st.delta = "自举暂停"; return st; }
+        var d = boot.deps || {};
+        if (d.status === "installing" || d.status === "running") { st.word = "自举中"; st.tone = "warning"; st.delta = "依赖安装/核对"; return st; }
+        if (boot.phase === "booting") { st.word = "自举中"; st.tone = "warning"; st.delta = "启动 Web Host"; return st; }
+        st.word = "自举中"; st.tone = "warning";
+        return st;
+      }
+      function pushPanel() {
+        try {
+          if (!hana || !hana.panel || !hana.panel.set) return;
+          var st = panelStatusView();
+          hana.panel.set({
+            sections: [
+              { kind: "status", id: "dshana-status", label: "DSH web host", value: st.word, delta: st.delta, deltaTone: st.tone },
+            ],
+            refresh: { intervalMs: 30000 },
+          }).catch(function () { /* 面板不可用静默降级 */ });
+        } catch (err) { /* 面板不可用静默降级 */ }
+      }
+      // 监听 dsh iframe（跨源）发来的复制请求 → 宿主能力 → 回执
       window.addEventListener("message", function (e) {
-        if (e.source !== window.parent) return;
         var m = e.data;
-        if (!m || m.protocol !== "hana.plugin.ui" || m.kind !== "event") return;
-        if (m.type === "hana.panel.event" && m.payload && typeof m.payload === "object") {
-          var ev = m.payload;
-          if (typeof ev.sectionId === "string" && (ev.kind === "select" || ev.kind === "action" || ev.kind === "toggle")) {
-            for (var i = 0; i < panelListeners.event.length; i++) { try { panelListeners.event[i](ev); } catch (err) { /* 面板回调异常忽略 */ } }
-          }
-        } else if (m.type === "hana.panel.refresh") {
-          for (var j = 0; j < panelListeners.refresh.length; j++) { try { panelListeners.refresh[j](); } catch (err) { /* 刷新回调异常忽略 */ } }
+        if (!m || m.__dshCopy !== true) return;
+        if (!frame || e.source !== frame.contentWindow) return;
+        var req = m;
+        var port = e.ports && e.ports[0];
+        function ack(ok) {
+          var payload = { __dshCopyResult: { id: req.id, ok: ok } };
+          if (port) { try { port.postMessage(payload); port.close(); } catch (err) { /* port 已关闭 */ } }
+          else { try { e.source.postMessage(payload, "*"); } catch (err) { /* 忽略 */ } }
         }
+        hostRequest("clipboard.writeText", { text: req.text })
+          .then(function () { ack(true); })
+          .catch(function () { ack(false); });
       });
-      function hanaApiUrl(path) {
-        var base = String(api || "").replace(/\/+$/, "");
-        var p = String(path || "").replace(/^\/+/, "");
-        return location.origin + base + "/" + p;
+      // ---- 工具 ----
+      function escHtml(s) {
+        return String(s == null ? "" : s)
+          .replace(/&/g, "&amp;")
+          .replace(/"/g, "&quot;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;");
       }
-      return {
-        api: {
-          url: hanaApiUrl,
-          fetch: function (path, init) {
-            var params = new URLSearchParams(location.search);
-            var sess = params.get("pluginSurfaceSession");
-            var headers = new Headers((init && init.headers) || {});
-            if (sess) headers.set("X-Hana-Plugin-Surface-Session", sess);
-            return fetch(hanaApiUrl(path), Object.assign({}, init || {}, { headers: headers }));
-          },
-        },
-        panel: {
-          set: function (props) {
-            // 面板不可用（宿主无 functionPanel / 未响应）时静默降级：返回空结果不抛错
-            return hanaRequest("hana.panel.set", props, 4000).catch(function () { return { accepted: 0, dropped: [] }; });
-          },
-          onEvent: function (cb) { panelListeners.event.push(cb); return function () { }; },
-          onRefresh: function (cb) { panelListeners.refresh.push(cb); return function () { }; },
-        },
-      };
-    })();
-    // ---- 功能面板（functionPanel：左侧功能面板常驻状态 + 操作）----
-    // 面板内容由壳页运行时推送（hana.panel.set），宿主用内置原语渲染；页面主体仍承载
-    // 完整诊断详情（未就绪自检），面板承载常驻状态与快捷操作。宿主未注入/不支持面板时
-    // 全部静默降级（pushPanel 内部吞错），页面功能回退现状不受影响。
-    var panelDiag = initDiag || null;
-    var panelLogPath = null;
-    var panelInstalling = false;
-    var panelVerifyRunning = false;
-    var diagRefreshing = false;
-    function syncPanelFromDiag(diag) {
-      if (diag) {
-        var deps = checkByKey(diag, "deps");
-        var proc = checkByKey(diag, "process");
-        panelDiag = diag;
-        panelInstalling = !!(deps && deps.installing === true);
-        panelVerifyRunning = !!(deps && deps.verifyRunning === true);
-        panelLogPath = (proc && proc.logPath) || null;
+      function pad2(n) { return (n < 10 ? "0" : "") + n; }
+      function fmtClock(ms) {
+        var d = new Date(ms);
+        if (isNaN(d.getTime())) return "";
+        return pad2(d.getHours()) + ":" + pad2(d.getMinutes()) + ":" + pad2(d.getSeconds());
       }
-      pushPanel();
-    }
-    // 状态派生：就绪 running / 安装依赖中 installing / 启动中 starting / 未就绪 stopped
-    function panelStatus() {
-      var st = { word: "未就绪", tone: "danger" };
-      if (readyReceived) { st.word = "运行中"; st.tone = "success"; }
-      else if (panelInstalling || depsRequested) { st.word = "安装依赖中"; st.tone = "warning"; }
-      else if (startRequested) { st.word = "启动中"; st.tone = "warning"; }
-      else {
-        var proc = checkByKey(panelDiag, "process");
-        if (proc && proc.alive && !proc.ready) { st.word = "启动中"; st.tone = "warning"; }
+      function fmtDelay(ms) {
+        if (ms < 60000) return Math.round(ms / 1000) + " 秒";
+        if (ms < 3600000) return Math.round(ms / 60000) + " 分钟";
+        return Math.round(ms / 3600000) + " 小时";
       }
-      return st;
-    }
-    function fpFullPanel() {
-      var st = panelStatus();
-      var busy = st.word === "安装依赖中" || st.word === "启动中";
-      var sections = [
-        { kind: "status", id: "dshana-status", label: "DSH web host", value: st.word, delta: "端口 " + panelPort, deltaTone: st.tone },
-        { kind: "actions", id: "dshana-actions", items: [
-          { id: "start", label: "手动启动 web host", tone: "info", activation: { kind: "emit" }, disabled: busy || readyReceived },
-          { id: "install-deps", label: "安装依赖", tone: "warning", activation: { kind: "emit" }, disabled: st.word === "安装依赖中" },
-          { id: "verify-deps", label: "检测依赖", activation: { kind: "emit" }, disabled: st.word === "安装依赖中" || panelVerifyRunning },
-          { id: "copyLog", label: "复制日志路径", activation: { kind: "emit" }, disabled: !panelLogPath },
-        ] },
+      // ---- 三态判定（字段组合即定态；与 readBootState 注释同语义）----
+      //   ready         = 快照顶层 ready（web host 就绪 → iframe 直嵌）
+      //   action-needed = phase waiting && boot.errorClass 非空 &&（deps.guidance 或
+      //                   boot.guidance）非空——失败已分类且指引齐备
+      //   booting       = 其余（阶段推进/依赖操作中/失败信息不全等过渡态）
+      function viewOf(bs) {
+        if (bs && bs.ready) return "ready";
+        // 依赖操作进行中（安装/核对）一律自举中视图：实时进度优先于 waiting 的旧失败呈现
+        var ds = bs && bs.deps && bs.deps.status;
+        if (ds === "installing" || ds === "running") return "booting";
+        if (bs && bs.phase === "waiting") {
+          var k = bs.boot && bs.boot.errorClass;
+          var g = (bs.deps && bs.deps.guidance) || (bs.boot && bs.boot.guidance);
+          if (k && g) return "action";
+        }
+        return "booting";
+      }
+      function failedStageLabels(bs) {
+        var out = [];
+        if (bs.deps && bs.deps.guidance) out.push("依赖安装");
+        if (bs.boot && bs.boot.guidance) out.push("Web Host 启动");
+        if (!out.length) out.push("自动链");
+        return out.join("、");
+      }
+      function currentStage(bs) {
+        if (bs.phase === "booting") return 1;
+        return 0; // ensure-deps（默认/未跑过）；waiting 兜底另走无高亮分支
+      }
+      // ---- 渲染 ----
+      var STEPS = [
+        { name: "依赖就绪", desc: "自动检查并按插件声明安装/核对 dsh 依赖" },
+        { name: "启动 DSH Web Host", desc: "进程内启动 dsh Web UI（自动）" },
+        { name: "就绪", desc: "自动进入 DSH Web UI" },
       ];
-      if (panelLogPath) sections.push({ kind: "meta", id: "dshana-meta", text: "日志会话路径：" + panelLogPath });
-      return sections;
-    }
-    function pushPanel() {
-      try {
-        if (!hana || !hana.panel || !hana.panel.set) return;
-        hana.panel.set({ sections: fpFullPanel(), refresh: { intervalMs: 30000 } }).catch(function () { /* 面板不可用静默降级 */ });
-      } catch (err) { /* 面板不可用静默降级 */ }
-    }
-    function copyLogPath() {
-      if (!panelLogPath) return;
-      hostRequest("clipboard.writeText", { text: panelLogPath })
-        .then(function () { /* 复制成功 */ })
-        .catch(function () { /* 复制失败 */ });
-    }
-    function panelOnEvent(ev) {
-      if (!ev || ev.sectionId !== "dshana-actions" || ev.kind !== "action") return;
-      if (ev.itemId === "start") startWebHost();
-      else if (ev.itemId === "install-deps") installDeps();
-      else if (ev.itemId === "verify-deps") verifyDeps();
-      else if (ev.itemId === "copyLog") copyLogPath();
-    }
-    if (hana && hana.panel && hana.panel.onEvent) {
-      hana.panel.onEvent(panelOnEvent);
-      hana.panel.onRefresh(function () {
-        // 宿主刷新 tick（30s 兜底）：只重推内存态面板，不周期打 /webui/health——
-        // 诊断刷新改事件驱动（bus.ready/bus.disconnect/启动失败/deps 翻转经
-        // /webui/events 推 ready/pending/diagnostics/diag-changed，壳页事件到达
-        // 时 refreshDiag 一次；安装中进度由 installing 态 tick 滚动）
-        pushPanel();
-      });
-    }
-    // 监听 dsh iframe（跨源）发来的复制请求（dsh-hana-clipboard 桥 __dshCopyBridge）→
-    // 宿主能力 → 回执。回执优先走桥随消息传来的 MessagePort（e.ports[0]，桥端
-    // port1.onmessage 等它）；老桥/无 port 时 fallback window postMessage。
-    window.addEventListener("message", function (e) {
-      var m = e.data;
-      if (!m || m.__dshCopy !== true) return;
-      if (!frame || e.source !== frame.contentWindow) return;
-      var req = m;
-      var port = e.ports && e.ports[0];
-      function ack(ok) {
-        var payload = { __dshCopyResult: { id: req.id, ok: ok } };
-        if (port) { try { port.postMessage(payload); port.close(); } catch (err) { /* port 已关闭 */ } }
-        else { try { e.source.postMessage(payload, "*"); } catch (err) { /* 忽略 */ } }
+      function timelineHtml(bs) {
+        var cur = currentStage(bs);
+        var html = '<ul class="timeline">';
+        for (var i = 0; i < STEPS.length; i++) {
+          var cls = "";
+          if (cur >= 0 && i < cur) cls = " done";
+          else if (i === cur) cls = " current";
+          html += '<li class="' + cls.trim() + '"><span class="tl-dot"></span><div class="tl-body">'
+            + '<div class="tl-name">' + escHtml(STEPS[i].name) + '</div>'
+            + '<div class="tl-desc">' + escHtml(STEPS[i].desc) + '</div></div></li>';
+        }
+        return html + "</ul>";
       }
-      hostRequest("clipboard.writeText", { text: req.text })
-        .then(function () { ack(true); })
-        .catch(function () { ack(false); });
-    });
-    function attach() {
-      // 就绪（宿主 push ready 事件 / postMessage ready）：挂载/刷新 iframe，切回主视图
-      clearReadyTimers();
-      var wasPending = document.body.getAttribute("data-pending") === "1";
-      document.body.setAttribute("data-pending", "0");
-      // @dsh-hanako/app 子插件（dsh 进程内）serve 完整 fork SPA——iframe 直接嵌
-      // （同源 3080，免鉴权：资源/API/SSE/WS 全由子插件提供，无宿主代理、无劫持、
-      // 无 token/PSS 负担；跨源桥（主题/剪贴板）经 postMessage 走壳页）。
-      // vY（T7b）：dsh WebUI 由 @dsh-hanako/app serve 在根路径（registerFallback 席位），
-      // /webui/ 前缀已退役——iframe 直嵌 127.0.0.1:<port>/，不带 ?dshReload bust
-      // （index.html no-cache + assets hash 文件名，更新后自然换新，bust 多余且污染 URL）。
-      var base = "http://127.0.0.1:{{= it.port }}/";
-      // 首次挂载（src 空）或从加载/诊断态切回（更新/停机后）：强制加载当前 web host
-      // （带时间戳 bust，避免相同 src 不触发重新加载，保证更新后拿到新版本 UI）；
-      // 已挂载且非 pending（重复 ready）不重复 reload，不打断 dsh UI
-      if (wasPending || !frame.getAttribute("src")) {
-        frame.src = base;
+      function stageStatus(bs) {
+        var st = bs.deps && bs.deps.status;
+        var ph = bs.phase;
+        if (st === "installing") return { t: "正在安装 dsh 依赖", s: "按插件声明自动安装（网络/环境类问题会自动退避重试，无需手动操作）" };
+        if (st === "running") return { t: "正在核对依赖完整性", s: "核对通过后自动继续启动 DSH Web Host" };
+        if (ph === "booting") return { t: "正在启动 DSH Web Host", s: "进程内启动 dsh Web UI，就绪后自动进入" };
+        if (ph === "waiting") return { t: "自动启动暂停", s: "自动链正在等待自动重试/条件变化（见下方状态）" };
+        return { t: "正在检查依赖就绪", s: "检查通过后自动启动 DSH Web Host，全程无需手动操作" };
       }
-      startThemePush();
-      pushPanel(); // 就绪挂载后同步面板状态（运行中）
-    }
-    // 连接失败自检渲染——服务端收集的 checks 列表（每项：状态图标/检查项名/
-    // 详情/修复指引）；escHtml 兜底转义（诊断文本含路径与 stderr，需防注入）
-    function escHtml(s) {
-      return String(s == null ? "" : s)
-        .replace(/&/g, "&amp;")
-        .replace(/"/g, "&quot;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;");
-    }
-    function renderDiagList(diag) {
-      var list = document.getElementById("diag-list");
-      if (!list) return;
-      if (!diag || !diag.checks || diag.checks.length === 0) {
-        // 工具模块冷启动未加载/收集暂不可用：占位，diag-changed 事件到达时刷新
-        list.innerHTML = '<li class="diag-item"><div class="diag-body"><div class="diag-detail">正在收集自检信息…</div></div></li>';
-        return;
-      }
-      var html = "";
-      for (var i = 0; i < diag.checks.length; i++) {
-        var d = diag.checks[i];
-        var mark = d.ok ? "✓" : "✗";
-        html += '<li class="diag-item ' + (d.ok ? "ok" : "bad") + '" data-check="' + escHtml(d.key) + '">'
-          + '<span class="diag-mark">' + mark + '</span>'
-          + '<div class="diag-body">'
-          + '<div class="diag-name">' + escHtml(d.name) + '</div>'
-          + (d.key === "deps" && d.version ? '<div class="diag-detail">' + escHtml(versionLine(d)) + '</div>' : "") // deps 版本行（当前已装版本；最新版本/可更新状态见设置页「检查与更新 DSH」卡片）
-          + (d.key === "deps" && d.pnpmChecked ? '<div class="diag-detail">' + escHtml(pnpmLine(d)) + '</div>' : "") // deps 卡片 pnpm 引导状态行（独立子项，不进依赖就绪判定）
-          + (d.detail ? '<div class="diag-detail">' + escHtml(d.detail) + '</div>' : "")
-          + (d.key === "process" && d.errLog ? '<pre class="diag-progress diag-errorlog">' + escHtml(d.errLog) + '</pre>' : "") // 进程错误全文滚动区（不截断：错误首行特征可诊断，实装 2026-09-02）
-          + (d.key === "deps" && d.installing ? progressHtml(d) : "") // 安装实时进度
-          + (d.key === "deps" && d.updating ? updateProgressHtml(d) : "") // 更新进度/结果（更新由设置页触发，web host 停机期间被动展示）
-          + (d.key === "process" && d.logPath ? '<div class="diag-logpath">本次会话日志：' + escHtml(d.logPath) + '</div>' : "") // 时间戳会话日志路径件路径
-          + (d.fix ? '<div class="diag-fix">修复：' + escHtml(d.fix) + '</div>' : "")
-          + actionButtonHtml(d)
-          + '</div></li>';
-      }
-      list.innerHTML = html;
-      syncActionButtons(diag); // 按检查项状态刷新卡片内操作按钮（启动中/安装中禁用，失败/缺失可用）
-    }
-    // 操作按钮嵌入诊断卡片（data-check 定位，事件委托在列表上）——
-    // process 卡片：进程未在跑（从未启动/启动失败/已退出）→「手动启动 web host」；
-    // 启动中（alive=true 未 ready）→ 禁用「启动中…」；健康（ready+alive）不渲染按钮。
-    //   t2（依赖）未通过（deps.ok=false / installing / verifyRunning）时启动按钮
-    //   不开放——禁用 + msg「依赖未就绪，请先安装/重新安装依赖」。
-    // deps 卡片：依赖缺失 →「安装依赖」；已装 → 常驻「检测依赖」（verify-deps，检测中禁用
-    // 「检测中…」）；存在但运行级验证失败 → 另加「重新安装依赖」（install-deps action）。
-    // 门禁链：t1（依赖）未通过 → t2（进程）启动按钮锁（依赖未就绪，启动必失败）。
-    // 状态机：startRequested/depsRequested/verifyRequested 只覆盖
-    // 「请求已发出但诊断尚未反映状态」的短暂窗口，诊断确认后一律以检查项为准。
-    var startRequested = false;
-    var depsRequested = false;
-    var verifyRequested = false;
-    // 卡片内操作按钮 HTML：deps 可返回多个按钮（重新安装 + 检测）
-    function actionButtonHtml(d) {
-      if (!d) return "";
-      if (d.key === "process") {
-        // 进程健康（已就绪且在跑）不渲染；否则卡片内给「手动启动」（启动中禁用）
-        if (d.alive && d.ready) return "";
-        var running = d.alive;
-        return '<button type="button" class="diag-btn" data-action="start" data-check="process"'
-          + (running ? " disabled" : "") + '>' + (running ? "启动中…" : "手动启动 web host") + '</button>'
-          + '<span class="diag-btn-msg"></span>';
-      }
-      if (d.key === "deps") {
+      // booting 视图：阶段时间线 + 实时安装进度（logTail 滚动）+ 重试信息
+      function bootViewHtml(bs) {
+        var ph = bs.phase;
+        var st = stageStatus(bs);
+        var d = bs.deps || {};
+        var busy = d.status === "installing" || d.status === "running";
         var html = "";
-        if (!d.installed) {
-          // 缺失：安装依赖（安装中禁用）
-          html += '<button type="button" class="diag-btn" data-action="install-deps" data-check="deps"'
-            + (d.installing ? " disabled" : "") + '>' + (d.installing ? "安装中…" : "安装依赖") + '</button>';
+        html += '<div class="view-head"><span class="spin"></span><h1 class="view-title">正在启动 DSH web host…</h1></div>';
+        html += '<p class="view-sub">自举全程自动：依赖检查/安装 → 启动 → 就绪。若需你操作，页面会给出明确指引。</p>';
+        if (ph !== "waiting") {
+          html += '<div class="card"><div class="card-label">启动阶段</div>' + timelineHtml(bs)
+            + '<p class="meta-line">当前：' + escHtml(st.t) + '（' + escHtml(st.s) + '）</p></div>';
         } else {
-          // 已装：验证失败 → 重新安装依赖（同一 install-deps action）
-          if (d.verified === false && !d.verifyRunning) {
-            html += '<button type="button" class="diag-btn" data-action="install-deps" data-check="deps"'
-              + (d.installing ? " disabled" : "") + '>' + (d.installing ? "安装中…" : "重新安装依赖") + '</button>';
-          }
-          // 常驻「检测依赖」（检测中/安装中禁用）
-          if (!d.installing) {
-            html += '<button type="button" class="diag-btn" data-action="verify-deps" data-check="deps"'
-              + (d.verifyRunning ? " disabled" : "") + '>' + (d.verifyRunning ? "检测中…" : "检测依赖") + '</button>';
-          }
-          // 版本管理（检查更新/更新 DSH）归设置页「检查与更新 DSH」卡片（@dsh-hanako/settings
-          // 版本卡片 + dsh_install 工具 action=check/update）；deps 卡片只保留依赖管理（安装/检测），不再渲染版本按钮。
+          html += '<div class="card"><p class="meta-line">' + escHtml(st.t) + '：' + escHtml(st.s) + '</p></div>';
         }
-        return html ? html + '<span class="diag-btn-msg"></span>' : "";
-      }
-      return "";
-    }
-    function listBtn(check, action) {
-      var list = document.getElementById("diag-list");
-      if (!list) return null;
-      var sel = '[data-check="' + check + '"] .diag-btn';
-      if (action) sel += '[data-action="' + action + '"]';
-      return list.querySelector(sel);
-    }
-    function checkByKey(diag, key) {
-      if (diag && diag.checks) {
-        for (var i = 0; i < diag.checks.length; i++) {
-          if (diag.checks[i].key === key) return diag.checks[i];
+        if (busy || d.logTail) {
+          var label = busy ? (d.status === "installing" ? "依赖安装进度（实时）" : "依赖核对进度") : "最近依赖输出";
+          html += '<div class="card"><div class="card-label">' + label + '</div>'
+            + '<pre class="diag-progress">' + escHtml(d.logTail || "正在准备…") + '</pre></div>';
         }
+        var b = bs.boot || {};
+        var lines = [];
+        if (b.attempt > 0) lines.push("第 " + b.attempt + " 次尝试");
+        if (b.nextRetryAt != null) lines.push("将于 <span id=\"retryAtText\"></span> 自动重试");
+        else if (b.attempt > 0 && ph !== "waiting") lines.push("自动重试已在进行");
+        if (lines.length) html += '<p class="muted">' + lines.join(" · ") + '</p>';
+        html += rawDetailsHtml("原始日志/错误（详情）", rawBody(bs));
+        return html;
       }
-      return null;
-    }
-    // 安装/检测进度时间格式化（HH:MM:SS）
-    function fmtTime(iso) {
-      if (!iso) return "";
-      var t = new Date(iso);
-      if (isNaN(t.getTime())) return "";
-      var p = function (n) { return (n < 10 ? "0" : "") + n; };
-      return p(t.getHours()) + ":" + p(t.getMinutes()) + ":" + p(t.getSeconds());
-    }
-    // deps 安装中实时进度块（npm i 输出尾部 + 更新时间，随 installing 态 3s tick 滚动）
-    function progressHtml(d) {
-      var html = '<pre class="diag-progress">' + escHtml(d.installLog || "正在准备…") + '</pre>';
-      if (d.installAt) html += '<div class="diag-progress-time">更新于 ' + escHtml(fmtTime(d.installAt)) + '</div>';
-      return html;
-    }
-    // deps 版本行（只显示当前已装版本——deps 卡片不再做版本检查，checkResult 无稳定数据源；
-    // 最新版本/可更新状态归设置页「检查与更新 DSH」卡片）
-    function versionLine(d) {
-      return "当前版本 " + (d.version ? "v" + d.version : "未安装");
-    }
-    // deps 卡片 pnpm 引导状态行（独立子项：就绪/未就绪 + 原因；不并入「dsh 依赖就绪」
-    // 判定——web host 启动不依赖 pnpm，patch 已去注入。数据源 = 诊断 pnpmReady/
-    // pnpmVersion/pnpmError（verifyDepsSmoke 与 dsh 冒烟并行检查，pnpm 缺失自动重下自愈）；
-    // settings「检查与更新 DSH」卡片不展示 pnpm 状态）
-    function pnpmLine(d) {
-      if (d.pnpmReady) {
-        return "pnpm 引导：就绪" + (d.pnpmVersion ? "（v" + d.pnpmVersion + "）" : "");
-      }
-      return "pnpm 引导：未就绪" + (d.pnpmError ? "（原因：" + d.pnpmError + "）" : "");
-    }
-    // 更新进度/结果块（内存态 updateResult = g.update 状态组合，随 diag-changed 事件刷新；
-    // v0.24 update-result.json 退役）——版本管理归设置页
-    // （@dsh-hanako/settings「检查与更新 DSH」卡片 + dsh_install 工具），deps 卡片已无更新
-    // 按钮，仅在设置页触发更新（web host 停机期间）时被动展示进度。
-    function updateProgressHtml(d) {
-      var r = d.updateResult || null;
-      var text = "正在更新 DSH…（将重启 DSHana，正在执行的任务会中断）";
-      if (r && r.state === "done") text = "更新完成 v" + (r.version || "?") + (r.error ? "（web host 重启失败：" + r.error + "）" : "") + "，请重启 DSHana 使完全生效";
-      else if (r && r.state === "error") text = "更新失败：" + (r.error || "未知错误");
-      var html = '<pre class="diag-progress">' + escHtml(text) + '</pre>';
-      if (r && r.at) html += '<div class="diag-progress-time">更新于 ' + escHtml(fmtTime(r.at)) + '</div>';
-      return html;
-    }
-    function setBtnMsg(check, text) {
-      var list = document.getElementById("diag-list");
-      var el = list ? list.querySelector('[data-check="' + check + '"] .diag-btn-msg') : null;
-      if (el) el.textContent = text;
-    }
-    function syncActionButtons(diag) {
-      var proc = null, deps = null;
-      if (diag && diag.checks) {
-        for (var i = 0; i < diag.checks.length; i++) {
-          if (diag.checks[i].key === "process") proc = diag.checks[i];
-          else if (diag.checks[i].key === "deps") deps = diag.checks[i];
-        }
-      }
-      // 依赖未通过 → 启动按钮不开放（依赖未就绪，启动必失败）：
-      // deps.ok=false（未装/验证失败）、安装中（installing）、检测中（verifyRunning）均视为未通过
-      var depsBlocked = deps && (deps.ok === false || deps.installing === true || deps.verifyRunning === true);
-      var pBtn = listBtn("process");
-      if (pBtn) {
-        if (depsBlocked) {
-          // 依赖未就绪：禁用 + msg 提示原因（用户先去安装/重新安装/等待检测）
-          startRequested = false;
-          pBtn.disabled = true;
-          pBtn.textContent = "手动启动 web host";
-          setBtnMsg("process", "依赖未就绪，请先安装/重新安装依赖");
-        } else if (startRequested && !(proc && !proc.alive)) {
-          // 请求已发出：进程未确认停止（含 alive 确认中）→ 保持禁用；确认在跑则转入「启动中…」
-          if (proc && proc.alive) startRequested = false;
-          pBtn.disabled = true;
-          pBtn.textContent = proc && proc.alive ? "启动中…" : "正在启动…";
+      // action-needed 视图：errorClass 人话 + 明确操作步骤（guidance 内含）+ 自动续跑/停等说明
+      function actionViewHtml(bs) {
+        var b = bs.boot || {};
+        var d = bs.deps || {};
+        var guide = d.guidance || b.guidance || "自动链暂时无法自动推进，请稍后刷新页面查看最新状态。";
+        var html = "";
+        html += '<h1 class="view-title">DSH web host 启动需要处理</h1>';
+        html += '<p class="view-sub">自动链已暂停推进；按下方指引完成后插件会自动续跑，无需再次手动启动。</p>';
+        html += '<div class="guide"><div class="guide-label">问题与处理指引</div>' + escHtml(guide) + '</div>';
+        if (b.nextRetryAt != null) {
+          html += '<div class="note auto">自动续跑中：插件正在退避重试（第 ' + (b.attempt || 0) + ' 次失败），将于 <span id="retryAtText"></span> 自动继续，无需手动操作。</div>';
         } else {
-          startRequested = false;
-          if (proc && proc.alive) {
-            pBtn.disabled = true;
-            pBtn.textContent = "启动中…";
-          } else {
-            pBtn.disabled = false;
-            pBtn.textContent = "手动启动 web host";
-          }
+          html += '<div class="note stop">' + stopNoteText(bs) + '</div>';
         }
+        html += '<p class="meta-line">失败阶段：' + escHtml(failedStageLabels(bs)) + ' · 错误分类：' + escHtml(b.errorClass || "-")
+          + ' · 第 ' + (b.attempt || 0) + ' 次尝试</p>';
+        html += rawDetailsHtml("原始错误（详情）", rawBody(bs));
+        return html;
       }
-      var installBtn = listBtn("deps", "install-deps");
-      if (installBtn && deps) {
-        if (deps.installing) {
-          depsRequested = false;
-          installBtn.disabled = true;
-          installBtn.textContent = "安装中…";
-        } else if (depsRequested) {
-          // 请求已发出但诊断尚未确认 installing/installed：保持禁用
-          installBtn.disabled = true;
-          installBtn.textContent = "正在安装…";
-        } else {
-          depsRequested = false;
-          installBtn.disabled = false;
-          installBtn.textContent = deps.installed ? "重新安装依赖" : "安装依赖";
-        }
+      function stopNoteText(bs) {
+        var b = bs.boot || {};
+        if (b.errorClass === "restart-needed") return "自动链停等：dsh 已跨版本升级，请重启宿主（Hana）加载新版本——重启后插件自动续跑，无需其它操作";
+        return "自动链停等：插件等待条件变化（配置保存 / 网络恢复 / 插件更新等）后自动续跑，无需重复手动操作";
       }
-      var verifyBtn = listBtn("deps", "verify-deps");
-      if (verifyBtn && deps) {
-        if (deps.verifyRunning) {
-          verifyRequested = false;
-          verifyBtn.disabled = true;
-          verifyBtn.textContent = "检测中…";
-        } else if (verifyRequested) {
-          // 请求已发出但诊断尚未反映 running：保持禁用
-          verifyBtn.disabled = true;
-          verifyBtn.textContent = "正在检测…";
-        } else {
-          verifyRequested = false;
-          verifyBtn.disabled = false;
-          verifyBtn.textContent = "检测依赖";
-        }
+      // 详情折叠体（原始错误/日志；仅信息展示，非操作入口）
+      function rawBody(bs) {
+        var parts = [];
+        var b = bs.boot || {};
+        var d = bs.deps || {};
+        if (b.lastError) parts.push("[自动链错误] " + b.lastError);
+        if (d.error) parts.push("[依赖错误] " + d.error);
+        if (d.logTail) parts.push("[依赖日志尾]\n" + d.logTail);
+        return parts.length ? parts.join("\n\n") : "暂无原始输出。";
       }
-      // 「检查更新」/「更新 DSH」按钮已移除（版本管理归设置页「检查与更新 DSH」卡片 +
-      // dsh_install 工具），无对应按钮状态同步
-    }
-    function startWebHost() {
-      if (startRequested || readyReceived) return; // 幂等：已在启动中/已就绪
-      startRequested = true;
-      var btn = listBtn("process");
-      if (btn) { btn.disabled = true; btn.textContent = "正在启动…"; setBtnMsg("process", ""); }
-      pushPanel();
-      hana.api.fetch("webui/start", {
-        method: "POST",
-        signal: AbortSignal.timeout(5000),
-      })
-        .then(function (r) { return r.json(); })
-        .then(function (d) {
-          if (d && d.ok && d.state === "ready") { mountReady(); return; } // 已就绪：mountReady（置 readyReceived + attach），与其他 ready 路径一致
-          if (d && d.ok) { pushPanel(); return; } // starting：保持禁用，面板/诊断刷新检测就绪
-          // 失败：恢复按钮并提示错误
-          startRequested = false;
-          if (btn) { btn.disabled = false; btn.textContent = "手动启动 web host"; setBtnMsg("process", d && d.error ? d.error : "启动请求失败，请稍后重试"); }
-          pushPanel();
-        })
-        .catch(function () {
-          startRequested = false;
-          if (btn) { btn.disabled = false; btn.textContent = "手动启动 web host"; setBtnMsg("process", "启动请求超时或网络错误，请重试"); }
-          pushPanel();
-        });
-    }
-    function installDeps() {
-      if (depsRequested) return; // 幂等：已在安装中
-      depsRequested = true;
-      var btn = listBtn("deps");
-      if (btn) { btn.disabled = true; btn.textContent = "正在安装…"; setBtnMsg("deps", ""); }
-      pushPanel();
-      hana.api.fetch("webui/install-deps", {
-        method: "POST",
-        signal: AbortSignal.timeout(5000),
-      })
-        .then(function (r) { return r.json(); })
-        .then(function (d) {
-          if (d && d.ok) { pushPanel(); return; } // installing：保持禁用，诊断刷新（安装中/完成）
-          // 失败：恢复按钮并提示错误
-          depsRequested = false;
-          if (btn) { btn.disabled = false; btn.textContent = "安装依赖"; setBtnMsg("deps", d && d.error ? d.error : "安装请求失败，请稍后重试"); }
-          pushPanel();
-        })
-        .catch(function () {
-          depsRequested = false;
-          if (btn) { btn.disabled = false; btn.textContent = "安装依赖"; setBtnMsg("deps", "安装请求超时或网络错误，请重试"); }
-          pushPanel();
-        });
-    }
-    // 运行级依赖检测（GET /webui/verify-deps，只读）——进标签页自动一次 + 手动
-    // 「检测依赖」按钮。服务端 await 检测（≤10s），结果写入 g.depsSmoke；拿到 ok 响应后
-    // 触发一次 health 读取诊断刷新 deps 卡片（检测中显示「正在检测依赖完整性…」，结果
-    // 回来显示通过/失败）。verify 状态翻转经 notifyDepsChanged → diag-changed 事件刷新。
-    // deps 安装中进度滚动：仅 installing 态运行 3s tick（事件驱动刷新 + 安装态低频
-    // 进度兜底；安装结束 diag-changed 事件 → refreshDiag → installing=false 即停）。
-    var installTick = null;
-    function syncInstallTick(diag) {
-      var deps = checkByKey(diag, "deps");
-      var installing = !!(deps && deps.installing === true);
-      if (installing && !installTick) {
-        installTick = setInterval(function () { refreshDiag(); }, 3000);
-      } else if (!installing && installTick) {
-        clearInterval(installTick);
-        installTick = null;
+      function rawDetailsHtml(label, body) {
+        return '<details class="raw-details"><summary>' + escHtml(label) + '</summary>'
+          + '<pre class="diag-progress">' + escHtml(body) + '</pre></details>';
       }
-    }
-    function stopInstallTick() {
-      if (installTick) { clearInterval(installTick); installTick = null; }
-    }
-    function refreshDiag() {
-      // 诊断数据源（事件驱动的一次性 health 查询；不轮询、不自动挂载——挂载只由
-      // ready 事件驱动）。diagRefreshing 防并发（diag-changed 事件/手动刷新共用）。
-      if (diagRefreshing) return;
-      diagRefreshing = true;
-      hana.api.fetch("webui/health", { signal: AbortSignal.timeout(3000) })
-        .then(function (r) { return r.json(); })
-        .then(function (d) {
-          if (d && d.ok && !readyReceived) { mountReady(); return; }
-          if (d && d.diagnostics) {
-            renderDiagList(d.diagnostics);
-            syncPanelFromDiag(d.diagnostics);
-            syncInstallTick(d.diagnostics);
-          }
-        })
-        .catch(function () { })
-        .finally(function () { diagRefreshing = false; pushPanel(); });
-    }
-    function runVerifyDeps(btn) {
-      if (verifyRequested) return; // 幂等：已在检测中
-      verifyRequested = true;
-      if (btn) { btn.disabled = true; btn.textContent = "正在检测…"; setBtnMsg("deps", ""); }
-      pushPanel();
-      hana.api.fetch("webui/verify-deps", {
-        signal: AbortSignal.timeout(15000), // 服务端 await 检测 ≤10s，留足余量
-      })
-        .then(function (r) { return r.json(); })
-        .then(function (d) {
-          verifyRequested = false;
-          if (d && d.ok) {
-            // 结果已写入服务端 g.depsSmoke：刷新一次诊断（通过/失败状态进 deps 卡片）
-            refreshDiag();
+      // ---- 状态应用/重绘 ----
+      var installTick = null;
+      var retryClock = null;
+      var readyTimer = null;
+      var retryRefreshed = false;
+      function clearClocks() {
+        if (installTick) { clearInterval(installTick); installTick = null; }
+        if (retryClock) { clearInterval(retryClock); retryClock = null; }
+      }
+      function clearReadyTimer() {
+        if (readyTimer) { clearTimeout(readyTimer); readyTimer = null; }
+      }
+      function armFallbackTimer() {
+        clearReadyTimer();
+        if (readyReceived) return;
+        readyTimer = setTimeout(function () {
+          readyTimer = null;
+          if (!readyReceived) refreshBoot();
+        }, 30000);
+      }
+      function startInstallTick() {
+        if (installTick) return;
+        installTick = setInterval(function () { refreshBoot(); }, 3000);
+      }
+      function stopInstallTick() {
+        if (installTick) { clearInterval(installTick); installTick = null; }
+      }
+      function startRetryClock() {
+        if (retryClock) { clearInterval(retryClock); retryClock = null; }
+        if (!boot || boot.nextRetryAt == null) return;
+        var el = document.getElementById("retryAtText");
+        if (!el) return;
+        retryRefreshed = false;
+        function tick() {
+          if (!boot || boot.nextRetryAt == null) return;
+          var left = boot.nextRetryAt - Date.now();
+          if (left <= 0) {
+            el.textContent = "（时间到，正在自动重试…）";
+            if (!retryRefreshed) {
+              retryRefreshed = true;
+              setTimeout(function () { if (!readyReceived) refreshBoot(); }, 2500);
+            }
             return;
           }
-          var b = listBtn("deps", "verify-deps");
-          if (b) { b.disabled = false; b.textContent = "检测依赖"; }
-          setBtnMsg("deps", d && d.error ? d.error : "检测请求失败，请稍后重试");
-          pushPanel();
-        })
-        .catch(function () {
-          verifyRequested = false;
-          var b = listBtn("deps", "verify-deps");
-          if (b) { b.disabled = false; b.textContent = "检测依赖"; }
-          setBtnMsg("deps", "检测请求超时或网络错误，请重试");
-          pushPanel();
-        });
-    }
-    function verifyDeps() {
-      runVerifyDeps(listBtn("deps", "verify-deps"));
-    }
-    // 版本管理（检查更新/更新 DSH）归设置页「检查与更新 DSH」卡片（@dsh-hanako/settings
-    // 版本卡片 + dsh_install 工具），deps 卡片不再做版本检查/更新，前端 checkUpdate/
-    // updateDsh 按钮与脚本已移除；/webui/check-update、/webui/update-dsh 路由保留
-    // （dsh_install 工具等仍经后端能力层调用）。
-    // 进标签页自动检测一次（仅依赖已装时；不随轮询重复——只在这里调一次）
-    function autoVerifyDeps() {
-      var deps = checkByKey(initDiag, "deps");
-      if (!deps || !deps.installed) return; // 未装：先安装，安装成功会自动重验
-      runVerifyDeps(listBtn("deps", "verify-deps"));
-    }
-    // 事件委托：卡片按钮点击（列表 innerHTML 每轮轮询重建，监听挂在 ul 上持久）
-    function onDiagClick(e) {
-      var t = e.target;
-      var btn = t && t.closest ? t.closest(".diag-btn") : null;
-      if (!btn) return;
-      var action = btn.getAttribute("data-action");
-      if (action === "start") startWebHost();
-      else if (action === "install-deps") installDeps();
-      else if (action === "verify-deps") verifyDeps();
-    }
-    // ---- 就绪事件化（v0.22.1+）：不再 3s 轮询 health 挂载 iframe——改事件驱动：
-    // ① 宿主 push ready（/webui/events 就绪事件流 或 父窗口 postMessage ready）→ 挂载；
-    // ② 未 ready 显示加载态；30s 超时兜底 → 引导刷新/看诊断；
-    // ③ 宿主推诊断事件（web host 启动失败）→ 直接显示自检诊断。----
-    var readyTimer = null;
-    var streamAbort = null;
-    var readyReceived = false;
-    // 只清超时与安装 tick（不 abort 事件流——流常驻，attach 重挂载时不能杀流；
-    // 流的终止只在页面卸载 abortEventStream）
-    function clearReadyTimers() {
-      if (readyTimer) { clearTimeout(readyTimer); readyTimer = null; }
-      stopInstallTick();
-    }
-    function abortEventStream() {
-      if (streamAbort) { try { streamAbort.abort(); } catch (e) { /* 已关闭 */ } streamAbort = null; }
-    }
-    function mountReady() {
-      if (readyReceived) return;
-      readyReceived = true;
-      stopInstallTick();
-      attach();
-    }
-    // 显示加载态（web host 启动中/停机窗口；默认进入）
-    function showLoading() {
-      var lb = document.getElementById("loading-box");
-      var db = document.getElementById("diag-box");
-      if (lb) lb.style.display = "";
-      if (db) db.style.display = "none";
-      document.body.setAttribute("data-pending", "1");
-    }
-    var diagShown = false;
-    // 显示诊断态（30s 超时 / 宿主推诊断事件 / 手动「查看诊断」）
-    function showDiagnostics(diag) {
-      var lb = document.getElementById("loading-box");
-      var db = document.getElementById("diag-box");
-      if (lb) lb.style.display = "none";
-      if (db) db.style.display = "";
-      document.body.setAttribute("data-pending", "1");
-      renderDiagList(diag || null);
-      syncPanelFromDiag(diag || null);
-      var rt = document.getElementById("diag-retry");
-      if (rt) {
-        rt.textContent = "web host 长时间未就绪：可刷新页面重试，或按上方自检修复后重试";
+          var bb = boot.boot || {};
+          var n = bb.attempt || 0;
+          el.textContent = fmtClock(boot.nextRetryAt) + "（约 " + fmtDelay(left) + " 后，第 " + (n + 1) + " 次）";
+        }
+        tick();
+        retryClock = setInterval(tick, 1000);
       }
-      if (!diagShown) {
-        diagShown = true;
-        autoVerifyDeps(); // 进诊断态自动运行级检测一次（结果经 refreshDiag 进 deps 卡片）
+      function panelEl() { return document.getElementById("boot-panel"); }
+      function applyBoot(bs) {
+        if (!bs || typeof bs !== "object") return;
+        boot = bs;
+        var view = viewOf(bs);
+        if (view === "ready") {
+          clearClocks();
+          clearReadyTimer();
+          if (!readyReceived) { mountReady(); }
+          pushPanel();
+          return;
+        }
+        document.body.setAttribute("data-view", view);
+        var el = panelEl();
+        if (el) el.innerHTML = view === "action" ? actionViewHtml(bs) : bootViewHtml(bs);
+        var d = bs.deps || {};
+        if (d.status === "installing" || d.status === "running") startInstallTick();
+        else stopInstallTick();
+        startRetryClock();
+        armFallbackTimer();
+        pushPanel();
       }
-    }
-    // 订阅宿主就绪事件流（/webui/events；SSE 式 chunked，非轮询）。
-    // 流断开（网络/服务端关闭）时按 10s 退避重开（有界 10 次）——覆盖
-    // 「web host 启动失败后用户修复重新拉起」的 ready 到达窗口；ready 后流保持
-    // 常驻（theme-pref / diag-changed 事件持续推送），断流同样重开恢复事件接收。
-    var streamRetries = 0;
-    function openReadyStream() {
-      if (streamRetries >= 10) return;
-      var ac = new AbortController();
-      streamAbort = ac;
-      var retryTimer = null;
-      hana.api.fetch("webui/events", {
-        signal: ac.signal,
-      })
-        .then(function (r) {
-          if (!r || !r.ok || !r.body) {
-            scheduleReopen();
-            return null;
-          }
-          streamRetries = 0; // 成功建立响应体：连续失败计数归零（有界重试只作用于连续失败）
-          var reader = r.body.getReader();
-          var decoder = new TextDecoder();
-          var buf = "";
-          var pump = function () {
-            reader.read().then(function process({ done, value }) {
-              if (done) {
-                scheduleReopen();
-                return;
-              }
-              buf += decoder.decode(value, { stream: true });
-              var idx;
-              while ((idx = buf.indexOf("\n\n")) !== -1) {
-                var chunk = buf.slice(0, idx);
-                buf = buf.slice(idx + 2);
-                var dataLine = null;
-                var ls = chunk.split("\n");
-                for (var i = 0; i < ls.length; i++) {
-                  if (ls[i].indexOf("data: ") === 0) { dataLine = ls[i].slice(6); break; }
-                }
-                if (!dataLine) continue;
-                var ev;
-                try { ev = JSON.parse(dataLine); } catch (e2) { continue; }
-                if (!ev || typeof ev.type !== "string") continue;
-                if (ev.type === "ready") { if (!readyReceived) mountReady(); }
-                else if (ev.type === "pending") {
-                  // web host 停机/重启窗口：退回未就绪态——清 readyReceived（重启完成
-                  // 后再次 ready 会经 mountReady 重挂 iframe），事件流保持常驻收 ready。
-                  // 重挂 30s 兜底（ready 事件缺失时引导看诊断）。
-                  if (readyReceived) {
-                    readyReceived = false;
-                    stopInstallTick();
-                    showLoading();
-                    if (!readyTimer) {
-                      readyTimer = setTimeout(function () {
-                        if (!readyReceived) loadDiagnosticsNow();
-                      }, 30000);
-                    }
-                  }
-                  pushPanel();
-                }
-                else if (ev.type === "diagnostics") { if (!readyReceived) showDiagnostics(ev.diagnostics); }
-                else if (ev.type === "theme-pref") { sendPrefTo(frame && frame.contentWindow, ev); }
-                else if (ev.type === "diag-changed") { refreshDiag(); }
-              }
-              // 递归 read 同样附加 rejection 处理：断流重开（ready 后亦然——事件流
-              // 常驻，theme-pref/diag-changed 依赖它持续到达）
-              reader.read().then(process).catch(function () {
-                scheduleReopen();
-              });
-            }).catch(function () {
-              scheduleReopen();
-            });
-          };
-          pump();
-          return null;
-        })
-        .catch(function () {
-          scheduleReopen();
-        });
-      function scheduleReopen() {
+      var bootRefreshing = false; // 快照拉取防并发（事件风暴/安装 tick/兜底共用）
+      function refreshBoot() {
+        if (bootRefreshing) return;
+        if (!hana || !hana.api || !hana.api.fetch) return;
+        bootRefreshing = true;
+        hana.api.fetch("webui/boot-state", { signal: AbortSignal.timeout(3000) })
+          .then(function (r) { return r.json(); })
+          .then(function (d) { if (d) applyBoot(d); })
+          .catch(function () { /* 快照读取失败忽略（等下一事件/兜底） */ })
+          .finally(function () { bootRefreshing = false; });
+      }
+      function mountReady() {
+        if (readyReceived) return;
+        readyReceived = true;
+        clearClocks();
+        clearReadyTimer();
+        document.body.setAttribute("data-view", "ready");
+        attach();
+        // 事件驱动的就绪（bus ready / 父窗口握手）可能早于快照：异步拉一次对齐面板/状态
+        if (!(boot && boot.ready === true)) refreshBoot();
+      }
+      function attach() {
+        var wasPending = document.body.getAttribute("data-view") !== "ready";
+        if (wasPending || !frame.getAttribute("src")) {
+          frame.src = "http://127.0.0.1:{{= it.port }}/";
+        }
+        startThemePush();
+        pushPanel();
+      }
+      // ---- 事件流（/webui/events，SSE 式 chunked）----
+      var streamAbort = null;
+      var streamRetries = 0;
+      function abortEventStream() {
+        if (streamAbort) { try { streamAbort.abort(); } catch (e) { /* 已关闭 */ } streamAbort = null; }
+      }
+      function openReadyStream() {
         if (streamRetries >= 10) return;
-        streamRetries += 1;
-        if (retryTimer) clearTimeout(retryTimer);
-        retryTimer = setTimeout(function () {
-          retryTimer = null;
-          openReadyStream();
-        }, 10000);
+        var ac = new AbortController();
+        streamAbort = ac;
+        var retryTimer = null;
+        hana.api.fetch("webui/events", { signal: ac.signal })
+          .then(function (r) {
+            if (!r || !r.ok || !r.body) { scheduleReopen(); return null; }
+            streamRetries = 0;
+            var reader = r.body.getReader();
+            var decoder = new TextDecoder();
+            var buf = "";
+            var pump = function () {
+              reader.read().then(function process(res) {
+                if (res.done) { scheduleReopen(); return; }
+                buf += decoder.decode(res.value, { stream: true });
+                var idx;
+                while ((idx = buf.indexOf("\n\n")) !== -1) {
+                  var chunk = buf.slice(0, idx);
+                  buf = buf.slice(idx + 2);
+                  var dataLine = null;
+                  var ls = chunk.split("\n");
+                  for (var i = 0; i < ls.length; i++) {
+                    if (ls[i].indexOf("data: ") === 0) { dataLine = ls[i].slice(6); break; }
+                  }
+                  if (!dataLine) continue;
+                  var ev;
+                  try { ev = JSON.parse(dataLine); } catch (e2) { continue; }
+                  if (!ev || typeof ev.type !== "string") continue;
+                  if (ev.type === "ready") {
+                    if (!readyReceived) mountReady();
+                  } else if (ev.type === "pending") {
+                    if (readyReceived) {
+                      readyReceived = false;
+                      refreshBoot();
+                    } else {
+                      refreshBoot();
+                    }
+                  } else if (ev.type === "diagnostics") {
+                    if (!readyReceived) refreshBoot();
+                  } else if (ev.type === "theme-pref") {
+                    sendPrefTo(frame && frame.contentWindow, ev);
+                  } else if (ev.type === "diag-changed") {
+                    refreshBoot();
+                  }
+                }
+                reader.read().then(process).catch(function () { scheduleReopen(); });
+              }).catch(function () { scheduleReopen(); });
+            };
+            pump();
+            return null;
+          })
+          .catch(function () { scheduleReopen(); });
+        function scheduleReopen() {
+          if (streamRetries >= 10) return;
+          streamRetries += 1;
+          if (retryTimer) clearTimeout(retryTimer);
+          retryTimer = setTimeout(function () {
+            retryTimer = null;
+            openReadyStream();
+          }, 10000);
+        }
       }
-    }
-    // 父窗口 postMessage ready（页面桥：宿主 UI / 测试直接推「ready」）
-    window.addEventListener("message", function (e) {
-      if (readyReceived) return;
-      var m = e.data;
-      if (m && typeof m === "object") {
-        // ① 纯 { type:"ready" }（壳页自身握手同款命名）
-        if (m.type === "ready" && !m.protocol) { mountReady(); return; }
-        // ② hana.plugin.ui 事件（type: dsh.ready）
-        if (m.protocol === "hana.plugin.ui" && m.kind === "event" && m.type === "dsh.ready") { mountReady(); return; }
+      // 父窗口 postMessage ready（页面桥 / hana.plugin.ui dsh.ready）
+      window.addEventListener("message", function (e) {
+        if (readyReceived) return;
+        var m = e.data;
+        if (m && typeof m === "object") {
+          if (m.type === "ready" && !m.protocol) { mountReady(); return; }
+          if (m.protocol === "hana.plugin.ui" && m.kind === "event" && m.type === "dsh.ready") { mountReady(); return; }
+        }
+      });
+      window.addEventListener("beforeunload", function () {
+        clearClocks();
+        clearReadyTimer();
+        abortEventStream();
+      });
+      // ---- 主题桥（壳页与内层 dsh iframe 主题实时跟随；保留既有实现）----
+      function readThemeVars() {
+        var cs = getComputedStyle(document.documentElement);
+        function v(name, fb) { var x = cs.getPropertyValue(name).trim(); return x || fb; }
+        var params = new URLSearchParams(location.search);
+        return {
+          themeId: params.get("hana-theme") || "inherit",
+          vars: {
+            bg: v("--bg", "#F5EFE4"),
+            bgCard: v("--bg-card", "#FBF7EE"),
+            sidebarBg: v("--sidebar-bg", "#EFE8DB"),
+            text: v("--text", "#2A2622"),
+            textLight: v("--text-light", "#4A433C"),
+            textMuted: v("--text-muted", "#6B6158"),
+            accent: v("--accent", "#537D96"),
+            accentHover: v("--accent-hover", "#3F6179"),
+            accentLight: v("--accent-light", "rgba(83,125,150,0.08)"),
+            userBg: v("--user-bg", "rgba(83,125,150,0.08)"),
+            border: v("--border", "#D8CFBE"),
+            green: v("--green", "#4A6B4A"),
+            danger: v("--danger", "#8B2C1F"),
+            overlayStrong: v("--overlay-strong", "rgba(42,38,34,0.15)"),
+            overlayMedium: v("--overlay-medium", "rgba(42,38,34,0.08)"),
+            dropOverlayBg: v("--drop-overlay-bg", "rgba(245,239,228,0.85)"),
+          },
+        };
       }
-    });
-    function loadDiagnosticsNow() {
-      // 一次性 health 查询（诊断数据源；不轮询）——30s 超时兜底/手动「查看诊断」用。
-      // 就绪（web host 已起但 ready 信号丢失）时直接挂载；未就绪渲染自检
-      hana.api.fetch("webui/health", { signal: AbortSignal.timeout(3000) })
-        .then(function (r) { return r.json(); })
-        .then(function (d) {
-          if (d && d.ok) { mountReady(); return; }
-          if (d && d.diagnostics) showDiagnostics(d.diagnostics);
-          else showDiagnostics(null);
-        })
-        .catch(function () { showDiagnostics(null); });
-    }
-    window.addEventListener("beforeunload", function () {
-      clearReadyTimers();
-      abortEventStream();
-    });
-    // 主题桥——dsh 页面（跨源 iframe）postMessage 索取 Hana 主题，
-    // 这里回传主题 id（location.search hana-theme）+ 实时变量值（hana-css 已
-    // link，getComputedStyle 读到当前主题生效值）；注入脚本与内置表合并后覆盖。
-    function readThemeVars() {
-      var cs = getComputedStyle(document.documentElement);
-      function v(name, fb) { var x = cs.getPropertyValue(name).trim(); return x || fb; }
-      var params = new URLSearchParams(location.search);
-      return {
-        themeId: params.get("hana-theme") || "inherit",
-        vars: {
-          bg: v("--bg", "#F5EFE4"),
-          bgCard: v("--bg-card", "#FBF7EE"),
-          sidebarBg: v("--sidebar-bg", "#EFE8DB"),
-          text: v("--text", "#2A2622"),
-          textLight: v("--text-light", "#4A433C"),
-          textMuted: v("--text-muted", "#6B6158"),
-          accent: v("--accent", "#537D96"),
-          accentHover: v("--accent-hover", "#3F6179"),
-          accentLight: v("--accent-light", "rgba(83,125,150,0.08)"),
-          userBg: v("--user-bg", "rgba(83,125,150,0.08)"),
-          border: v("--border", "#D8CFBE"),
-          green: v("--green", "#4A6B4A"),
-          danger: v("--danger", "#8B2C1F"),
-          overlayStrong: v("--overlay-strong", "rgba(42,38,34,0.15)"),
-          overlayMedium: v("--overlay-medium", "rgba(42,38,34,0.08)"),
-          dropOverlayBg: v("--drop-overlay-bg", "rgba(245,239,228,0.85)"),
-        },
-      };
-    }
-    function sendThemeTo(dst) {
-      var msg = { dshHanaTheme: readThemeVars() };
-      try { dst.postMessage(msg, "*"); } catch (err) { /* 目标不可达忽略 */ }
-    }
-    function sendPrefTo(dst, ev) {
-      // DSH 主题偏好变更通知（宿主经 /webui/events 收到 settings/document-updated 的
-      // ui-theme 后转来）：只带 revision，preference 值由注入脚本收到后重读一次
-      // settings/describe（事件驱动替代 3s 轮询）。
-      if (!dst) return;
-      var msg = { dshHanaPref: { revision: ev && ev.revision != null ? ev.revision : null } };
-      try { dst.postMessage(msg, "*"); } catch (err) { /* 目标不可达忽略 */ }
-    }
-    // —— 宿主主题实时跟随（feat/theme-live）——
-    // 宿主在 iframe 握手 ready 后，用进程级 MutationObserver 盯根节点 data-theme 与
-    // 样式表，主题一变即向插件 iframe 发 hana.theme.changed 协议事件（payload 含
-    // { theme, cssUrl }）。此前壳页只在挂载时读一次主题快照，宿主切主题后壳页不
-    // 感知、仍推旧快照，需重开标签页才生效。此分支收到实时通知后：按新 cssUrl 更新
-    // 自身主题 <link>（让 getComputedStyle 读到新变量）→ 经现有 readThemeVars() 重读
-    // → sendThemeTo(frame.contentWindow) 重推内层 dsh iframe（dsh-hana-theme 幂等，
-    // 收到新 vars 即重建样式）。与下方 1.5s 定时重推 / dshHanaThemeRequest 应答并存，
-    // 互不冲突（后者留作 fallback）。
-    function hanaThemeLink() {
-      // 精确锚定宿主 hana-css（href 固定带 /theme.css），避免误换 head 里其它样式表。
-      var links = document.head.querySelectorAll('link[rel="stylesheet"]');
-      for (var i = 0; i < links.length; i++) {
-        if (links[i].href && links[i].href.indexOf("/theme.css") !== -1) return links[i];
+      function sendThemeTo(dst) {
+        var msg = { dshHanaTheme: readThemeVars() };
+        try { dst.postMessage(msg, "*"); } catch (err) { /* 目标不可达忽略 */ }
       }
-      return null;
-    }
-    function pushThemeNow() {
-      var cw = frame && frame.contentWindow;
-      if (cw) sendThemeTo(cw);
-    }
-    function applyHostThemeChange(m) {
-      var p = (m && m.payload && typeof m.payload === "object") ? m.payload : (m || {});
-      var theme = p.theme || p.themeId || "";
-      var cssUrl = p.cssUrl || "";
-      // 更新壳页自身主题标记与 color-scheme：data-hana-theme 反映实时主题，color-scheme
-      // 让壳页诊断区与跨源 dsh iframe 继承的 prefers-color-scheme 跟随宿主明暗。
-      if (theme) {
-        document.body.setAttribute("data-hana-theme", theme);
-        var csMeta = document.querySelector('meta[name="color-scheme"]');
-        if (csMeta) csMeta.setAttribute("content", /midnight|dark/i.test(theme) ? "dark" : "light");
+      function sendPrefTo(dst, ev) {
+        if (!dst) return;
+        var msg = { dshHanaPref: { revision: ev && ev.revision != null ? ev.revision : null } };
+        try { dst.postMessage(msg, "*"); } catch (err) { /* 目标不可达忽略 */ }
       }
-      if (!cssUrl) { pushThemeNow(); return; }
-      // 按新 cssUrl 更新主题 <link>：宿主挂载时已注入 hana-css link 则换 href，否则
-      // 补建一个（宿主未传 hana-css 的兜底）。需等新样式表加载完再读 getComputedStyle，
-      // 否则读到的还是旧变量。
-      var link = hanaThemeLink();
-      var done = false;
-      function settle() { if (done) return; done = true; pushThemeNow(); }
-      if (!link) {
-        link = document.createElement("link");
-        link.rel = "stylesheet";
-        link.onload = settle;
-        link.onerror = settle;
-        link.href = cssUrl;
-        document.head.appendChild(link);
-      } else {
-        link.onload = settle;
-        link.onerror = settle;
-        if (link.href !== cssUrl) link.href = cssUrl;
+      function hanaThemeLink() {
+        var links = document.head.querySelectorAll('link[rel="stylesheet"]');
+        for (var i = 0; i < links.length; i++) {
+          if (links[i].href && links[i].href.indexOf("/theme.css") !== -1) return links[i];
+        }
+        return null;
       }
-      // 兜底：跨源/缓存样式表 onload 可能不触发，300ms 后无论如何重推一次。
-      setTimeout(settle, 300);
-    }
-    window.addEventListener("message", function (e) {
-      var m = e.data;
-      if (m && m.dshHanaThemeRequest) { sendThemeTo(e.source); return; }
-      // 宿主实时主题变更（hana.plugin.ui 协议或事件名 hana.theme.changed，源自宿主父窗口）。
-      if (m && (m.type === "hana.theme.changed" || m.event === "hana.theme.changed")
+      function pushThemeNow() {
+        var cw = frame && frame.contentWindow;
+        if (cw) sendThemeTo(cw);
+      }
+      function applyHostThemeChange(m) {
+        var p = (m && m.payload && typeof m.payload === "object") ? m.payload : (m || {});
+        var theme = p.theme || p.themeId || "";
+        var cssUrl = p.cssUrl || "";
+        if (theme) {
+          document.body.setAttribute("data-hana-theme", theme);
+          var csMeta = document.querySelector('meta[name="color-scheme"]');
+          if (csMeta) csMeta.setAttribute("content", /midnight|dark/i.test(theme) ? "dark" : "light");
+        }
+        if (!cssUrl) { pushThemeNow(); return; }
+        var link = hanaThemeLink();
+        var done = false;
+        function settle() { if (done) return; done = true; pushThemeNow(); }
+        if (!link) {
+          link = document.createElement("link");
+          link.rel = "stylesheet";
+          link.onload = settle;
+          link.onerror = settle;
+          link.href = cssUrl;
+          document.head.appendChild(link);
+        } else {
+          link.onload = settle;
+          link.onerror = settle;
+          if (link.href !== cssUrl) link.href = cssUrl;
+        }
+        setTimeout(settle, 300);
+      }
+      window.addEventListener("message", function (e) {
+        var m = e.data;
+        if (m && m.dshHanaThemeRequest) { sendThemeTo(e.source); return; }
+        if (m && (m.type === "hana.theme.changed" || m.event === "hana.theme.changed")
           && e.source === window.parent) {
-        applyHostThemeChange(m);
+          applyHostThemeChange(m);
+        }
+      });
+      var activePushTimer = null;
+      function startThemePush() {
+        var cw = frame && frame.contentWindow;
+        if (!cw) return;
+        sendThemeTo(cw);
+        clearInterval(activePushTimer);
+        activePushTimer = setInterval(function () {
+          var win = frame && frame.contentWindow;
+          if (win) sendThemeTo(win);
+          else { clearInterval(activePushTimer); activePushTimer = null; }
+        }, 1500);
       }
-    });
-    var activePushTimer = null;
-    function startThemePush() {
-      var cw = frame && frame.contentWindow;
-      if (!cw) return;
-      sendThemeTo(cw);
-      clearInterval(activePushTimer);
-      activePushTimer = setInterval(function () {
-        var win = frame && frame.contentWindow;
-        if (win) sendThemeTo(win);
-        else { clearInterval(activePushTimer); activePushTimer = null; }
-      }, 1500);
-    }
-    // 就绪事件化引导：未就绪（服务端渲染即总线未连接）→ 加载态 + 订阅宿主就绪事件流
-    // + 30s 超时兜底（引导刷新/看诊断）；就绪态（服务端渲染即已连接）→ 直接进入。
-    // 诊断页按钮事件委托无条件绑定（diag-list 元素恒在，从 iframe 态退回诊断页后按钮依旧可点）
-    var diagList = document.getElementById("diag-list");
-    if (diagList) diagList.addEventListener("click", onDiagClick);
-    if (document.body.getAttribute("data-pending") === "1") {
-      showLoading(); // 未就绪：加载态（「正在启动 DSH web host…」）
-      openReadyStream(); // 订阅宿主就绪事件流（ready/pending/diagnostics 事件）
-      readyTimer = setTimeout(function () {
-        if (!readyReceived) loadDiagnosticsNow(); // 30s 未就绪：引导看诊断（可刷新/修复）
-      }, 30000);
-    } else {
-      // 就绪态（服务端渲染即已连接）：统一走 attach 挂载（src 由壳页 JS 设置——
-      // 直嵌根路径，无 BFF 代理/凭据透传（vY：pluginSurfaceSession 仅用于 hana.api.fetch 调用）），
-      // 并订阅常驻事件流——theme-pref / diag-changed / 重启窗口的 pending → ready
-      // 周期在就绪态同样生效，全部依赖这条流。
-      readyReceived = true;
-      attach();
-      openReadyStream();
-    }
-    syncPanelFromDiag(initDiag); // 初始面板状态（readyReceived 已就位，避免初始错推「未就绪」）
-}) ();
+      // ---- 初始化 ----
+      if (document.body.getAttribute("data-view") === "ready") {
+        readyReceived = true;
+        attach();
+        openReadyStream();
+      } else {
+        if (initBoot && typeof initBoot === "object") applyBoot(initBoot);
+        else refreshBoot();
+        openReadyStream();
+      }
+    })();
   </script>
 </body>
 

--- a/src/index.js
+++ b/src/index.js
@@ -18,8 +18,8 @@
 //     web host boot → ready，失败按 errorClass 退避重试或停等待条件，见 onload 内自动链注释）
 //  4. 插件卸载/重载时回收常驻 web host 子进程。
 // 单例挂在 globalThis.__dshHanako（tools/dsh-run.js 的 rspack bundle 内联 app/lifecycle.js，
-// mountLifecycle 挂 closeProcess/collectDiagnostics/updateDsh/startWebHost/installDeps/verifyDeps/
-// checkDshUpdate）。本文件为 bundle 收敛入口：静态 import 全部插件模块（单 bundle 内无模块缓存问题）。
+// mountLifecycle 挂 closeProcess/updateDsh/startWebHost/installDeps/verifyDeps/checkDshUpdate）。
+// 本文件为 bundle 收敛入口：静态 import 全部插件模块（单 bundle 内无模块缓存问题）。
 import { existsSync, mkdirSync, appendFileSync, watch } from "node:fs";
 import { join, dirname } from "node:path";
 // 日志生命周期（vX 起独立于 migrate 体系）：旧日志归档压缩 + 时间戳日志文件命名
@@ -227,7 +227,7 @@ export default class DshHanakoPlugin {
     // 链（30s→2m→10m→30m cap，插件生命周期内持续）到点自动重新评估；③ 停等类中配置引导
     // 类（macos-signature：nodejsPath 配置）→ fs.watch config.json 变化即重新评估（设置保存
     // 后自动续跑）；④ 宿主重启/插件重载 → 新 onload 重新评估（g.web?.ready 快速路径收敛）。
-    // 手动/工具路径（dsh_install autoStart、/webui/start、诊断卡按钮）与状态机并存：
+    // 手动/工具路径（dsh_install 工具 autoStart）与状态机并存：
     // installDepsFromPlugin 的 installing/running 守卫 + ensureWebHost 的 readyPromise 幂等
     // ——他人路径先装/先起时状态机让路（等落终态或直接收敛），互不冲突。
     //
@@ -250,7 +250,7 @@ export default class DshHanakoPlugin {
     ]);
     // 停等类中「配置变化即可续跑」的子集（挂 config.json watch；其余停等类只等重载/重启）
     const CONFIG_CONTINUE_CLASSES = new Set(["macos-signature"]);
-    // boot 升级缓存残留特征（与 lifecycle.js pickProcessFix 判定同源）：跨 dsh 版本升级后
+    // boot 升级缓存残留特征（原诊断修复指引判定同源，T5 随诊断壳退役，特征正则沿用）：跨 dsh 版本升级后
     // 宿主进程仍持旧模块缓存，boot 读已删 .pnpm 路径必败——重启宿主前重试无意义，归
     // restart-needed 停等
     const ENOENT_TEXT_RE = /(?:ENOENT|no such file|cannot find)/i;

--- a/src/index.js
+++ b/src/index.js
@@ -342,6 +342,7 @@ export default class DshHanakoPlugin {
       g.boot.attempt = 0;
       g.boot.nextRetryAt = null;
       g.boot.errorClass = null;
+      g.boot.guidance = null;
       g.boot.lastError = null;
     };
     // 读最近 install 失败分类（T1 落 g.deps.errorClass = { errorClass, guidance }；
@@ -380,6 +381,10 @@ export default class DshHanakoPlugin {
       // 通知纪律：同一失败原因（阶段+类别+错误首行）只主动通知一次；后续重试只打进度日志
       const notifyKey = stage + ":" + klass + ":" + head;
       const guide = guidance || ERROR_CLASS_GUIDANCE[klass] || "";
+      // T3：失败决策的指引文案随失败状态落 g.boot.guidance（快照端点/壳页 action-needed
+      // 渲染数据源——六类 + restart-needed 均有文案，页面不猜；成功收敛时随失败记录一并
+      // 清空，见 convergeReady；重试期间保留最近一次失败文案，与 errorClass/lastError 同生命周期）
+      g.boot.guidance = guide || null;
       if (notifyKey !== lastNotifiedKey) {
         lastNotifiedKey = notifyKey;
         g.appendLog?.(

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -10,7 +10,6 @@
 // 本模块承载（逐字迁移自 dsh-run.js，逻辑零改动）：
 //   web host 拉起    ensureWebHost（进程内 boot dsh + 端口就绪等待，幂等）+ startWebHostFromPlugin（挂 g.startWebHost）
 //   关闭回收         closeProcess（先清 provider/update watch，再 kill 子进程）
-//   连接失败自检     collectWebDiagnostics + buildDepsDiagCheck + buildProcessDiagCheck + pickProcessFix
 //   更新 DSH         updateDsh（停 host → 装依赖 → 起 host → 读版本，结果走内存态 g.update）
 //   watch           ensureProviderPushWatch（provider 热跟随 watch）
 //   provider 路由     detectHostProviderPaths / readJsonFile / mapModel / readHostConfig / buildProviderRoutes
@@ -19,7 +18,7 @@
 //                    本模块经 runMigrations 统一调度（startWebHostFromPlugin 调 config-schema；
 //                    junction 收敛同样迁入 migrate.js，ensureWebHost 调 junction-converge）
 //   web host 日志     logTs / appendLog / logFileStamp / newWebLogPath（兜底实现）
-// 单例挂载（globalThis.__dshHanako，经 getSingleton()）：g.closeProcess / g.collectDiagnostics /
+// 单例挂载（globalThis.__dshHanako，经 getSingleton()）：g.closeProcess /
 // g.updateDsh / g.startWebHost / g.installDeps / g.verifyDeps / g.checkDshUpdate 均在本模块顶层完成
 // （installDeps/verifyDeps/checkDshUpdate 直接引用 lib/install.js & lib/check.js）；g.runMigrations
 // 由 src/migrate.js 顶层挂载（本模块 import 时即挂好）。routes/webui.js、index.js、tools/dsh-*.js
@@ -34,8 +33,8 @@
 //
 // 语义不变：ensureWebHost 重复调用幂等；web host 进程随插件 onload/卸载生命周期拉起/回收
 // （index.js register 回收调用 g.closeProcess）；providerPushCleanup / updateWatchCleanup 清理时机与
-// 拆分前一致；updateDsh 流程（停 host→装依赖→起 host→读版本）保持完整；collectWebDiagnostics 输出的
-// checks 结构（t1 依赖 / t2 进程）令 routes/webui.js 渲染不变。
+// 拆分前一致；updateDsh 流程（停 host→装依赖→起 host→读版本）保持完整。（T5：旧诊断壳
+// checks 结构已随 collectWebDiagnostics 家族退役，自举状态出口 = GET /webui/boot-state）
 import { randomUUID } from "node:crypto";
 import { createRequire } from "node:module";
 import { pathToFileURL } from "node:url";
@@ -54,10 +53,6 @@ import {
   rmSync,
   rmdirSync,
   readdirSync,
-  statSync,
-  openSync,
-  readSync,
-  closeSync,
 } from "node:fs";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
@@ -72,7 +67,6 @@ import {
   resolveDshPkgDir,
   installDepsFromPlugin,
   verifyDepsSmoke,
-  readDshInstalledVersion,
 } from "./tools/lib/install.js";
 import { connectBus, closeBus, setBusConfigProvider } from "./lib/bus.js";
 
@@ -684,8 +678,8 @@ export async function ensureWebHost(cfg) {
     g.web = null;
   }
   // 新启动尝试开始：作废旧退出记录（webLastExit 只反映「最近一次进程退出」；本次尝试
-  // 失败会更新 webLastError，诊断应走启动失败分支而非旧退出分支——否则 lastExit 遮蔽
-  // 当前失败，pickProcessFix 指引丢失。CodeRabbit PR #53）
+  // 失败会更新 webLastError，boot-state 应反映启动失败而非旧退出——否则 lastExit 遮蔽
+  // 当前失败，自举页误示进程退出。CodeRabbit PR #53）
   g.webLastExit = null;
   if (!cfg.dshPkgDir) cfg.dshPkgDir = resolveDshPkgDir(cfg);
 
@@ -1097,8 +1091,8 @@ getSingleton().startWebHost = async function startWebHostFromPlugin(
     const logPath = g.web?.logPath || g.webLastExit?.logPath || null;
     if (logPath) g.webLastLogPath = logPath;
     g.webLastErrorAt = new Date().toISOString();
-    // web host 启动失败：通知壳页就绪事件流推诊断（routes/webui.js 注册回调，
-    // 诊断对象由 readDiagnostics 收集；无订阅者 no-op）
+    // web host 启动失败：通知壳页事件流刷新自举状态（routes/webui.js 注册回调，推
+    // diag-changed 信号 → 壳页刷新 /webui/boot-state 呈现 waiting；无订阅者 no-op）
     if (typeof g.notifyWebStartFailed === "function") {
       try {
         g.notifyWebStartFailed();
@@ -1112,373 +1106,16 @@ getSingleton().startWebHost = async function startWebHostFromPlugin(
 
 // installDepsFromPlugin / verifyDepsSmoke 已提取到 lib/install.js（本文件顶部
 // import），这里显式挂单例（getSingleton 本体在 lib/state.js 不再逐函数赋值；mountSingleton
-// 与 lib 侧挂载保持同款幂等语义）。routes/webui.js 经 g.installDeps / g.verifyDeps 调用。
+// 与 lib 侧挂载保持同款幂等语义）。tools/dsh-install.js（Agent）与 index.js 自动链经
+// g.installDeps / g.verifyDeps 调用（/webui 手动路由已随 T5 退役）。
 getSingleton().installDeps = installDepsFromPlugin;
 getSingleton().verifyDeps = verifyDepsSmoke;
-// ---- 连接失败自检（插件页 web host 未就绪时的诊断数据源）----
-// 供 routes/webui.js 使用（经单例 globalThis.__dshHanako.collectDiagnostics 挂载，
-// 不静态 import 本模块——Hana 带 ?t= 加载 tools，静态 import 会命中 Node ESM 固定
-// URL 缓存读到旧模块，见文件头注释；与 index.js 经单例取 closeProcess 同一套纪律）。
-// web host 未就绪时逐项检查：① dsh 依赖（resolveDshPkgDir + cliBin 存在性）② DSH 进程状态（单例 web /
-// webLastError / stderr 尾部）。只回布尔与截断文本；单例/字段缺失（冷启动、
-// web 从未拉起）全部容错，本函数永不抛异常。
-export function collectWebDiagnostics(cfg = {}) {
-  const out = {
-    port: Number(cfg.webPort) || 3080,
-    checks: [],
-  };
-  try {
-    // 数据目录解析链：显式传入 → 单例记录（onload/工具已写入）→ 从 web.dshHome 反推
-    const g = getSingleton();
-    const dataDir =
-      cfg.dataDir ||
-      g.dataDir ||
-      (g.web?.dshHome ? dirname(g.web.dshHome) : "");
-    const diagCfg = { ...cfg, dataDir };
-    // 不再自动触发运行级检测（去掉 maybeTriggerDepsSmoke）——检测改为「进标签页
-    // 自动一次 + 手动「检测依赖」按钮」，经 GET /webui/verify-deps 路由驱动；g.deps.result
-    // 只存最近一次检测结果供诊断展示（不随 3s 轮询重复 spawn）。
-    out.checks.push(buildDepsDiagCheck(g, diagCfg));
-    out.checks.push(buildProcessDiagCheck(g, out));
-  } catch (e) {
-    // 顶层兜底：诊断读取本身异常时回退成「未知」项，接口不抛
-    out.checks.push({
-      key: "unknown",
-      name: "自检异常",
-      ok: false,
-      detail: String(e?.message || e).slice(0, 400),
-      fix: "请查看 Hana 日志或重启 Hana 后重试",
-    });
-  }
-  return out;
-}
-
-/** ① dsh 依赖：cliBin 存在性（resolveDshPkgDir 同款：数据目录 dsh-pkg 优先，插件根兑底）
- * v0.8.6: 叠加部署状态——g.deps.status（installing 进行中）/ g.deps.error（上次失败）/ g.deps.log
- * v0.8.7: 叠加运行级完整性验证——g.deps.result（verifyDepsSmoke 缓存 { ok, version, error, stderr, at, running }）。
- * v0.24: 单例分组结构化——g.deps = { status, result, error, time, log }、g.update =
- * { status, result, error, time, log }、g.check = { status, result, error, time, log }
- * （旧平铺字段全废；update-result.json 退役，updateResult 改内存态组合）。
- * v0.13.0: 叠加版本/检查/更新状态——version（当前版本）、check（最近一次 checkDshUpdate
- * 缓存：latest/updateAvailable/at/error）、checking/updating（进行中）、updateResult
- * （内存态：g.update.status + g.update.result.version）——deps 卡片版本行 + 「检查更新」
- * 「更新 DSH」按钮数据源。
- * ok 判定升级：存在 且（未验证/验证中视为暂通过，验证过必须通过）——文件存在 ≠ 依赖完整。 */
-function buildDepsDiagCheck(g, cfg) {
-  const pkgDir = resolveDshPkgDir(cfg);
-  const cliBin = join(
-    pkgDir,
-    "node_modules",
-    "@deepseek-ai",
-    "dsh",
-    "lib",
-    "bin.js",
-  );
-  // 候选位置全列出，未命中时讲清「查了哪些位置」（resolveDshPkgDir 只回命中/兑底那一个）
-  const candidates = [];
-  if (cfg.dataDir) candidates.push(join(cfg.dataDir, "dsh-pkg"));
-  candidates.push(PLUGIN_ROOT);
-  const checked = [
-    ...new Set(
-      candidates.map((p) =>
-        join(p, "node_modules", "@deepseek-ai", "dsh", "lib", "bin.js"),
-      ),
-    ),
-  ];
-  const installed = existsSync(cliBin);
-  // 部署状态（installDeps 写入单例分组 g.deps；只回非敏感布尔与截断文本）
-  const installing = g.deps.status === "installing";
-  const installError = String(g.deps.error || "").slice(0, 300);
-  const installLog = String(g.deps.log || "").slice(-800);
-  const installAt = g.deps.time || null; // 最近一次 npm i 输出时间（实时进度）
-  // 依赖核对状态（verifyDepsSmoke 静态核对缓存于 g.deps.result；非敏感：布尔/版本号/截断错误文本）
-  const smoke = g.deps.result || null;
-  const verifyRunning = Boolean(smoke?.running);
-  const verified = installed && smoke ? Boolean(smoke.ok) : null; // null = 未安装/未验证过（暂通过）
-  const verifyError =
-    smoke && !smoke.ok && !smoke.running
-      ? String(smoke.error || smoke.stderr || "").slice(0, 400)
-      : null;
-  const verifyVersion = smoke?.version ?? null;
-  const verifyAt = smoke?.at ?? null;
-  // pnpm 引导状态（独立子项，不进 ok 判定）：透出 verifyDepsSmoke 的 pnpm 检查结果
-  // （pnpmReady/pnpmVersion/pnpmError；smoke 未生成过 → checked=false，前端不渲染该行）。
-  // 仅 DSHana 标签页 deps 卡片展示（settings「检查与更新 DSH」卡片不展示 pnpm 状态——
-  // 用户决策：远端版本查询已改 HTTP 直查，settings 侧不关心 pnpm 引导）。
-  const pnpmChecked = Boolean(smoke);
-  const pnpmReady = Boolean(smoke?.pnpmReady);
-  const pnpmVersion = smoke?.pnpmVersion || null;
-  const pnpmError = smoke?.pnpmError
-    ? String(smoke.pnpmError).slice(0, 300)
-    : null;
-  // 当前版本（核对缓存优先，无则直读 dsh 包 package.json）+ 版本检查
-  // 状态（g.check.result 缓存：最近一次 checkDshUpdate 结果）+ 更新状态（g.update.status /
-  // g.update.error + 内存态 updateResult，v0.24 起不再读 update-result.json）。
-  // 只回非敏感布尔/版本号/截断文本。
-  const currentVersion =
-    (smoke && !smoke.running && smoke.ok ? smoke.version : null) ||
-    readDshInstalledVersion(cfg) ||
-    null;
-  const checkResult = g.check.result || null;
-  const checking = g.check.status === "running";
-  const updating = g.update.status === "running";
-  const updateError = String(g.update.error || "").slice(0, 300);
-  // 更新结果内存态组合（v0.24：update-result.json 退役，不再读文件；状态 + 终态版本 +
-  // 错误 + 时间，version 更新终态优先、依赖验证缓存兜底）
-  // 状态值域映射：g.update.status（idle/running/ok/error）→ 诊断对外契约值
-  // （done/updating/error；webui-shell.jinja2 按 state === "done" 渲染完成文案）
-  const updateState =
-    { ok: "done", running: "updating" }[g.update.status] || g.update.status;
-  const updateResult = {
-    state: updateState,
-    version: g.update.result?.version || g.deps.result?.version || null,
-    error: g.update.error || null,
-    at: g.update.time || null,
-  };
-  // ok：存在 且（未验证/验证中暂通过；验证过必须通过）——验证失败 → ok=false
-  const ok = installed && (!smoke || smoke.ok || smoke.running);
-  const check = {
-    key: "deps",
-    name: "DSH 依赖安装",
-    ok,
-    installed,
-    installing,
-    verified,
-    verifyRunning,
-    verifyError,
-    verifyVersion,
-    verifyAt,
-    installError: installError || null,
-    installLog: installLog || null,
-    installAt,
-    pkgDir,
-    cliBin,
-    // 版本/检查/更新状态（deps 卡片版本行 + 检查更新/更新 DSH 按钮）
-    version: currentVersion,
-    check: {
-      latest: checkResult?.latestVersion ?? null,
-      updateAvailable: Boolean(checkResult?.updateAvailable),
-      at: checkResult?.at || null,
-      error: String(checkResult?.error || "").slice(0, 300) || null,
-    },
-    checking,
-    updating,
-    updateError: updateError || null,
-    updateResult,
-    // pnpm 引导状态（独立子项，不进 ok 判定；见上方 pnpmChecked 注释）
-    pnpmChecked,
-    pnpmReady,
-    pnpmVersion,
-    pnpmError,
-    detail: "",
-    fix: "",
-  };
-  if (installing) {
-    // 安装中（含重装场景 installed 仍可能为 true）优先——实时进度
-    // installLog 尾部由前端 .diag-progress 展示（随轮询刷新）
-    check.detail = "正在安装依赖…（进度见下方）";
-    check.fix = "";
-  } else if (!installed) {
-    // 未安装：保持现有文案
-    check.detail =
-      "未找到 DSH 包：" +
-      cliBin +
-      " 不存在" +
-      (checked.length > 1 ? "（已检查 " + checked.join("、") + "）" : "");
-    if (installError) check.detail += "\n[上次安装失败] " + installError;
-    check.fix =
-      "依赖缺失：点击本卡片「安装依赖」按钮自动按插件声明安装依赖（完成后自动核对）；或确认插件目录 node_modules 解压完整";
-  } else if (!smoke) {
-    // 未检测过（进标签页自动检测一次 / 手动「检测依赖」；ok 暂算 installed）
-    check.detail = "DSH 包已就绪，点击「检测依赖」核对完整性";
-  } else if (verifyRunning) {
-    // 检测进行中（静态核对瞬时完成，此分支实际罕见；保留兼容 running 语义）
-    check.detail = "正在检测依赖…";
-  } else if (!smoke.ok) {
-    // 存在但核对失败（cliBin 缺失 / 版本与声明不一致，error 为原因）
-    check.detail =
-      "DSH 包核对失败：" +
-      (verifyError || smoke.error || "未知原因（版本与声明不一致？）");
-    check.fix =
-      "点击本卡片「重新安装依赖」按钮重新按插件声明安装（完成后自动核对）";
-  } else {
-    // 存在 + 核对通过（静态：磁盘版本 === 插件声明）——能跑与否由 boot 进程内裁决
-    check.detail =
-      "DSH 包已就绪（与插件声明一致，版本 v" +
-      (currentVersion || smoke?.version || "?") +
-      "）：" +
-      cliBin;
-  }
-  return check;
-}
-
-/** ② DSH 进程：单例 web 状态（child/exitCode/ready/stderr 尾部）+ webLastError/webLastErrorAt + webLastExit
- * v0.8.5: webLastExit 为单例持久退出记录（进程被外部杀掉时 g.web 已摘除，凭它区分
- * 「已退出」而非误报「尚未启动」）；只在 ensureWebHost 成功拉起新进程（ready）时清掉。 */
-// 会话日志尾部读取（诊断滚动区数据源）：错误行/堆栈本来就逐行写进会话日志文件
-// （emitLog 行规范化，见文件头「统一日志」）——单一事实源 = 日志文件，不为 UI 在
-// 内存另存副本（实装 2026-09-02 指示）。失败态诊断读尾部 ≤maxBytes 供界面滚动渲染：
-// openSync + readSync 只读尾部（不整文件读入）；路径缺失/读失败静默返回 ""（无滚动区）。
-function readLogTail(logPath, maxBytes) {
-  try {
-    if (!logPath || !existsSync(logPath)) return "";
-    const st = statSync(logPath);
-    if (!st || st.size <= 0) return "";
-    const len = Math.min(st.size, maxBytes || 16384);
-    const fd = openSync(logPath, "r");
-    try {
-      const buf = Buffer.alloc(len);
-      readSync(fd, buf, 0, len, st.size - len);
-      return buf.toString("utf8");
-    } finally {
-      closeSync(fd);
-    }
-  } catch {
-    return "";
-  }
-}
-
-function buildProcessDiagCheck(g, out) {
-  const web = g.web || null;
-  const child = web?.child || null;
-  // T7b 进程内形态：无子进程——「存活」= boot 完成且未 shutdown（disposed 标记）
-  const inproc = web?.processMode === "inproc";
-  const lastExit = g.webLastExit || null; // 持久退出记录：{ code, signal, at, stderr, logPath } | null
-  const started = Boolean(web || g.webLastError || lastExit);
-  const alive = inproc
-    ? Boolean(web && !web.disposed)
-    : Boolean(child && child.exitCode === null);
-  const ready = Boolean(web?.ready);
-  const exitCode = inproc ? null : child?.exitCode ?? lastExit?.code ?? null;
-  const stderr = String(web?.stderr || lastExit?.stderr || "").slice(-800); // stderr 尾部截断 ≤800
-  const lastError = String(g.webLastError || "").slice(-800);
-  // 完整错误原文（不截断，供修复指引匹配）：存储端已限 message≤1500 + stderr≤800（见
-  // startWebHostFromPlugin catch）。匹配不依赖截断窗口——长错误被 slice(-800) 截尾会丢
-  // 掉首行的错误特征（错误码/路径在头部），实装验证 2026-09-02 曾因此落兑底文案误导。
-  const lastErrorFull = String(g.webLastError || "");
-  const lastErrorAt = g.webLastErrorAt || "";
-  // 本次会话日志路径（当前 web / 退出记录 / 失败记录，三级兜底）
-  const logPath = web?.logPath || lastExit?.logPath || g.webLastLogPath || null;
-  const check = {
-    key: "process",
-    name: "DSH 进程状态",
-    ok: started && ready && alive,
-    started,
-    alive,
-    ready,
-    exitCode,
-    stderr,
-    lastError,
-    lastErrorAt,
-    logPath, // 完整日志路径（界面展示「本次会话日志」）
-    lastExit, // 结构化退出记录（非敏感），供前端/调试
-    detail: "",
-    fix: "",
-  };
-  const port = out.port;
-  if (!started) {
-    // 从未启动：无 web / webLastError / webLastExit（冷启动或从未拉起过）
-    check.detail =
-      "web host 尚未启动（插件加载即拉起，可能仍在初始化，或从未成功启动过）";
-    check.fix =
-      "稍候自动重试；若持续未就绪，可点击本卡片「手动启动 web host」按钮重新拉起，或检查上方依赖项";
-  } else if (ready && alive) {
-    // 已就绪但探测未命中（端口短暂不可达等）：仍提示重试
-    check.detail =
-      (inproc ? "进程内 boot 已就绪，但端口 " : "进程运行中且已就绪，但端口 ") +
-      port +
-      " 探测未命中（可能短暂不可达）";
-    check.fix = "稍候自动重试；若持续未就绪，检查端口是否被其他程序占用";
-  } else if (alive) {
-    check.detail =
-      (inproc
-        ? "进程内 boot 完成，端口 " + port + " 尚未就绪"
-        : "进程运行中，端口 " + port + " 尚未就绪") +
-      (stderr ? "\n[stderr 尾部] " + stderr : "");
-    check.fix =
-      "正在启动，请稍候自动重试；若长时间未就绪，检查端口是否被占用，或重启 Hana";
-  } else if (lastExit) {
-    // 进程曾运行后退出/被外部杀掉：展示持久退出记录（g.web 已摘除，stderr 从 lastExit 取）。
-    // code/signal 可能为 null（Windows 杀进程无 signal、信号杀进程无 code）：只列非空项
-    const codeTxt =
-      lastExit.code !== null && lastExit.code !== undefined
-        ? "code=" + lastExit.code
-        : null;
-    const sigTxt =
-      lastExit.signal !== null && lastExit.signal !== undefined
-        ? "signal=" + lastExit.signal
-        : null;
-    const exitTxt =
-      codeTxt || sigTxt
-        ? [codeTxt, sigTxt].filter(Boolean).join(" ")
-        : "code=? signal=?";
-    check.detail =
-      "进程已退出（" +
-      exitTxt +
-      "，时间 " +
-      lastExit.at +
-      "）" +
-      (lastExit.stderr ? "\n[stderr 尾部] " + lastExit.stderr : "");
-    // 进程退出现场：日志尾部滚动查看（stderr 展示截断 ≤800，全文在会话日志）
-    check.errLog = readLogTail(logPath, 16384);
-    check.fix = "点击本卡片「手动启动 web host」按钮重新拉起，或重启 Hana";
-  } else {
-    // 启动失败（webLastError）：detail 摘要取错误首行（错误码在头部，一眼可读）；
-    // errLog = 会话日志尾部（错误行与堆栈本来逐行写进日志，滚动区直接显示日志，不为
-    // UI 另存内存副本）；完整日志路径 logPath 已展示，可跳全文。
-    // depsOk 传入 pickProcessFix：升级缓存残留判定需依赖「当前可用」为前提——取本次诊断
-    // deps 项的 ok（= installed && 无明确验证失败，见 buildDepsDiagCheck），而非 verified：
-    // verified（installed && smoke.ok）在 verify 进行中会被瞬时置 false（running 窗口
-    // smoke 重置为 ok:false），此时 boot 失败 ENOENT 会误落兑底；ok 含当前 installed 硬
-    // 条件（包被移除不判残留，CodeRabbit PR #51）且 running/未验证暂通过不误杀
-    const errHead = (lastErrorFull.split("\n")[0] || lastError || "").slice(0, 300);
-    check.detail = lastErrorFull || lastError
-      ? "启动失败：" + errHead
-      : "进程已退出（code=" +
-        (exitCode ?? "?") +
-        "）" +
-        (stderr ? "\n[stderr 尾部] " + stderr : "");
-    check.errLog = readLogTail(logPath, 16384);
-    check.fix = pickProcessFix(
-      lastErrorFull || lastError,
-      stderr,
-      port,
-      out.checks.find((c) => c.key === "deps")?.ok === true,
-    );
-  }
-  return check;
-}
-
-/** 进程失败修复指引：按失败原因内容匹配（依赖 / 升级缓存残留 / 端口占用），兜底通用建议。
- * 同时匹配 webLastError 与 stderr 尾部——端口占用等错误常只出现在 stderr（进程退出时
- * webLastError 可能未携带 stderr 尾部，见「进程已退出」分支）。
- * depsOk：依赖是否当前可用（调用方取本次诊断 deps 项 ok = installed && 无明确验证失败）
- * ——升级缓存残留判定以此为门控，见下方注释。 */
-function pickProcessFix(lastError, stderr, port, depsOk) {
-  const text = (lastError || "") + "\n" + (stderr || "");
-  // 跨 dsh 版本升级缓存残留（spec「升级 dsh = 装新插件包 + 重启宿主」既定流程，无豁免层）：
-  // 宿主进程内 ESM import 缓存 key 跨版本稳定，热加载新插件后仍命中旧 dsh 模块，boot 读
-  // 已删旧 .pnpm 路径 ENOENT。特征 = 依赖当前可用（depsOk）+ 错误含 ENOENT/no
-  // such file/Cannot find + 路径指向 .pnpm/@deepseek-ai+dsh@（真实样本 2026-09-02：alpha.10
-  // 热加载 boot ENOENT 旧 .pnpm 目录）。depsOk 门控必须：安装不完整/依赖图缺失同样
-  // 报 ENOENT + .pnpm 路径，那种情况重启不愈（磁盘仍坏），只给重启提示会误导——依赖
-  // 明确不可用时落下方依赖分支（自动补齐）。注意门控用 ok 而非 verified：verified 在
-  // verify running 窗口被瞬时置 false，会把升级残留误落兑底（实装 2026-09-02 复现）。
-  if (
-    depsOk === true &&
-    /(?:ENOENT|no such file|cannot find)/i.test(text) &&
-    /\.pnpm[\\/]@deepseek-ai\+dsh@/i.test(text)
-  ) {
-    return "检测到 dsh 已跨版本升级，当前 Hana 进程仍持有升级前的旧模块缓存：请重启 Hana 加载新版本（dsh 升级后需重启为既定流程，无需其它操作）";
-  }
-  if (/dsh 包未就绪|DSH 包未就绪|cliBin|npm i/i.test(text)) {
-    return "依赖未就绪：自动安装链会按插件声明补齐并核对，完成后自动重试启动 web host；若持续失败请查看上方依赖诊断详情";
-  }
-  if (/EADDRINUSE|address already in use|占用|bind/i.test(text)) {
-    return "检查端口 " + port + " 是否被占用（释放后重启 Hana）";
-  }
-  return "检查上方依赖项；仍失败请重启 Hana 后重试";
-}
+// ---- 连接失败自检展示层退役（T5 spec：dsh-deps-zero-intervention）----
+// 旧「诊断壳 checks 结构」（collectWebDiagnostics / buildDepsDiagCheck /
+// buildProcessDiagCheck / pickProcessFix / readLogTail，t1 依赖 + t2 进程卡片）已随
+// Bootstrap 自举壳页（T4）退役：浏览器壳页只消费 /webui/boot-state（T3 单一状态出口，
+// routes/webui.js readBootState——g.boot 状态机 + g.deps errorClass/guidance + g.web 就绪）。
+// 日志诊断保留 = 会话日志文件（g.logPath，含 install/boot 全程里程碑），不再生成 UI checks。
 
 export async function closeProcess() {
   const g = getSingleton();
@@ -1520,13 +1157,12 @@ export async function closeProcess() {
   }
 }
 // ---- 单例挂载（原 tools/dsh-run.js 的 mountSingleton 迁入本模块；g.startWebHost 已在上方
-// startWebHostFromPlugin 处单独赋值，这里只挂其余生命周期能力——closeProcess / collectDiagnostics /
+// startWebHostFromPlugin 处单独赋值，这里只挂其余生命周期能力——closeProcess /
 // updateDsh / installDeps / verifyDeps / checkDshUpdate）。routes/webui.js、index.js、tools/dsh-*.js 均经
 // globalThis 单例调用，不静态 import 本模块（见文件头「分发形态」）。
 const mountLifecycle = () => {
   const g = getSingleton();
   g.closeProcess = closeProcess;
-  g.collectDiagnostics = collectWebDiagnostics;
   g.installDeps = installDepsFromPlugin;
   g.verifyDeps = verifyDepsSmoke;
   return g;

--- a/src/routes/webui.js
+++ b/src/routes/webui.js
@@ -15,11 +15,9 @@
 //                         → 推 diag-changed（信号，壳页刷新 boot-state）；DSH 主题偏好
 //                         变更 → 推 theme-pref。壳页订阅此流实现事件化（挂载/自举状态
 //                         刷新/偏好跟随全事件驱动）。
-//   GET  /webui/check-update 版本检查（经宿主能力层 g.checkDshUpdate；按钮已移除——版本
-//                            管理归设置页「检查与更新 DSH」卡片 + dsh_install 工具，路由保留）
-//   POST /webui/update-dsh   更新 DSH（经宿主能力层 g.updateDsh，异步触发，更新会重启
-//                            web host、正在执行的任务中断；按钮已移除，入口归设置页
-//                            dsh_install 工具，路由保留）
+//   （已移除，不再注册：/webui/check-update、/webui/update-dsh——版本检查与更新整链随
+//    「更新 DSH = 更新插件发版」退役（updateDsh / checkDshUpdate 及 dsh_install 的
+//    check/update 动作全删），DSH 设置页「DSH 版本」卡片只显示本地版本）
 //   （T5 退役：/webui/health 与 /webui/start、/webui/install-deps、/webui/verify-deps
 //   已删除——壳页无手动入口，install/verify/start 通道收敛为自动链 + dsh_install 工具）
 //

--- a/src/routes/webui.js
+++ b/src/routes/webui.js
@@ -2,8 +2,10 @@
 // Copyright (c) 2026 Nyasers
 //
 // routes/webui.js — dsh-hanako 插件页：contributes.cards（realization:page）内嵌 dsh Web UI
-//   GET /webui            插件页（iframe 嵌 http://127.0.0.1:<port>/，含就绪事件化/主题注入/失败自检；
-//                         壳页另接入功能面板 functionPanel（hana.panel 推送状态/操作，见 webui-shell））
+//   GET /webui            插件页：ready（总线已连接）直嵌 dsh Web UI iframe；未 ready 渲染
+//                         Bootstrap 三态自举页（booting/action-needed/ready，见 webui-shell 头注释；
+//                         数据源 = GET /webui/boot-state + /webui/events 事件流；
+//                         功能面板 functionPanel 仅 status 常驻，无操作段）
 //   GET /webui/events     就绪事件流（SSE 式 chunked，常驻）：bus ready → 推 ready；
 //                         启动失败 → 推 diagnostics；停机 → 推 pending；deps 状态翻转
 //                         → 推 diag-changed；DSH 主题偏好变更 → 推 theme-pref。
@@ -25,21 +27,21 @@
 //
 // 机制：与 routes/card.js 同构——宿主把 app 挂在 /api/plugins/<pluginId> 命名空间下，
 // 这里注册相对路径。渲染前按总线连接状态（g.dshanaBus.status().connected）判定 ready：已连接
-// 直接渲染 iframe；未连接渲染加载态（壳页订阅 /webui/events 就绪事件流，bus ready 后宿主
-// 推 ready 事件 → 壳页动态挂载 iframe——v0.22.1+ 就绪事件化，替代旧「服务端 probeHost +
-// 浏览器 3s 轮询 /webui/health 挂载」链路）。脚本首行 postMessage ready 是宿主原始握手
-// （参照 PLUGINS.md；插件 bundle 不含 @hana/plugin-sdk，不依赖它——壳页内置最小 hana 桥
-// （hana.api.fetch / hana.panel.*，与 SDK 同协议 hana.plugin.ui v1），浏览器侧 fetch 一律
-// 走 hana.api.fetch（自动带 pluginSurfaceSession 头），面板内容经 hana.panel.set 推送）。
+// 直接渲染 iframe；未连接渲染 Bootstrap 三态自举页（T4 spec：dsh-deps-zero-intervention——
+// 壳页数据源 = 首帧内嵌 /webui/boot-state 快照（readBootState）+ /webui/events 事件流：
+// bus ready → ready 事件挂载 iframe；bus.disconnect → pending；web host 启动失败 →
+// diagnostics 事件；deps 状态翻转 → diag-changed 事件——后两者壳页只当作「刷新快照」
+// 信号，不再消费旧 diagnostics checks 结构（浏览器侧 t1/t2 诊断展示已退役）。
+// 脚本首行 postMessage ready 是宿主原始握手（参照 PLUGINS.md；插件 bundle 不含
+// @hana/plugin-sdk，不依赖它——壳页内置最小 hana 桥（hana.api.fetch / hana.panel.*，与
+// SDK 同协议 hana.plugin.ui v1），浏览器侧 fetch 一律走 hana.api.fetch（自动带
+// pluginSurfaceSession 头），面板内容经 hana.panel.set 推送）。
 //
-// 连接失败自检：web host 未就绪时逐项检查 ① dsh 依赖（存在性 + 版本与声明核对）
-// ② DSH 进程状态（t1/t2，见 lifecycle.js collectWebDiagnostics），明确指出哪一项坏了、
-// 为什么、怎么修。诊断由服务端收集（Node 侧才能读 config.json、进程单例与 fs 状态；
-// 浏览器 iframe 读不到插件进程）——收集函数挂在 globalThis 单例（tools/dsh-run.js 的
-// collectDiagnostics，lifecycle.js 实现），这里经单例调用而非静态 import：Hana 以 ?t=
-// 时间戳加载 tools 模块，静态 import 会命中 Node ESM 固定 URL 缓存读到旧模块（见
-// tools/dsh-run.js 头部注释），与 index.js 经单例取 closeProcess 同一套纪律。工具模块
-// 未加载（冷启动窗口）时单例函数缺失，返回 null 由壳页诊断渲染兜底。
+// 自举状态快照（T3）：服务端把启动自动链状态机 g.boot + 依赖状态 g.deps（含 errorClass/
+// guidance）+ g.web 就绪收敛成单一状态出口（GET /webui/boot-state，见 readBootState），
+// 壳页只消费它做三态渲染，不再各自拼装诊断。旧连接失败自检（collectWebDiagnostics 的
+// checks 结构）仍由 /webui/health 与 /webui/events diagnostics 事件在服务端收集
+// （浏览器壳页不再展示；T5 将废弃其展示层，收集函数保留作日志诊断）。
 
 // 插件页 HTML 壳（构建期 template-loader 经 doT 编译为自包含渲染函数，运行时零依赖）
 import { render as webuiShellHtml } from "../assets/webui-shell.jinja2";
@@ -230,12 +232,13 @@ function readBootState() {
   }
 }
 
-/** 插件页 HTML 壳：ready=true 直接内联 iframe；否则加载态（壳页订阅就绪事件流后挂载）。
+/** 插件页 HTML 壳：ready=true 直接内联 iframe；否则渲染自举页（三态 Bootstrap 壳，
+ * 见 assets/webui-shell.jinja2 头注释；T4 spec：dsh-deps-zero-intervention）。
  * colorScheme：按宿主 hana-theme 映射的 color-scheme（dark/light）。dsh 主题为
  * system 时通过 prefers-color-scheme 解析，Chromium 会让跨源 iframe 继承父页面
  * 的 color-scheme，因此 dsh 会跟随宿主主题；dsh 内显式选了 light/dark 则不受影响。
- * diagnostics：未就绪时服务端收集的首帧自检数据（JSON 对象或 null）；浏览器端
- * 渲染进诊断区（30s 超时兜底 / 宿主推诊断事件时展示）。 */
+ * boot：未就绪时服务端取一次自举状态快照（readBootState，T3 单一状态出口）作首帧
+ * 渲染数据（JSON 对象或 null）；壳页随后以 /webui/events 事件驱动刷新本快照。 */
 function buildShell({
   ready,
   hcLink,
@@ -243,7 +246,7 @@ function buildShell({
   api,
   port,
   colorScheme,
-  diagnostics,
+  boot,
 }) {
   // dsh-frame 保持裸嵌（曾尝试显式声明 sandbox/allow 绕过宿主沙箱，实测跨源继承链
   // 下内层声明无法生效，属无效方案已回滚，见 CHANGELOG）。
@@ -252,9 +255,9 @@ function buildShell({
   // iframe src 由壳页 JS 统一设置（attach）：直嵌 @dsh-hanako/app 子插件
   // （dsh 3080 fork SPA）——同源 iframe，无需 BFF 代理/凭据透传。
   const iframe = `<iframe id="dsh-frame"></iframe>`;
-  // 嵌入首帧自检 JSON：把 </ 转义成 <\/，防诊断文本（路径/stderr）里的 </script> 提前闭合脚本
-  const initDiag = diagnostics
-    ? JSON.stringify(diagnostics).replace(/<\//g, "<\\/")
+  // 嵌入首帧自举状态快照 JSON：把 </ 转义成 <\/，防快照文本（路径/错误）里的 </script> 提前闭合脚本
+  const initBoot = boot
+    ? JSON.stringify(boot).replace(/<\//g, "<\\/")
     : "null";
   // HTML 模板来自 src/assets/webui-shell.jinja2（asset/source 内联，占位符保留）；
   // 渲染函数由 template-loader 在构建期生成（doT），scope 直接作 it 传入。
@@ -266,7 +269,7 @@ function buildShell({
     ready,
     iframe,
     api,
-    initDiag,
+    initBoot,
     port,
   });
 }
@@ -278,26 +281,28 @@ export default function registerWebuiRoutes(app, ctx) {
     ctx && typeof ctx.config === "object" && ctx.config ? ctx.config : {};
   const port = Number(cfg.webPort) || 3080;
 
-  // 插件页：按总线连接状态判定就绪——已连接直接渲染 iframe；未连接渲染加载态（壳页
-  // 订阅 /webui/events 就绪事件流，bus ready 后宿主推 ready 事件动态挂载）。不再服务端
-  // probeHost（就绪事件化，probeHost 仅诊断路径使用）。未就绪时服务端同步收集一次自检
-  // （首屏即渲染，诊断路径刷新）；就绪不收集保持轻量。
-  // 壳页不再注入任何脚本/横幅：web host 状态与诊断由壳页 JS 订阅 /webui/events
-  // 事件流驱动（就绪事件化），SPA 全部资源由 @dsh-hanako/app 子插件
+  // 插件页：按总线连接状态判定就绪——已连接直接渲染 iframe；未连接渲染 Bootstrap
+  // 自举页（三态：booting/action-needed/ready，壳页订阅 /webui/events 事件流 + 刷新
+  // /webui/boot-state 驱动）。不再服务端 probeHost（就绪事件化，probeHost 仅诊断路径
+  // 使用）。未就绪时服务端同步取一次自举状态快照（readBootState，首屏即渲染三态）；
+  // 就绪不取保持轻量。
+  // 壳页不再注入任何脚本/横幅：自举状态与事件由壳页 JS 订阅 /webui/events + 读
+  // /webui/boot-state（T3 单一状态出口），SPA 全部资源由 @dsh-hanako/app 子插件
   // （dsh 3080）iframe 同源直嵌提供，无浏览器端劫持/改写。
 
   app.get("/webui", async (c) => {
     // 壳页：iframe 直嵌 @dsh-hanako/app 子插件（dsh 3080）serve 的 fork SPA——
     // iframe 内同源（资源/API/SSE/WS 全由子插件提供，免鉴权，无劫持无 token/PSS）；
-    // 宿主只做页面壳：就绪事件化 / 诊断 / 主题与剪贴板桥（全部在壳页 JS 里）。
+    // 宿主只做页面壳：就绪事件化 / 自举状态 / 主题与剪贴板桥（全部在壳页 JS 里）。
     const ready = busReady();
     const hc = c.req.query("hana-css") || "";
     const th = c.req.query("hana-theme") || "inherit";
     const hcLink = hc ? `<link rel="stylesheet" href="${esc(hc)}">` : "";
     // 宿主深色主题（midnight/dark 等）→ iframe 内 prefers-color-scheme dark，dsh 的 system 跟随宿主
     const colorScheme = /midnight|dark/i.test(th) ? "dark" : "light";
-    // 未就绪时服务端同步收集一次自检（首屏即渲染，诊断/超时兜底再刷新）；就绪不收集保持轻量
-    const diagnostics = ready ? null : readDiagnostics(ctx, cfg, port);
+    // 未就绪时服务端同步取一次自举状态快照（首屏即渲染三态；随后事件流/30s 兜底再刷新）；
+    // 就绪不取保持轻量（壳页直接挂载 iframe，快照只在 pending/diag-changed 时按需拉取）
+    const boot = ready ? null : readBootState();
     return c.html(
       buildShell({
         ready,
@@ -306,7 +311,7 @@ export default function registerWebuiRoutes(app, ctx) {
         api: base,
         port,
         colorScheme,
-        diagnostics,
+        boot,
       }),
     );
   });

--- a/src/routes/webui.js
+++ b/src/routes/webui.js
@@ -10,6 +10,10 @@
 //                         壳页订阅此流实现事件化（挂载/诊断刷新/偏好跟随全事件驱动）。
 //   GET /webui/health     纯诊断 GET 端点：返回 readDiagnostics 自检结果 + web host 状态
 //                         （probeHost 逻辑仅诊断路径使用；事件化后仅兑底/手动刷新）
+//   GET /webui/boot-state  自举状态快照（T3 spec：dsh-deps-zero-intervention）——单一状态出口：
+//                         g.boot 状态机 + g.deps（含 T1 errorClass/guidance）+ g.web 就绪收敛成
+//                         { phase, ready, deps, boot, web } 三段 JSON，三态可渲染；T4 Bootstrap
+//                         壳页只消费它，不再各自拼装诊断（事件驱动刷新仍走 /webui/events）
 //   POST /webui/start        手动启动 web host（process 卡片「手动启动」按钮；ready/starting/触发启动三态）
 //   POST /webui/install-deps 自动安装 dsh 依赖（deps 卡片「安装依赖」按钮；installing/触发安装）
 //   GET  /webui/verify-deps  依赖完整性静态核对（cliBin + 磁盘版本 vs 声明；进标签页自动一次 + 手动「检测依赖」按钮）
@@ -114,6 +118,115 @@ function busReady() {
     );
   } catch {
     return false;
+  }
+}
+
+/** 自举状态快照（T3 spec：dsh-deps-zero-intervention，见文件头「GET /webui/boot-state」）。
+ * 单一状态出口：把启动自动链状态机 g.boot + 依赖部署/核对状态 g.deps（含 T1 失败分类
+ * errorClass/guidance）+ web host 就绪态（g.web / g.webLastError / 总线）收敛成确定性
+ * JSON，T4 Bootstrap 壳页只消费它（不再各自拼装诊断）。纯只读聚合：不 spawn、不探测、
+ * 不 import 能力模块；单例缺失（冷启动窗口）/ 字段缺省逐层兜底为显式空值（null/""），
+ * 本函数永不以异常终结（读单例缺字段即空值，页面不猜）。
+ *
+ * 返回结构（值域与缺省语义）：
+ *   phase     状态机阶段 ensure-deps|waiting|booting|ready（g.boot.phase；未跑过 = ensure-deps）
+ *   ready     web host 就绪 = g.web.ready（boot 收敛）或总线已连接（busReady，与 /webui
+ *             渲染同源判定）；停机/重启窗口由 /webui/events pending/ready 事件驱动页面翻转
+ *   deps      { status, errorClass, guidance, error, version, logTail }
+ *               status     g.deps.status：idle|installing|running|ok|error
+ *               errorClass install 失败分类（g.deps.errorClass.errorClass；成功/从未失败 = null）
+ *               guidance   errorClass 随附人话（g.deps.errorClass.guidance；仅分类非空时非空）
+ *               error      最近失败可读文本（g.deps.error，前缀 ≤800；成功/从未失败 = null）
+ *               version    已装 dsh 版本（g.deps.result.version；未验证 = null）
+ *               logTail    依赖日志尾（g.deps.log 尾部 ≤800，复用现有诊断截断约定；空 = null）
+ *   boot      { attempt, nextRetryAt, errorClass, guidance, lastError }
+ *               attempt     连续失败尝试计数（g.boot.attempt；收敛归零，未失败 = 0）
+ *               nextRetryAt 下次自动重试时刻（epoch ms；不可恢复停等 = null = 不自动重试）
+ *               errorClass  最近失败分类（g.boot.errorClass；成功收敛/从未失败 = null）
+ *               guidance    最近失败指引文案（index.js handleFailure 随失败落 g.boot.guidance；
+ *                           六类 + restart-needed 均有文案；成功收敛/从未失败 = null）
+ *               lastError   最近失败可读文本（g.boot.lastError；成功收敛/从未失败 = null）
+ *   web       { ready, lastError }
+ *               ready      web host boot 收敛标志（g.web.ready === true）
+ *               lastError  web host 最近失败文本（g.webLastError 展示尾部 ≤800，与诊断同约定；
+ *                           从未失败 = null；恢复就绪后可能残留上次失败，页面以顶层 ready 为准）
+ *
+ * 三态渲染语义（字段组合即定态，无歧义；T4 壳页按此分支）：
+ *   ready         顶层 ready = true（web host 就绪 → iframe 直嵌）
+ *   action-needed boot.phase === "waiting" && boot.errorClass 非空 &&（deps.guidance 或
+ *                 boot.guidance）非空——失败已分类且指引齐备（用户有可读操作/自动续跑说明）
+ *   booting       其余（phase ensure-deps/booting、deps.status installing/running 进行中、
+ *                 waiting 但失败信息不全等过渡/未知态 → 阶段时间线 + 重试信息） */
+function readBootState() {
+  // 兜底快照（字段齐、全显式空值）：单例整体缺失或聚合异常时接口仍回完整结构，页面不猜
+  const fallback = () => ({
+    phase: null,
+    ready: false,
+    timestamp: Date.now(),
+    deps: {
+      status: null,
+      errorClass: null,
+      guidance: null,
+      error: null,
+      version: null,
+      logTail: null,
+    },
+    boot: {
+      attempt: null,
+      nextRetryAt: null,
+      errorClass: null,
+      guidance: null,
+      lastError: null,
+    },
+    web: { ready: false, lastError: null },
+  });
+  try {
+    const g = globalThis.__dshHanako;
+    if (!g || typeof g !== "object") return fallback();
+    const boot = (g.boot && typeof g.boot === "object" && g.boot) || {};
+    const deps = (g.deps && typeof g.deps === "object" && g.deps) || {};
+    // T1 分类记录形态 { errorClass, guidance }（install.js 失败路径落；缺省 null）
+    const ec =
+      deps.errorClass && typeof deps.errorClass === "object" ? deps.errorClass : null;
+    // 依赖核对缓存（verifyDepsSmoke 落 g.deps.result = { ok, version, error, at, ... }）
+    const smoke =
+      deps.result && typeof deps.result === "object" ? deps.result : null;
+    const s = (v) => (typeof v === "string" && v ? v : null); // 可读字符串安全取值
+    const tail = (v, n) => {
+      // 截断约定：展示用文本一律取尾 ≤800（与 buildDepsDiagCheck/Process 诊断同款）
+      const t = s(v);
+      return t ? t.slice(-(n || 800)) : null;
+    };
+    const num = (v) => (typeof v === "number" && Number.isFinite(v) ? v : null);
+    const webReady = !!(g.web && g.web.ready === true);
+    const depsError = s(deps.error);
+    return {
+      phase: s(boot.phase),
+      ready: webReady || busReady(),
+      timestamp: Date.now(),
+      deps: {
+        status: s(deps.status),
+        errorClass: s(ec && ec.errorClass),
+        guidance: s(ec && ec.guidance),
+        error: depsError ? depsError.slice(0, 800) : null,
+        version: s(smoke && smoke.version),
+        logTail: tail(deps.log, 800),
+      },
+      boot: {
+        attempt: num(boot.attempt) ?? 0,
+        nextRetryAt: num(boot.nextRetryAt),
+        errorClass: s(boot.errorClass),
+        guidance: s(boot.guidance),
+        lastError: s(boot.lastError),
+      },
+      web: {
+        ready: webReady,
+        lastError: tail(g.webLastError, 800),
+      },
+    };
+  } catch {
+    // 聚合兜底（防御；正常路径各字段已逐层空值化，理论不可达）
+    return fallback();
   }
 }
 
@@ -378,6 +491,14 @@ export default function registerWebuiRoutes(app, ctx) {
     };
     body.diagnostics = readDiagnostics(ctx, cfg, port);
     return c.json(body);
+  });
+
+  // 自举状态快照（T3 spec：dsh-deps-zero-intervention）——Bootstrap 壳页唯一数据源：
+  // 返回 readBootState() 聚合的单一状态出口（phase/deps/boot/web 三段 + ready），页面只
+  // 消费它、不各自拼装诊断。纯只读同步聚合（无 spawn/探测），永不抛（见 readBootState）；
+  // 三态渲染语义（ready → action-needed → booting）见 readBootState 注释，字段齐备无歧义。
+  app.get("/webui/boot-state", (c) => {
+    return c.json(readBootState());
   });
 
   // 手动启动 web host（process 卡片「手动启动」按钮调用）：读单例按当前状态返回——

--- a/src/routes/webui.js
+++ b/src/routes/webui.js
@@ -6,32 +6,29 @@
 //                         Bootstrap 三态自举页（booting/action-needed/ready，见 webui-shell 头注释；
 //                         数据源 = GET /webui/boot-state + /webui/events 事件流；
 //                         功能面板 functionPanel 仅 status 常驻，无操作段）
-//   GET /webui/events     就绪事件流（SSE 式 chunked，常驻）：bus ready → 推 ready；
-//                         启动失败 → 推 diagnostics；停机 → 推 pending；deps 状态翻转
-//                         → 推 diag-changed；DSH 主题偏好变更 → 推 theme-pref。
-//                         壳页订阅此流实现事件化（挂载/诊断刷新/偏好跟随全事件驱动）。
-//   GET /webui/health     纯诊断 GET 端点：返回 readDiagnostics 自检结果 + web host 状态
-//                         （probeHost 逻辑仅诊断路径使用；事件化后仅兑底/手动刷新）
 //   GET /webui/boot-state  自举状态快照（T3 spec：dsh-deps-zero-intervention）——单一状态出口：
 //                         g.boot 状态机 + g.deps（含 T1 errorClass/guidance）+ g.web 就绪收敛成
-//                         { phase, ready, deps, boot, web } 三段 JSON，三态可渲染；T4 Bootstrap
+//                         { phase, ready, deps, boot, web } 三段 JSON，三态可渲染；Bootstrap
 //                         壳页只消费它，不再各自拼装诊断（事件驱动刷新仍走 /webui/events）
-//   POST /webui/start        手动启动 web host（process 卡片「手动启动」按钮；ready/starting/触发启动三态）
-//   POST /webui/install-deps 自动安装 dsh 依赖（deps 卡片「安装依赖」按钮；installing/触发安装）
-//   GET  /webui/verify-deps  依赖完整性静态核对（cliBin + 磁盘版本 vs 声明；进标签页自动一次 + 手动「检测依赖」按钮）
-//   GET  /webui/check-update 版本检查（经宿主能力层 g.checkDshUpdate；deps 卡片「检查更新」
-//                            按钮已移除——版本管理归设置页「检查与更新 DSH」卡片 + dsh_install 工具，路由保留）
+//   GET /webui/events     就绪事件流（SSE 式 chunked，常驻）：bus ready → 推 ready；
+//                         停机/重启 → 推 pending；web host 启动失败与 deps 状态翻转
+//                         → 推 diag-changed（信号，壳页刷新 boot-state）；DSH 主题偏好
+//                         变更 → 推 theme-pref。壳页订阅此流实现事件化（挂载/自举状态
+//                         刷新/偏好跟随全事件驱动）。
+//   GET  /webui/check-update 版本检查（经宿主能力层 g.checkDshUpdate；按钮已移除——版本
+//                            管理归设置页「检查与更新 DSH」卡片 + dsh_install 工具，路由保留）
 //   POST /webui/update-dsh   更新 DSH（经宿主能力层 g.updateDsh，异步触发，更新会重启
-//                            web host、正在执行的任务中断；deps 卡片「更新 DSH」按钮已移除，
-//                            入口归设置页 dsh_install 工具，路由保留）
+//                            web host、正在执行的任务中断；按钮已移除，入口归设置页
+//                            dsh_install 工具，路由保留）
+//   （T5 退役：/webui/health 与 /webui/start、/webui/install-deps、/webui/verify-deps
+//   已删除——壳页无手动入口，install/verify/start 通道收敛为自动链 + dsh_install 工具）
 //
 // 机制：与 routes/card.js 同构——宿主把 app 挂在 /api/plugins/<pluginId> 命名空间下，
 // 这里注册相对路径。渲染前按总线连接状态（g.dshanaBus.status().connected）判定 ready：已连接
 // 直接渲染 iframe；未连接渲染 Bootstrap 三态自举页（T4 spec：dsh-deps-zero-intervention——
 // 壳页数据源 = 首帧内嵌 /webui/boot-state 快照（readBootState）+ /webui/events 事件流：
-// bus ready → ready 事件挂载 iframe；bus.disconnect → pending；web host 启动失败 →
-// diagnostics 事件；deps 状态翻转 → diag-changed 事件——后两者壳页只当作「刷新快照」
-// 信号，不再消费旧 diagnostics checks 结构（浏览器侧 t1/t2 诊断展示已退役）。
+// bus ready → ready 事件挂载 iframe；bus.disconnect → pending；web host 启动失败与
+// deps 状态翻转 → diag-changed 信号（壳页刷新 boot-state），无其它载荷。
 // 脚本首行 postMessage ready 是宿主原始握手（参照 PLUGINS.md；插件 bundle 不含
 // @hana/plugin-sdk，不依赖它——壳页内置最小 hana 桥（hana.api.fetch / hana.panel.*，与
 // SDK 同协议 hana.plugin.ui v1），浏览器侧 fetch 一律走 hana.api.fetch（自动带
@@ -39,9 +36,10 @@
 //
 // 自举状态快照（T3）：服务端把启动自动链状态机 g.boot + 依赖状态 g.deps（含 errorClass/
 // guidance）+ g.web 就绪收敛成单一状态出口（GET /webui/boot-state，见 readBootState），
-// 壳页只消费它做三态渲染，不再各自拼装诊断。旧连接失败自检（collectWebDiagnostics 的
-// checks 结构）仍由 /webui/health 与 /webui/events diagnostics 事件在服务端收集
-// （浏览器壳页不再展示；T5 将废弃其展示层，收集函数保留作日志诊断）。
+// 壳页只消费它做三态渲染，不再各自拼装诊断。T5 起旧连接失败自检展示层
+// （collectWebDiagnostics / buildDepsDiagCheck / buildProcessDiagCheck / pickProcessFix /
+// readLogTail 及 readDiagnostics/probeHost 与 /webui/health）整体退役删除——日志诊断
+// 保留会话日志文件，浏览器侧不再有 checks 结构消费方。
 
 // 插件页 HTML 壳（构建期 template-loader 经 doT 编译为自包含渲染函数，运行时零依赖）
 import { render as webuiShellHtml } from "../assets/webui-shell.jinja2";
@@ -62,50 +60,6 @@ function esc(v) {
     .replace(/"/g, "&quot;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
-}
-
-/** 探测 dsh web host 是否就绪（host.describe RPC，1.5s 超时；任何失败视为未就绪）。
- * 仅诊断路径使用（/webui/health 与 /webui/events 的初始判定）；/webui 渲染不再探测——
- * 就绪判定改总线连接状态（g.dshanaBus.status().connected，就绪事件化）。 */
-async function probeHost(port, log) {
-  try {
-    const res = await fetch(`http://127.0.0.1:${port}/api/host.describe`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        type: "client-request",
-        rpcId: "probe",
-        method: "host.describe",
-        payload: {},
-      }),
-      signal: AbortSignal.timeout(1500),
-    });
-    return res.ok;
-  } catch (e) {
-    log?.warn?.(
-      `[dsh-hanako] probeHost 失败（port ${port}）：${e?.message || e}`,
-    );
-    return false;
-  }
-}
-
-/** 读连接失败自检（服务端收集：config.json + 单例 + fs；经单例调用 tools 的收集函数）。
- * 工具模块未加载（冷启动窗口）时返回 null，页面先渲染占位，诊断路径刷新后填充。
- * 只回布尔与截断文本（不返回凭据）；stderr 尾部在收集端已截断 ≤800。 */
-function readDiagnostics(ctx, cfg, port) {
-  const g = globalThis.__dshHanako;
-  if (g && typeof g.collectDiagnostics === "function") {
-    try {
-      return g.collectDiagnostics({ dataDir: ctx?.dataDir, webPort: port });
-    } catch (e) {
-      ctx.log?.warn?.(
-        "[dsh-hanako] 收集连接自检失败:",
-        e?.message || String(e),
-      );
-      return null;
-    }
-  }
-  return null;
 }
 
 /** 总线连接状态（就绪事件化的 ready 判定）：bus 已连接（hello 完成）= web host 就绪。 */
@@ -195,7 +149,7 @@ function readBootState() {
       deps.result && typeof deps.result === "object" ? deps.result : null;
     const s = (v) => (typeof v === "string" && v ? v : null); // 可读字符串安全取值
     const tail = (v, n) => {
-      // 截断约定：展示用文本一律取尾 ≤800（与 buildDepsDiagCheck/Process 诊断同款）
+      // 截断约定：展示用文本一律取尾 ≤800（沿旧诊断壳同款约定）
       const t = s(v);
       return t ? t.slice(-(n || 800)) : null;
     };
@@ -317,18 +271,19 @@ export default function registerWebuiRoutes(app, ctx) {
   });
 
   // 就绪事件流（GET /webui/events，SSE 式 chunked）——壳页事件化的宿主推送通道
-  // （就绪/诊断/主题偏好/deps 状态，全部事件驱动，替代周期轮询）：
-  //   · 打开时已 ready（bus 已连接）→ 立即推 ready 事件并关闭（壳页就绪态不开流）；
-  //   · 未 ready → 先推 pending 事件（壳页保持加载态），挂起等待：
-  //       - bus.ready（本机事件，hello-ok 到达）→ 推 ready 事件（流保持常驻）；
-  //       - bus.disconnect（web host 停机/重启窗口）→ 推 pending 事件（壳页退回加载态）；
-  //       - web host 启动失败（lifecycle notifyWebStartFailed）→ 推 diagnostics 事件；
-  //       - deps 状态翻转（install.js notifyDepsChanged）→ 推 diag-changed 事件；
+  // （就绪/停机/自举状态变化/主题偏好，全部事件驱动；壳页收到后刷新 /webui/boot-state
+  // 或转推 iframe，见 webui-shell.jinja2 事件处理）：
+  //   · 打开时已 ready（bus 已连接）→ 立即推 ready 事件（流保持常驻）；
+  //   · 未 ready → 先推 pending 事件（壳页保持自举页），挂起等待：
+  //       - bus.ready（本机事件，hello-ok 到达）→ 推 ready 事件（壳页挂载 iframe）；
+  //       - bus.disconnect（web host 停机/重启窗口）→ 推 pending 事件（壳页退回自举页）；
+  //       - web host 启动失败（lifecycle notifyWebStartFailed）→ 推 diag-changed 信号
+  //         （壳页刷新 boot-state 呈现 waiting——不再携带旧 diagnostics checks 载荷）；
+  //       - deps 状态翻转（install.js notifyDepsChanged）→ 推 diag-changed 信号；
   //       - DSH 设置变更（bridge $events 转发 settings/document-updated 的 ui-theme）
   //         → 推 theme-pref 事件（壳页转告注入脚本重读偏好，替代 3s 轮询 describe）。
-  // ready 后流保持常驻：重启窗口的 pending → ready 周期、主题偏好与 deps 变更继续推送。
-  // 事件格式：SSE data: JSON，{ type: "ready" | "pending" | "diagnostics" |
-  // "diag-changed" | "theme-pref", diagnostics? }。
+  // ready 后流保持常驻：重启窗口的 pending → ready 周期、主题偏好与自举状态变化继续推送。
+  // 事件格式：SSE data: JSON，{ type: "ready" | "pending" | "diag-changed" | "theme-pref" }。
   // 实现与 routes/card.js 的 /ops/dep-stream 同构（ReadableStream + c.body）；客户端
   // 断开（ReadableStream cancel）时清理订阅与挂钩，不泄漏。
   app.get("/webui/events", (c) => {
@@ -368,17 +323,15 @@ export default function registerWebuiRoutes(app, ctx) {
             /* 已关 */
           }
         };
-        // web host 启动失败 → 推诊断事件（诊断对象由 readDiagnostics 收集）；
-        // 不关闭流——用户修复（手动启动/装依赖）后 bus.ready 仍可推 ready 事件挂载
+        // web host 启动失败 → 推 diag-changed 信号（不携带载荷；壳页收到后刷新
+        // /webui/boot-state 呈现 waiting——T5 起不再收集旧 diagnostics checks）。
+        // 不关闭流——自动链续跑成功后 bus.ready 仍可推 ready 事件挂载
         onStartFailed = () => {
           if (closed) return;
-          send({
-            type: "diagnostics",
-            diagnostics: readDiagnostics(ctx, cfg, port),
-          });
+          send({ type: "diag-changed" });
         };
-        // deps 状态翻转（安装/检测进入与终态）→ 推 diag-changed 事件：壳页收到后
-        // 一次性刷新诊断（事件驱动替代面板 5s 周期 tick；install.js 状态翻转点调用
+        // deps 状态翻转（安装/检测进入与终态）→ 推 diag-changed 信号：壳页收到后
+        // 刷新 /webui/boot-state（进度/终态/errorClass；install.js 状态翻转点调用
         // g.notifyDepsChanged）。
         onDepsChanged = () => {
           if (closed) return;
@@ -481,126 +434,13 @@ export default function registerWebuiRoutes(app, ctx) {
     });
   });
 
-  // 纯诊断 GET 端点（v0.22.1+ 收缩，vZ 事件化后仅剩兜底）：返回 readDiagnostics 自检
-  // 结果 + web host 状态（probeHost 探测 ok + 总线连接状态）。壳页不再轮询此端点——
-  // 挂载由 /webui/events ready 事件驱动，诊断刷新由 diag-changed 事件驱动；此处仅作
-  // 30s 超时兑底「查看诊断」、手动刷新与事件驱动 refreshDiag 的数据源。
-  // diagnostics 为 null 时事件到达会再补上（refreshDiag 每次查询都重新收集）。
-  app.get("/webui/health", async (c) => {
-    const ready = busReady() || (await probeHost(port, ctx.log));
-    const body = {
-      ok: ready,
-      port,
-      timestamp: Date.now(),
-      busConnected: busReady(),
-    };
-    body.diagnostics = readDiagnostics(ctx, cfg, port);
-    return c.json(body);
-  });
-
   // 自举状态快照（T3 spec：dsh-deps-zero-intervention）——Bootstrap 壳页唯一数据源：
   // 返回 readBootState() 聚合的单一状态出口（phase/deps/boot/web 三段 + ready），页面只
   // 消费它、不各自拼装诊断。纯只读同步聚合（无 spawn/探测），永不抛（见 readBootState）；
   // 三态渲染语义（ready → action-needed → booting）见 readBootState 注释，字段齐备无歧义。
+  // T5 起 /webui/start、/webui/install-deps、/webui/verify-deps、/webui/health 已退役
+  // （壳页无手动入口；install/verify 通道收敛为 dsh_install 工具 + 自动链能力层）。
   app.get("/webui/boot-state", (c) => {
     return c.json(readBootState());
-  });
-
-  // 手动启动 web host（process 卡片「手动启动」按钮调用）：读单例按当前状态返回——
-  // 已就绪 → ready；启动中（readyPromise 挂起）→ starting；否则异步触发
-  // g.startWebHost(ctx.config, dataDir)（不 await 其就绪，页面靠就绪事件流检测）→ starting。
-  // 单例缺失/无函数/异常一律容错回 {ok:false}，本路由不抛异常。
-  app.post("/webui/start", (c) => {
-    const g = globalThis.__dshHanako;
-    try {
-      if (!g || typeof g.startWebHost !== "function") {
-        return c.json({ ok: false, error: "插件工具模块未加载，稍后重试" });
-      }
-      if (g.web?.ready) return c.json({ ok: true, state: "ready" });
-      if (g.web?.readyPromise) return c.json({ ok: true, state: "starting" });
-      // 异步触发（startWebHostFromPlugin 内部已 try/catch 记 webLastError 返回布尔；
-      // 这里再 .catch 兜底——路由不等待就绪、不抛异常）。dataDir 缺省用单例记录值，
-      // 避免路由 ctx 无 dataDir 时误落 PLUGIN_ROOT/data。
-      Promise.resolve(
-        g.startWebHost(ctx.config, ctx.dataDir || g.dataDir),
-      ).catch(() => {});
-      return c.json({ ok: true, state: "starting" });
-    } catch (e) {
-      ctx.log?.warn?.(
-        "[dsh-hanako] 手动启动 web host 失败:",
-        e?.message || String(e),
-      );
-      return c.json({ ok: false, error: "启动请求失败，请稍后重试" });
-    }
-  });
-
-  // 自动安装 dsh 依赖（deps 卡片「安装依赖」按钮调用）：读单例按状态返回——
-  // 部署中（g.deps.status === "installing"）→ {ok:true,state:"installing"}；否则异步触发
-  // g.installDeps(ctx.config, dataDir)（不 await 其完成，页面靠诊断刷新）→ installing。
-  // 单例缺失/无函数/异常一律容错回 {ok:false}，本路由不抛异常。
-  app.post("/webui/install-deps", (c) => {
-    const g = globalThis.__dshHanako;
-    try {
-      if (!g || typeof g.installDeps !== "function") {
-        return c.json({ ok: false, error: "插件工具模块未加载，稍后重试" });
-      }
-      // installing+running 都是「依赖操作进行中」（install 内部重验期间 status 短暂为
-      // running），此时重复 install 直接返回状态不重复触发（与能力层内部守卫一致）
-      if (
-        g.deps.status === "installing" ||
-        g.deps.status === "running"
-      )
-        return c.json({ ok: true, state: "installing" });
-      // 异步触发（installDepsFromPlugin 内部已 try/catch 记 g.deps.error 返回结果；
-      // 这里再 .catch 兜底——路由不等待完成、不抛异常）。dataDir 缺省用单例记录值。
-      Promise.resolve(
-        g.installDeps(ctx.config, ctx.dataDir || g.dataDir),
-      ).catch(() => {});
-      return c.json({ ok: true, state: "installing" });
-    } catch (e) {
-      ctx.log?.warn?.(
-        "[dsh-hanako] 自动安装依赖失败:",
-        e?.message || String(e),
-      );
-      return c.json({ ok: false, error: "安装请求失败，请稍后重试" });
-    }
-  });
-
-  // 静态完整性核对（deps 卡片「检测依赖」按钮 + 进标签页自动一次；GET 只读，去 spawn
-  // 2026-09-02：无子进程秒回）：核对中/安装中 → {ok:true,running:true}；否则 await
-  // verifyDepsSmoke(cfg)（cliBin 存在 + 磁盘版本 === 插件声明；pnpm 引导检查并行）→
-  // {ok:true, verified, version, error, running:false, pnpmReady, pnpmVersion, pnpmError}。
-  // pnpm 引导状态为独立子项（不进 verified 判定）：未就绪时 pnpmError 为原因，自愈
-  // 路径（缺缓存自动重下）恢复就绪。结果写入 g.deps.result，前端随后经 health 读取
-  // 诊断刷新 deps 卡片。单例缺失/无函数/异常一律容错回 {ok:false}。
-  app.get("/webui/verify-deps", async (c) => {
-    const g = globalThis.__dshHanako;
-    try {
-      if (!g || typeof g.verifyDeps !== "function") {
-        return c.json({ ok: false, error: "插件工具模块未加载，稍后重试" });
-      }
-      if (g.deps.status === "running" || g.deps.status === "installing")
-        return c.json({ ok: true, running: true });
-      const smoke = await g.verifyDeps({
-        dataDir: ctx.dataDir || g.dataDir,
-        webPort: port,
-      });
-      return c.json({
-        ok: true,
-        running: false,
-        verified: smoke.ok,
-        version: smoke.version,
-        error: smoke.error || null,
-        pnpmReady: smoke.pnpmReady === true,
-        pnpmVersion: smoke.pnpmVersion || null,
-        pnpmError: smoke.pnpmError || null,
-      });
-    } catch (e) {
-      ctx.log?.warn?.(
-        "[dsh-hanako] 依赖核对失败:",
-        e?.message || String(e),
-      );
-      return c.json({ ok: false, error: "检测请求失败，请稍后重试" });
-    }
   });
 }

--- a/src/tools/dsh-run.js
+++ b/src/tools/dsh-run.js
@@ -42,8 +42,8 @@ import {
   textFromMessageBlocks,
 } from "./lib/protocol.js";
 // 生命周期能力（web host 拉起）——本模块只做任务提交，对单例/web host 的依赖经
-// app/lifecycle.js 转发（lifecycle.js 顶层 mountLifecycle 已把 closeProcess / collectDiagnostics /
-// updateDsh / startWebHost / installDeps / verifyDeps / checkDshUpdate 挂到 globalThis 单例）。
+// app/lifecycle.js 转发（lifecycle.js 顶层 mountLifecycle 已把 closeProcess / updateDsh /
+// startWebHost / installDeps / verifyDeps / checkDshUpdate 挂到 globalThis 单例）。
 // config.json 引导已退役（vX，migrate 体系删除）：配置读取侧 resolve* 缺省回退兜底。
 // 与 lifecycle.js 同属 index.js 单 bundle 收敛入口的静态 import 链。
 import { ensureWebHost } from "../lifecycle.js";

--- a/src/tools/lib/install.js
+++ b/src/tools/lib/install.js
@@ -8,7 +8,7 @@
 // time, log }（v0.24 状态收敛：旧平铺 g.depsInstalling/g.depsInstallLog/g.depsSmoke 等
 // 全废；status 值域 idle/installing/ok/error，result = 依赖核对缓存复合对象，log =
 // 内存尾环字符串，time = 最近一次 npm i 输出时间）。
-// 消费方：dsh-run.js（updateDsh / buildDepsDiagCheck 等组合）、lib/check.js
+// 消费方：dsh-run.js（updateDsh 编排）、lib/check.js（checkDshUpdate 读本地版本）
 // （checkDshUpdate 依赖 verifyDepsSmoke 缓存 + 本地版本直读）、tools/dsh-install.js
 // （经单例 g.installDeps / g.verifyDeps 调用）。
 //
@@ -771,7 +771,7 @@ export async function installDepsFromPlugin(ctxConfig, ctxDataDir, opts = {}) {
 // 结果缓存到单例分组 g.deps.result = { ok, version, error, at, running, pnpm* }（
 // v0.24 状态收敛：旧 g.depsSmoke 平铺字段并入）；防并发守卫保留（兼容 running/installing
 // 语义，静态后 running 窗口消失）。
-// 触发时机：进标签页自动一次 + 手动「检测依赖」按钮（GET /webui/verify-deps）/ installDeps
+// 触发时机：dsh_install 工具 action=verify（Agent 只读排查，标签页手动按钮已随诊断壳退役）/ installDeps
 // 部署成功后强制重验（opts.force）。
 // pnpm 引导状态（pnpmReady/pnpmVersion/pnpmError）为独立子项，不进 ok 判定（web host
 // 启动不依赖 pnpm）；仅作 deps 卡片「pnpm 引导：就绪/未就绪」独立展示行。

--- a/src/tools/lib/state.js
+++ b/src/tools/lib/state.js
@@ -29,7 +29,7 @@
 //     update 任一进行中另一动作拒绝；tools/dsh-install.js 同步段检查/置位、操作完成
 //     释放；能力层守卫 g.deps.status / g.update.status 保留为 webui 路由等其他调用
 //     路径双保险；verify/check 不占用）
-//   g.boot   = { phase, attempt, nextRetryAt, errorClass, lastError, timer? }
+//   g.boot   = { phase, attempt, nextRetryAt, errorClass, guidance, lastError, timer? }
 //     启动自动链状态机（T2 spec：dsh-deps-zero-intervention 新增设计 2；index.js onload
 //     维护：ensure-deps/waiting/booting/ready + 失败退避重试，见 index.js 自动链注释）——
 //     本函数只做兜底初始化，不驱动状态（与 g.update/g.deps 同款热更新兼容语义）
@@ -193,6 +193,9 @@ export function getSingleton() {
   //   errorClass   最近失败分类（install 六类 network/macos-signature/native-toolchain/
   //                declaration/environment/unknown；boot 升级缓存残留另归 restart-needed；
   //                成功收敛/从未失败 = null）
+  //   guidance     最近失败的用户指引文案（index.js handleFailure 随失败落：六类经
+  //                ERROR_CLASS_GUIDANCE、restart-needed 等不可恢复类亦带文案；T3 快照端点/
+  //                壳页 action-needed 渲染用；成功收敛/从未失败 = null）
   //   lastError    最近失败可读文本（截断；成功收敛/从未失败 = null）
   //   timer        后台退避 setTimeout 句柄（index.js 维护：调度置位、到点/卸载/收敛清理；
   //                句柄不跨会话有效——卸载即清，重载后新 onload 重新调度）
@@ -203,6 +206,7 @@ export function getSingleton() {
   if (g.boot.attempt === undefined) g.boot.attempt = 0;
   if (g.boot.nextRetryAt === undefined) g.boot.nextRetryAt = null;
   if (g.boot.errorClass === undefined) g.boot.errorClass = null;
+  if (g.boot.guidance === undefined) g.boot.guidance = null;
   if (g.boot.lastError === undefined) g.boot.lastError = null;
   if (!g.check || typeof g.check !== "object") g.check = {};
   if (g.check.status === undefined) g.check.status = "idle";

--- a/src/tools/lib/state.js
+++ b/src/tools/lib/state.js
@@ -15,7 +15,7 @@
 // 单例纪律（与旧 dsh-run.js getSingleton 完全一致）：globalThis.__dshHanako 跨模块
 // 共享，index.js 卸载清理时读取；旧对象可能缺新字段（热更新后旧 globalThis 对象仍在）
 // 逐字段兜底。函数挂载（g.closeProcess / g.installDeps / g.verifyDeps /
-// g.checkDshUpdate / g.updateDsh / g.startWebHost / g.collectDiagnostics）由各定义模块
+// g.checkDshUpdate / g.updateDsh / g.startWebHost）由各定义模块
 // 在自己文件内显式赋值（本模块是叶子，避免与 dsh-run.js 循环依赖）。
 //
 // 分组状态（v0.24 状态收敛：单例平铺字段重构为分组结构化）——旧平铺字段


### PR DESCRIPTION
dsh-deps-zero-intervention T3-T6 一次性落地（同一分支 4 commits，一个 PR 收尾）：自举状态快照端点 → Bootstrap 壳页重写 → 手动入口退役 + 路由清理 → 文档同步。T1/T2 已合（beta.1 后），本 PR 完成后 spec T1-T6 全闭环。

## Commits

- **e648cff (T3)** 自举状态快照端点：`GET /webui/boot-state` → `readBootState()` 把 g.boot 状态机 + g.deps（含 T1 errorClass/guidance）+ g.web 收敛成 `{ phase, ready, deps, boot, web }` 单一状态出口（全空值兜底，永不抛）；g.boot.guidance 联动（handleFailure 落指引 / convergeReady 清）
- **c8ad0ce (T4)** Bootstrap 壳页重写：webui-shell.jinja2 1108 行诊断壳 → ~740 行三态自举页（707+/965−）——booting（阶段时间线 + 实时日志滚动 + 退避重试脚注）/ action-needed（errorClass 人话指引 + 自动续跑/停等区分 + 原始错误折叠详情）/ ready（iframe 直嵌）。**页面无任何可点的启动/安装入口**（actions/t1/t2 诊断卡/门禁链/手动按钮全家删除）。保留剪贴板桥/主题跟随/events 事件驱动；webui.js 首帧内嵌 boot-state
- **ad60f69 (T5)** 手动入口退役 + 路由清理：删 `/webui/start` `/webui/install-deps` `/webui/verify-deps` `/webui/health`（调用面核实：壳页已停用、tools 经能力层直调，均无浏览器消费者）；`collectWebDiagnostics`/`buildDepsDiagCheck`/`buildProcessDiagCheck`/`pickProcessFix`/`readLogTail` 整链退役（−13.4KB）；events 的 diagnostics 载荷收敛为无载荷 diag-changed（壳页刷新 boot-state 信号）
- **491ffc0 (T6)** 文档同步：DESIGN（生命周期/自举页/已知限制补 dsh 升级需重启）、README（全自动安装）、skills/dsh-hanako 整篇重写 + dsh-install verify 静态语义、CHANGELOG 补 v1.0.0-beta.2 草稿（T1-T6）

## 净效果

+849/−1685（含 T4 重写）——诊断壳与手动入口退役，替换为零干预自举面（自动链 + 分类 + 三态呈现）。

## 验证

- 4 文件批量 `node --check` 通过；`node scripts/build.mjs` rspack 单 bundle 构建通过（含静态断言）
- 残留扫描：src 内 install-deps/verify-deps/webui/start|health/collectWebDiagnostics/readDiagnostics/probeHost 无非注释引用；模板无手动入口字样
- T3 readBootState 8 场景冒烟（单例缺失/从未跑/installing/deps 失败/boot restart-needed/web.ready/waiting 无 guidance/bus 就绪）符合预期；T4 模板编译 + 渲染冒烟通过

## 待实装验证

装包后三态呈现：依赖缺失/断网 → booting（时间线 + 退避倒计时）；不可恢复（declaration/需重启）→ action-needed（指引 + 详情折叠）；就绪 → iframe 直嵌。页面全程无可点手动入口。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic dependency setup and WebUI startup with retry and fallback handling.
  - Added a three-state Bootstrap experience: booting, action needed, and ready.
  - Added unified boot-status reporting with progress, retry timing, and user guidance.
- **Changes**
  - The ready interface now loads automatically without manual start, install, or verification controls.
  - Retired legacy manual web routes and diagnostic APIs.
- **Documentation**
  - Updated installation, troubleshooting, design, and skill documentation for the automated startup workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->