### PR TITLE
refactor: 脚本工作流改 pre 钩子声明串联（prepack/preversion）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Install dev dependencies
         run: pnpm install --frozen-lockfile
 
-      # pack 内部自动 build（rspack）+ 复制交付清单 + zip + sha256
+      # pack 经 prepack 钩子自动前置 build（rspack）+ 复制交付清单 + zip + sha256
       - name: Package
         run: pnpm run pack
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "node scripts/build.mjs",
     "pack": "node scripts/pack.mjs",
+    "prepack": "node scripts/build.mjs",
     "version": "node scripts/version.mjs"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "node scripts/build.mjs",
     "pack": "node scripts/pack.mjs",
     "prepack": "node scripts/build.mjs",
+    "preversion": "pnpm run pack",
     "version": "node scripts/version.mjs"
   },
   "dependencies": {

--- a/scripts/pack.mjs
+++ b/scripts/pack.mjs
@@ -5,13 +5,12 @@
 // 交付物 = 代码 bundle（dist/）+ 配置 + 技能 + cordis 插件 + lockfile，零依赖（Agent pnpm i 装，
 // pnpm 运行时引导：tools/lib/pnpm.js ensurePnpm 下载单文件 pnpm.mjs 到数据目录 pnpm-dist/，
 // 供 tools/lib/install.js 部署 @deepseek-ai/dsh）。
-// 流程：build（rspack 单 bundle）→ 复制交付清单 → zip → SHA256。
-// 用法：node scripts/pack.mjs [version]（缺省用 package.json 的 version）
+// 流程：复制交付清单（prepack 钩子已先行 build）→ zip → SHA256。
+// 用法：pnpm run pack（prepack 自动前置 build；单独 node scripts/pack.mjs 要求 dist/ 已构建）
 // 产出：releases/dsh-hanako-v<version>.zip + .sha256；铺平目录 _tmp/pkg/（zip 中间原料，可清空）
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { ZipArchive } from "archiver";
 
@@ -32,15 +31,7 @@ if (version !== manifestVersion)
     `版本不一致：package.json ${version} ≠ manifest.json ${manifestVersion}（manifest 未同步，跑 scripts/version.mjs 或手动同步后再打包）`,
   );
 
-// 1. 构建 bundle
-console.log("[pack] build...");
-execFileSync(process.execPath, [join(ROOT, "scripts", "build.mjs")], {
-  cwd: ROOT,
-  stdio: "inherit",
-  env: { ...process.env, RSPACK_ENV: process.env.RSPACK_ENV || "" },
-});
-
-// 2. 静态项复制进 dist —— dist 即完整交付目录（bundle + manifest + skills + cordis 插件），
+// 1. 静态项复制进 dist —— dist 即完整交付目录（bundle + manifest + skills + cordis 插件），
 //    包根结构 = 标准插件形态（根 index.js + routes/ 壳，无 dist 这层目录）。
 //    app/（card.js/css 已 asset/source 内联进 bundle）与 routes/（壳由 build 生成）不再复制。
 const staticItems = [
@@ -70,7 +61,7 @@ for (const item of staticItems) {
   });
 }
 
-// 2.5 静态资产压缩（terser JS 纯语法级 + clean-css CSS 压缩，覆盖写回 dist 副本）
+// 2. 静态资产压缩（terser JS 纯语法级 + clean-css CSS 压缩，覆盖写回 dist 副本）
 //     cordis 插件（dist/cordis/node_modules/@dsh-hanako/*/index.js，由 build 从
 //     src-cordis 组装）被 dsh 运行时 import() 加载、client.js 被浏览器
 //     ModuleLoader 按 window.__ModuleLoader__.load 注册；均只做语法级压缩。

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -8,7 +8,9 @@
 // 工作区干净（自测/预览时允许有未提交改动）。
 //
 // 职责边界：只做版本号的机械同步——package.json（单一事实源）bump → manifest.json
-// 同步（防手改漏同步的坑）→ pack 校验（版本一致性强制校验）→ commit + annotated tag。
+// 同步（防手改漏同步的坑）→ commit + annotated tag。
+// 打包验证（源码能 build + 链路通 + 版本一致）由 preversion 钩子前置：
+// pnpm run version → preversion(pnpm run pack → prepack(build) → pack) → version。
 // push 手动（tag 触发 CI 发布）。
 // 说明：pnpm-lock.yaml 不含该包自身 version（lockfileVersion 仅记录依赖解析树与
 // importers 的依赖声明，根包版本不落在 lock 里），故 bump 只同步 package.json +
@@ -237,7 +239,7 @@ function main() {
     pkg.version = next;
     write("package.json", pkg);
   }
