### PR TITLE
chore: 发布包许可证声明改 NOTICE（MPL-2.0 Exhibit A/B + IWSL）

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,8 @@
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+Copyright (c) 2026 Nyasers
+
+Source code for this distribution is available at:
+https://github.com/Nyasers/dsh-hanako
+
+This Source Code Form is "Incompatible With Secondary Licenses", as defined by the Mozilla Public License, v. 2.0.

--- a/README.md
+++ b/README.md
@@ -27,3 +27,5 @@
 
 This project is licensed under the **Mozilla Public License 2.0**.
 See the [LICENSE](LICENSE) file for details.
+
+This Source Code Form is "Incompatible With Secondary Licenses", as defined by the Mozilla Public License, v. 2.0.

--- a/scripts/pack.mjs
+++ b/scripts/pack.mjs
@@ -44,8 +44,7 @@ execFileSync(process.execPath, [join(ROOT, "scripts", "build.mjs")], {
 //    包根结构 = 标准插件形态（根 index.js + routes/ 壳，无 dist 这层目录）。
 //    app/（card.js/css 已 asset/source 内联进 bundle）与 routes/（壳由 build 生成）不再复制。
 const staticItems = [
-  "LICENSE",
-  "README.md",
+  "NOTICE",
   "package.json",
   "manifest.json",
   "pnpm-workspace.yaml",
@@ -59,8 +58,8 @@ for (const item of staticItems) {
   // dereference: true —— 历史为内置 pnpm 的符号链接复制（node_modules/pnpm →
   // .pnpm/pnpm@…/node_modules/pnpm，zip 内置 pnpm）；现版本起 pnpm 改运行时引导
   // （tools/lib/pnpm.js ensurePnpm 下载单文件到数据目录 pnpm-dist/），不再打包
-  // node_modules/pnpm——其余静态项（LICENSE/README/package.json/manifest/dsh-plugin/
-  // skills）均为真实实体，dereference 恒为 no-op，保留无害。
+  // node_modules/pnpm——其余静态项（NOTICE/package.json/manifest/pnpm-workspace/
+  // pnpm-lock/skills）均为真实实体，dereference 恒为 no-op，保留无害。
   fs.copySync(src, join(distDir, item), {
     dereference: true,
     filter: (srcPath) => {


### PR DESCRIPTION
## 背景

发布包此前直接打包 `LICENSE`（MPL-2.0 全文）与 `README.md`。本次按 MPL-2.0 Exhibit A/B 的惯例改为随附 `NOTICE`：单文件承载许可副本指引、版权声明、源码地址与 IWSL 声明，README 保留在包外。

## 变更

- **NOTICE（新增）**：MPL-2.0 Exhibit A（许可副本指引）+ 版权声明（© 2026 Nyasers）+ 源码地址 + Exhibit B（Incompatible With Secondary Licenses 声明）
- **README.md**：License 节末尾补 IWSL 声明，引号与官方文本统一为直引号，补文件末尾换行
- **scripts/pack.mjs**：`staticItems` 打包清单由 `LICENSE` + `README.md` 替换为 `NOTICE`，同步过时注释

## 验证

- ` node --check scripts/pack.mjs` 语法通过
- 变更面纯清单替换 + 文本声明，不涉及运行时逻辑