-  console.log("[version] 1/4 package.json -> " + next);
+  console.log("[version] 1/3 package.json -> " + next);
 
   // 2) manifest.json 同步（脚本保证同步，防漏）
   if (!dryRun) {
@@ -245,19 +247,13 @@ function main() {
     manifest.version = next;
     write("manifest.json", manifest);
   }
-  console.log("[version] 2/4 manifest.json -> " + next);
+  console.log("[version] 2/3 manifest.json -> " + next);
 
   // 2.5) pnpm-lock.yaml 不同步版本（见文件头：pnpm-lock 不含根包 version，bump 只同步
   //    package.json + manifest.json；lock 由 pnpm install 自动维护，不做机械对齐）
 
-  // 3) pack 验证（version 仅本地使用，打包只为验证正常产出：源码能 build + 打包链路通
-  //    + 版本一致性强制校验 package.json == manifest.json == 打包版本，不一致直接 fail；
-  //    打包版本只读 package.json，不传参）。走 pnpm run pack 触发 prepack 钩子先行
-  //    build——验证的是最新源码的全链路产出，而非复用旧 dist。
-  run("pnpm run pack", "3/4 打包验证");
-
-  // 4) git commit + annotated tag（CHANGELOG 由发版人自行维护，bump 前写好并提交；
-  //    本脚本只提交版本号两个文件）
+  // 3) git commit + annotated tag（CHANGELOG 由发版人自行维护，bump 前写好并提交；
+  //    本脚本只提交版本号两个文件；打包验证已由 preversion 钩子先行完成）
   run("git add package.json manifest.json", "git add");
   run("git commit -m \"chore: bump v" + next + "\"", "git commit");
   run("git tag -a v" + next + " -m \"v" + next + "\"", "git tag -a v" + next);

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -11,6 +11,8 @@
 // 同步（防手改漏同步的坑）→ commit + annotated tag。
 // 打包验证（源码能 build + 链路通 + 版本一致）由 preversion 钩子前置：
 // pnpm run version → preversion(pnpm run pack → prepack(build) → pack) → version。
+// dry-run 预览（--dry-run）走 node 直跑绕过 preversion 钩子——钩子感知不到脚本参数
+// （pre 钩子 argv 恒为空），无法条件跳过打包；需要完整链路验证时用真实 bump。
 // push 手动（tag 触发 CI 发布）。
 // 说明：pnpm-lock.yaml 不含该包自身 version（lockfileVersion 仅记录依赖解析树与
 // importers 的依赖声明，根包版本不落在 lock 里），故 bump 只同步 package.json +
@@ -215,6 +217,12 @@ function main() {
   const next = nextBase + "+" + dshBuild();
 
   console.log("[version] 当前 " + current + " -> 新版本 " + next + (dryRun ? "（dry-run，不落盘）" : ""));
+  if (dryRun) {
+    // dry-run 预览绕过 preversion 钩子（钩子感知不到参数，无法条件跳过），故不触发
+    // 打包验证；需要完整链路验证时用真实 bump（pnpm run version，无 --dry-run）。
+    console.log("[version] dry-run 预览：preversion 打包验证已绕过（钩子无法感知 --dry-run）；");
+    console.log("[version]   完整链路验证请走真实 bump：pnpm run version -- <子命令>");
+  }
   if (next === current) {
     console.error("[version] 版本号未变化");
     process.exit(1);

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -250,9 +250,10 @@ function main() {
   // 2.5) pnpm-lock.yaml 不同步版本（见文件头：pnpm-lock 不含根包 version，bump 只同步
   //    package.json + manifest.json；lock 由 pnpm install 自动维护，不做机械对齐）
 
-  // 3) pack 验证（内含版本一致性强制校验：package.json == manifest.json == 打包版本，
-  //    不一致直接 fail；打包版本只读 package.json，不传参）。走 pnpm run pack 触发
-  //    prepack 钩子先行 build（pack 脚本本身已不含构建步骤）。
+  // 3) pack 验证（version 仅本地使用，打包只为验证正常产出：源码能 build + 打包链路通
+  //    + 版本一致性强制校验 package.json == manifest.json == 打包版本，不一致直接 fail；
+  //    打包版本只读 package.json，不传参）。走 pnpm run pack 触发 prepack 钩子先行
+  //    build——验证的是最新源码的全链路产出，而非复用旧 dist。
   run("pnpm run pack", "3/4 打包验证");
 
   // 4) git commit + annotated tag（CHANGELOG 由发版人自行维护，bump 前写好并提交；

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -251,8 +251,9 @@ function main() {
   //    package.json + manifest.json；lock 由 pnpm install 自动维护，不做机械对齐）
 
   // 3) pack 验证（内含版本一致性强制校验：package.json == manifest.json == 打包版本，
-  //    不一致直接 fail；打包版本只读 package.json，不传参）
-  run("node scripts/pack.mjs", "3/4 打包验证");
+  //    不一致直接 fail；打包版本只读 package.json，不传参）。走 pnpm run pack 触发
+  //    prepack 钩子先行 build（pack 脚本本身已不含构建步骤）。
+  run("pnpm run pack", "3/4 打包验证");
 
   // 4) git commit + annotated tag（CHANGELOG 由发版人自行维护，bump 前写好并提交；
   //    本脚本只提交版本号两个文件）


### PR DESCRIPTION
## 背景

pack.mjs 此前代码内 \xecFileSync\ 串联 build.mjs，version.mjs 又直接 \
ode scripts/pack.mjs\——脚本间靠代码互相引用串流程。改用 npm/pnpm pre 钩子声明式串联：构建前置逻辑收进 \package.json\ 的 \prepack\，pack 变纯打包脚本，调用方统一走 \pnpm run pack\ 即自动触发。

## 变更

- **package.json**：新增 \prepack\: \
ode scripts/build.mjs\
- **scripts/pack.mjs**：删除 execFileSync 构建调用与 import（−8 行），头部流程/用法注释同步，步骤编号顺延
- **scripts/version.mjs**：3/4 打包验证 \
ode scripts/pack.mjs\ → \pnpm run pack\（触发 prepack 钩子）
- **.github/workflows/release.yml**：注释同步（CI 本就跑 \pnpm run pack\，行为不变）

## 验证

- \pnpm run pack\ 全链路实测：prepack(build rspack 230ms + terser + cordis) → pack(minify 11 files + zip) 产出正常
- \
ode --check\ 三个脚本语法通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release packaging now automatically prepares the latest application files before creating the release archive.
  * Release archives consistently use the current application version.
  * Version updates now validate the complete build-and-package workflow before committing release changes.
  * Packaging steps and their order have been clarified to support more reliable release generation.
  * Dry-run version checks now clearly indicate when full packaging validation requires a real version update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->