### PR TITLE
chore: pnpm 引导单一事实源化——tarball + pm 段 sha512 校验，PNPM_BOOTSTRAP 全删

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dsh-hanako",
   "version": "1.0.0-beta.2-hotfix.2+dsh-0.1.2-rc.1",
   "private": true,
-  "packageManager": "pnpm@11.25.0",
+  "packageManager": "pnpm@11.25.0+sha512.5cde925b4f075f725eb71fbae18a42ffe784524789f19b61c731cb8721ec28aaee160e01a8d5af4fedb2a42cdbf300efe23db356b0d4a17b4d63e11f8ab7c956",
   "type": "module",
   "scripts": {
     "build": "node scripts/build.mjs",
@@ -19,6 +19,7 @@
     "@rspack/core": "^2.2.1",
     "archiver": "^8.0.0",
     "clean-css": "^5.3.3",
+    "corepack": "0.36.0",
     "dot": "^1.1.3",
     "fs-extra": "^11.4.0",
     "html-minifier-terser": "^7.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       clean-css:
         specifier: ^5.3.3
         version: 5.3.3
+      corepack:
+        specifier: 0.36.0
+        version: 0.36.0
       dot:
         specifier: ^1.1.3
         version: 1.1.3
@@ -2958,6 +2961,11 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  corepack@0.36.0:
+    resolution: {integrity: sha512-SiiJsBhZqdBiPHTEl6OT3sASrRrKIcYTQMsVGXx6EE/gM8WFMwYjeIX8Tt8RiU4Iv2J6LbT8KpGfCOsBpRWB/w==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    hasBin: true
 
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
@@ -7185,6 +7193,8 @@ snapshots:
   cookie@0.7.2: {}
 
   core-util-is@1.0.3: {}
+
+  corepack@0.36.0: {}
 
   cors@2.8.6:
     dependencies:

--- a/src/tools/lib/pnpm.js
+++ b/src/tools/lib/pnpm.js
@@ -3,15 +3,16 @@
 //
 // tools/lib/pnpm.js — pnpm 运行时引导（tarball 渐进式方案）共用模块（lib 提取）
 // 从插件安装包中摘除 pnpm（zip 不再携带 node_modules/pnpm，package.json 不再声明
-// devDependencies pnpm），改为运行时按需引导：下载 pnpm npm 包的 dist/pnpm.mjs
-// （自包含入口 CLI，静态 import 全为 node: 内置模块，宿主 electron node 直接执行）
-// + dist/worker.js（package 导入 worker）到数据目录
-// <dataDir>/pnpm-dist/pnpm-{version}/，版本随 packageManager、文件 sha256 静态校验。
+// devDependencies pnpm），改为运行时按需引导：下载 pnpm npm 包 tarball（registry
+// 官方源，gzip 压缩 ~4.9MB，一次下载含全部所需），以 packageManager 的 sha512 校验
+// 后解压提取 dist/pnpm.mjs（自包含入口 CLI，静态 import 全为 node: 内置模块，宿主
+// electron node 直接执行）+ dist/worker.js（package 导入 worker）到数据目录
+// <dataDir>/pnpm-dist/pnpm-{version}/。版本与完整性单一事实源 = packageManager。
 // 实测确认（宿主 node v26.8.1）：pnpm view 路径只依赖 pnpm.mjs；pnpm install/add 的导入
 // 阶段经 new Worker(join(import.meta.dirname, "worker.js")) 加载 worker.js（pnpm.mjs
 // 内联处 workerScriptPath），缺 worker.js 时导入 worker 静默退出 1（无错误信息）——
-// 故引导下载两个文件，缺一即重下。文件清单与 sha256 静态配置（见下方 PNPM_BOOTSTRAP）；
-// 版本不在此硬编码——单一事实源 = package.json packageManager 字段（见下方解析）。
+// 引导零静态校验字段：tarball sha512 来自 packageManager（corepack 维护），下载校验
+// 后解压提取两文件，缺一即重下。升级 pnpm 仅改 packageManager（corepack use 刷 hash）。
 //
 // 为什么自给自足：宿主 electron node 不带 npm/corepack/npx（Electron 发行只有 node
 // 运行时），引导是唯一自给自足路径；宿主侧未来可能开放 npm 调用（liliMozi 口头确认，
@@ -36,15 +37,16 @@
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
-  createReadStream,
   createWriteStream,
   existsSync,
   mkdirSync,
   readFileSync,
   renameSync,
   rmSync,
+  writeFileSync,
 } from "node:fs";
 import { get as httpsGet } from "node:https";
+import { gunzipSync } from "node:zlib";
 import { join } from "node:path";
 import {
   getSingleton,
@@ -53,68 +55,54 @@ import {
   resolveNodeExecEnv,
 } from "./state.js";
 
-// ---- 版本单一事实源：package.json packageManager 字段（pnpm@<version>[+sha512…]）----
-// corepack 语义：版本与 tarball 完整性（sha512）由 packageManager 单一承载。升级 pnpm =
-// 改 packageManager 版本 + `corepack use pnpm@<ver>` 刷新 hash（corepack 作 devDep 引入——
-// Node 25+ 官方不再捆绑 corepack，hash 维护工具需固定来源；devDep 不进运行时）。
-// 运行时引导的 pnpm 版本不在此硬编码：PNPM_VERSION 从插件根 package.json（PLUGIN_ROOT
-// 定位，源码/bundle 两形态均成立）解析，兼容裸版本（pnpm@11.25.0）与带 hash
-// （pnpm@11.25.0+sha512.…）两种形态；解析失败（字段缺失/畸形）引导时报可读错误，
-// 不静默回退——版本已无第二事实源，回退即用错版本。
-// ---- 运行时引导文件（静态，只存清单 + sha256）----
-// 文件 sha256 必须静态：packageManager 的 sha512 是 tarball 粒度，引导下载的是 dist
-// 单文件（pnpm.mjs + worker.js），校验粒度不同无法推导——文件级完整性锚点只能静态留。
-// 升级 pnpm 版本时：改 packageManager → corepack use 刷 hash → 重算两文件 sha256 更新此处。
+// ---- 版本与完整性单一事实源：package.json packageManager（pnpm@<version>+sha512.<hex>）----
+// corepack 语义：版本 + tarball sha512 由 packageManager 单一承载（corepack use 生成）。
+// 升级 pnpm = 改 packageManager + `corepack use pnpm@<ver>` 刷新 hash（corepack 作 devDep
+// 引入——Node 25+ 官方不再捆绑 corepack，hash 维护工具需固定来源；devDep 不进运行时）。
+// 运行时引导零静态校验字段：从插件根 package.json（PLUGIN_ROOT 定位，源码/bundle 两
+// 形态均成立）解析出版本与 sha512，下载 tarball 后即以此 sha512 校验——完整性链
+// packageManager（corepack 维护）→ tarball → 解压文件，无人工重算环节。
+// 要求 pm 段带 sha512 hash：旧裸版本形态（pnpm@11.25.0 无 hash）无法校验 tarball，
+// 引导时报可读错误提示 corepack use 刷新（历史发布包不含本代码，兼容非问题）。
 // ⚠️ 版本兼容：pnpm 11.25.0 的 engines 要求 node >=22.13；宿主 electron node 当前为
 // v26.8.1（满足）。升级 pnpm 时须核对新版本 engines 不超过宿主 node 版本
 // （宿主 node 版本固定，不做运行时探测；该约束靠此处注释人工把关）。
-// 两个文件：pnpm.mjs（入口 CLI）+ worker.js（package 导入 worker）——pnpm add 的
-// 导入阶段经 new Worker(import.meta.dirname/worker.js) 加载 worker.js（pnpm.mjs
-// 内联处：workerScriptPath = join(import.meta.dirname, "worker.js")），只下载
-// pnpm.mjs 会让 add 的导入 worker 崩溃（exit 1，无错误信息）；pnpm view 路径不触
-// 发 worker，单文件即可。实测（2026-09，宿主 node v24.15.0 → v26.8.1）确认两文件均必需。
-const PNPM_BOOTSTRAP = {
-  files: [
-    {
-      name: "pnpm.mjs",
-      sha256: "ddc64218bc85fb88d28b5def06eb01fafb39cb67f7a9465ce736456658cc7f11",
-    },
-    {
-      name: "worker.js",
-      sha256: "81648f68f288deeace8ca799f1d1021bda7493cdc8afa2582600de9129fd9a82",
-    },
-  ],
-};
+// tarball 内所需两文件：package/dist/pnpm.mjs（入口 CLI）+ package/dist/worker.js
+// （package 导入 worker）——pnpm add 的导入阶段经 new Worker(join(import.meta.dirname,
+// "worker.js")) 加载 worker.js（pnpm.mjs 内联处 workerScriptPath），只提取 pnpm.mjs
+// 会让 add 的导入 worker 崩溃（exit 1，无错误信息）；pnpm view 路径不触发 worker。
+// 实测（2026-09，宿主 node v24→v26）确认两文件均必需。
 
-// 从插件根 package.json 的 packageManager 解析 pnpm 版本（pnpm@<ver> 或 pnpm@<ver>+sha512…）。
-// 正则：版本段 = 严格 semver 主体（含 prerelease），可选 +build（hash）段截断；非 pnpm /
-// 畸形格式不匹配 → null。解析失败返回 null（不 throw）——调用方（引导路径）给可读错误。
-function parsePnpmVersion() {
+// 从插件根 package.json 的 packageManager 解析 { version, sha512 }：
+// pnpm@<semver>+sha512.<hex>（corepack use 生成形态；sha512 为 tarball 完整性的 128 hex）。
+// 旧裸版本形态（无 +sha512 段）/ 畸形格式 → null（引导路径给可读错误，不静默回退）。
+function parsePnpmManager() {
   try {
     const pkg = JSON.parse(readFileSync(join(PLUGIN_ROOT, "package.json"), "utf8"));
     const pm = pkg && typeof pkg === "object" ? pkg.packageManager : null;
-    const m =
-      typeof pm === "string"
-        ? pm.match(/^pnpm@([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)(?:\+[0-9A-Za-z.-]+)?$/)
-        : null;
-    return m ? m[1] : null;
+    if (typeof pm !== "string") return null;
+    const m = pm.match(
+      /^pnpm@([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)\+sha512\.([0-9a-fA-F]{128})$/,
+    );
+    if (!m) return null;
+    return { version: m[1], sha512: m[2].toLowerCase() };
   } catch {
     return null; // 文件缺失 / JSON 畸形 → 引导路径统一给可读错误
   }
 }
 
 // 模块加载解析一次（packageManager 是插件包静态内容，运行期不变）；null = 解析失败
-// （install.js 等消费方在 ensurePnpm 成功后才读此值，解析失败时引导已抛错，不会取到 null）
-export const PNPM_VERSION = parsePnpmVersion();
+const PNPM_MANAGER = parsePnpmManager();
 
-// 下载源：unpkg 直链优先 → npmmirror（npm registry 官方镜像，/files/ 包内文件直链，
-// 国内网络可达）→ jsdelivr 收尾。同一文件（npmmirror 与 registry tarball 逐字节一致，
-// 实测 sha256 同源）；均可能 302/跳边缘 CDN。registry.npmjs.org 官方无单文件端点
-// （只供 tarball）未纳入——为 tarball 引入解压分支不值，三家文件 CDN 已覆盖国际+国内。
-const PNPM_CDNS = [
-  (name) => `https://unpkg.com/pnpm@${PNPM_VERSION}/dist/${name}`,
-  (name) => `https://registry.npmmirror.com/pnpm/${PNPM_VERSION}/files/dist/${name}`,
-  (name) => `https://cdn.jsdelivr.net/npm/pnpm@${PNPM_VERSION}/dist/${name}`,
+// 兼容导出（外部取版本号用；install.js smoke 报告等；值 = pm 段解析 version）
+export const PNPM_VERSION = PNPM_MANAGER ? PNPM_MANAGER.version : null;
+
+// tarball 下载源：registry.npmjs.org 官方优先 → registry.npmmirror.com 镜像兜底
+// （同一 tarball；npmmirror 可能 302 到边缘 CDN，downloadToFile 已跟随）。文件 CDN
+// （unpkg/jsdelivr）无 tarball 直链端点，不入列。
+const PNPM_TARBALL_SOURCES = [
+  (version) => `https://registry.npmjs.org/pnpm/-/pnpm-${version}.tgz`,
+  (version) => `https://registry.npmmirror.com/pnpm/-/pnpm-${version}.tgz`,
 ];
 const DOWNLOAD_TIMEOUT_MS = 60000; // 单次下载请求超时（重定向跟随共享）
 const STDOUT_CAP = 65536; // runPnpm 内存累积上限（调用方只需尾部/错误提取）
@@ -144,15 +132,71 @@ function resolveDataDir(opts) {
   return join(PLUGIN_ROOT, "data");
 }
 
-// ---- sha256（node:crypto 流式计算，零依赖）----
-function sha256File(file) {
-  return new Promise((resolve, reject) => {
-    const hash = createHash("sha256");
-    const rs = createReadStream(file);
-    rs.on("error", reject);
-    rs.on("data", (d) => hash.update(d));
-    rs.on("end", () => resolve(hash.digest("hex")));
-  });
+// ---- tar 提取（零依赖：node 无内置 tar；npm tarball = gzip(tar) 字节流）----
+// 遍历 512B 头块：常规文件（typeflag '0'/NUL）+ PAX 扩展头（'x'，path 覆盖）+
+// GNU longname（'L'）。目标条目命中才取数据 Buffer——只读不按路径写盘，无 zip-slip
+// 面。size 按 8 进制解析（>8GiB 文件的 base-256 size 不处理，npm 包无此量级）。
+// pnpm tarball 条目带 package/ 前缀，dist 下两文件为所需。
+const TAR_TARGETS = {
+  "package/dist/pnpm.mjs": "pnpm.mjs",
+  "package/dist/worker.js": "worker.js",
+};
+
+function extractPnpmFiles(tgzBuf) {
+  const tarBuf = gunzipSync(tgzBuf);
+  const out = new Map(); // 短名（pnpm.mjs/worker.js）→ Buffer
+  let off = 0;
+  let pendingLong = null; // GNU longname 待应用到下一实体头
+  let paxPath = null; // PAX path 覆盖（同样只对下一实体头生效）
+  while (off + 512 <= tarBuf.length) {
+    const head = tarBuf.subarray(off, off + 512);
+    if (head.every((b) => b === 0)) break; // 全零块 = 归档结束
+    const typeflag = String.fromCharCode(head[156] || 0);
+    const sizeStr = head.subarray(124, 136).toString("utf8").replace(/\0.*$/, "").trim();
+    const size = sizeStr ? parseInt(sizeStr, 8) : 0;
+    if (!Number.isFinite(size) || size < 0) {
+      throw new Error("tar 头解析失败 @ " + off);
+    }
+    const dataStart = off + 512;
+    const dataEnd = dataStart + size;
+    off = dataEnd + (Math.ceil(size / 512) * 512 - size);
+    if (typeflag === "x") {
+      // PAX 扩展头记录：格式 "<len> key=value\n"；只取 path
+      const pax = tarBuf.subarray(dataStart, dataEnd).toString("utf8");
+      for (const rec of pax.split("\n")) {
+        const sp = rec.indexOf(" ");
+        const eq = rec.indexOf("=", sp + 1);
+        if (sp > 0 && eq > sp + 1 && rec.slice(sp + 1, eq) === "path") {
+          paxPath = rec.slice(eq + 1);
+        }
+      }
+      continue;
+    }
+    if (typeflag === "L") {
+      pendingLong = tarBuf.subarray(dataStart, dataEnd).toString("utf8").replace(/\0.*$/, "");
+      continue;
+    }
+    let name;
+    if (pendingLong) {
+      name = pendingLong;
+      pendingLong = null;
+    } else if (paxPath) {
+      name = paxPath;
+      paxPath = null;
+    } else {
+      const raw = head.subarray(0, 100).toString("utf8").replace(/\0.*$/, "");
+      const prefix = head.subarray(345, 500).toString("utf8").replace(/\0.*$/, "");
+      name = prefix ? prefix + "/" + raw : raw;
+    }
+    if ((typeflag === "0" || typeflag === "\0") && Object.hasOwn(TAR_TARGETS, name)) {
+      out.set(TAR_TARGETS[name], tarBuf.subarray(dataStart, dataEnd));
+    }
+  }
+  const missing = Object.keys(TAR_TARGETS).filter((n) => !out.has(TAR_TARGETS[n]));
+  if (missing.length) {
+    throw new Error("tarball 缺少目标文件: " + missing.join(", "));
+  }
+  return out;
 }
 
 // ---- https GET（跟随 3xx 重定向；unpkg/jsdelivr 均可能 302 到边缘 CDN）----
@@ -225,7 +269,7 @@ let ensurePromise = null;
 
 export function ensurePnpm(opts) {
   // 并发防护：引导进行中（下载/校验）的调用共享同一 promise——install/check/lifecycle
-  // 并发触发只下载一次。settle 后重置为 null：下次调用重新走「缓存存在 + sha256 一致」
+  // 并发触发只下载一次。settle 后重置为 null：下次调用重新走「缓存存在（两文件）」
   // 快速路径（幂等，不重复下载；文件被外部删除时也能自愈重下）。
   if (ensurePromise) return ensurePromise;
   ensurePromise = doEnsurePnpm(opts).finally(() => {
@@ -238,96 +282,84 @@ async function doEnsurePnpm(opts) {
   // ① 宿主通道探测（未来接入点；当前恒 null → 走单文件引导）
   const host = await tryHostChannel();
   if (host && typeof host === "string" && host) return host;
-  // 版本解析失败（pm 段缺失/畸形）→ 可读错误，不静默回退（版本已无第二事实源）
-  if (!PNPM_VERSION) {
+  // 版本解析失败（pm 段缺失/畸形/无 sha512）→ 可读错误，不静默回退
+  if (!PNPM_MANAGER) {
     throw new Error(
-      "pnpm 版本解析失败：package.json packageManager 缺失或格式异常（期望 pnpm@<semver>[+sha512…]，由 corepack use 维护）",
+      "pnpm 引导配置解析失败：package.json packageManager 缺失或格式异常（期望 pnpm@<semver>+sha512.<hex>，用 corepack use 维护）",
     );
   }
+  const { version, sha512 } = PNPM_MANAGER;
   // ② 缓存路径 <dataDir>/pnpm-dist/pnpm-{version}/{pnpm.mjs,worker.js}（独立于 dsh-pkg）
   const dataDir = resolveDataDir(opts);
-  const cacheDir = join(dataDir, "pnpm-dist", "pnpm-" + PNPM_VERSION);
+  const cacheDir = join(dataDir, "pnpm-dist", "pnpm-" + version);
   const entry = join(cacheDir, "pnpm.mjs");
-  // ③ 缓存命中且全部文件 sha256 与预期一致 → 直接返回（幂等快速路径）
+  // ③ 缓存命中（两文件存在；tarball 校验 + 原子落位保证无部分写入形态）→ 幂等快速路径
   const cached = await cacheIntact(cacheDir);
   if (cached) {
     console.log("[pnpm] 命中缓存：" + entry);
     return entry;
   }
-  // ④ 下载：按 PNPM_CDNS 逐源尝试（unpkg → npmmirror → jsdelivr）；逐文件临时文件 →
-  // 校验 sha256 → 原子落位（mkdir + rename）。任一文件全源失败 → 抛可读错误（含源清单）。
+  // ④ 下载 tarball → sha512 校验（packageManager hash）→ gunzip + tar 提取两文件 →
+  // 逐文件原子落位。完整性链：sha512 覆盖下载全量，解压产物随之可信，无文件级二次校验。
   mkdirSync(cacheDir, { recursive: true });
-  for (const file of PNPM_BOOTSTRAP.files) {
-    const target = join(cacheDir, file.name);
-    const tmp = join(
+  let lastError = null;
+  for (const makeUrl of PNPM_TARBALL_SOURCES) {
+    const url = makeUrl(version);
+    const tmpTgz = join(
       cacheDir,
-      ".pnpm." + file.name + "." + process.pid + "." + Date.now() + ".tmp",
+      ".pnpm." + version + ".tgz." + process.pid + "." + Date.now() + ".tmp",
     );
-    let lastError = null;
-    for (const cdn of PNPM_CDNS) {
-      const url = cdn(file.name);
-      try {
-        console.log("[pnpm] 引导下载 " + url + " …");
-        await downloadToFile(url, tmp);
-        const actual = await sha256File(tmp);
-        if (actual !== file.sha256) {
-          try {
-            rmSync(tmp, { force: true });
-          } catch {
-            /* 清理失败忽略 */
-          }
-          throw new Error(
-            "pnpm 引导 sha256 校验失败（" +
-              file.name +
-              "：期望 " +
-              file.sha256 +
-              "，实际 " +
-              actual +
-              "）",
-          );
-        }
-        rmSync(target, { force: true }); // 旧缓存（哈希不符场景）先清，再原子落位
+    try {
+      console.log("[pnpm] 引导下载 " + url + " …");
+      await downloadToFile(url, tmpTgz);
+      const actual = createHash("sha512").update(readFileSync(tmpTgz)).digest("hex");
+      if (actual !== sha512) {
+        throw new Error(
+          "tarball sha512 校验失败（期望 " + sha512 + "，实际 " + actual + "）",
+        );
+      }
+      console.log("[pnpm] sha512 校验通过，解压提取 …");
+      const files = extractPnpmFiles(readFileSync(tmpTgz)); // Map<短名, Buffer>
+      for (const [shortName, buf] of files) {
+        const target = join(cacheDir, shortName);
+        const tmp = join(
+          cacheDir,
+          ".pnpm." + shortName + "." + process.pid + "." + Date.now() + ".tmp",
+        );
+        writeFileSync(tmp, buf);
+        rmSync(target, { force: true }); // 旧缓存（缺失/损坏场景）先清，再原子落位
         renameSync(tmp, target); // 同目录 rename，原子替换
         console.log("[pnpm] 引导完成：" + target);
-        lastError = null;
-        break;
-      } catch (e) {
-        lastError = e;
-        try {
-          rmSync(tmp, { force: true });
-        } catch {
-          /* 清理失败忽略 */
-        }
-        console.warn("[pnpm] " + url + " 下载失败：" + (e?.message || e));
       }
+      rmSync(tmpTgz, { force: true }); // 下载产物用完即清（缓存只留解压出的两文件）
+      lastError = null;
+      break;
+    } catch (e) {
+      lastError = e;
+      try {
+        rmSync(tmpTgz, { force: true });
+      } catch {
+        /* 清理失败忽略 */
+      }
+      console.warn("[pnpm] " + url + " 失败：" + (e?.message || e));
     }
-    if (lastError) {
-      throw new Error(
-        "pnpm 引导失败（" +
-          file.name +
-          "）：全部 CDN 源均不可用（" +
-          PNPM_CDNS.map((f) => f(file.name)).join("、") +
-          "），最后错误：" +
-          (lastError?.message || lastError) +
-          "。请检查网络后重试。",
-      );
-    }
+  }
+  if (lastError) {
+    throw new Error(
+      "pnpm 引导失败：全部 tarball 源均不可用（" +
+        PNPM_TARBALL_SOURCES.map((f) => f(version)).join("、") +
+        "），最后错误：" +
+        (lastError?.message || lastError) +
+        "。请检查网络后重试。",
+    );
   }
   return entry;
 }
 
-// 缓存完整性：全部引导文件存在且 sha256 与预期一致（任一缺失/不符 → 重新下载）
-async function cacheIntact(cacheDir) {
-  for (const file of PNPM_BOOTSTRAP.files) {
-    const p = join(cacheDir, file.name);
-    if (!existsSync(p)) return false;
-    try {
-      if ((await sha256File(p)) !== file.sha256) return false;
-    } catch {
-      return false;
-    }
-  }
-  return true;
+// 缓存完整性：两引导文件存在即视为完整——下载经 tarball sha512 校验 + 逐文件原子
+// 落位（tmp + rename），不存在部分写入形态；文件缺失/被外部删除 → 重新走下载自愈。
+function cacheIntact(cacheDir) {
+  return existsSync(join(cacheDir, "pnpm.mjs")) && existsSync(join(cacheDir, "worker.js"));
 }
 
 // ---- runPnpm：spawn node（Electron 自带 node 或自定义 nodejsPath，每次 spawn 前解析）+ pnpm 入口 ----

--- a/src/tools/lib/pnpm.js
+++ b/src/tools/lib/pnpm.js
@@ -8,7 +8,7 @@
 // 后解压提取 dist/pnpm.mjs（自包含入口 CLI，静态 import 全为 node: 内置模块，宿主
 // electron node 直接执行）+ dist/worker.js（package 导入 worker）到数据目录
 // <dataDir>/pnpm-dist/pnpm-{version}/。版本与完整性单一事实源 = packageManager。
-// 实测确认（宿主 node v26.8.1）：pnpm view 路径只依赖 pnpm.mjs；pnpm install/add 的导入
+// 宿主 node v26.8.1 下：pnpm view 路径只依赖 pnpm.mjs；pnpm install/add 的导入
 // 阶段经 new Worker(join(import.meta.dirname, "worker.js")) 加载 worker.js（pnpm.mjs
 // 内联处 workerScriptPath），缺 worker.js 时导入 worker 静默退出 1（无错误信息）——
 // 引导零静态校验字段：tarball sha512 来自 packageManager（corepack 维护），下载校验
@@ -21,14 +21,13 @@
 //
 // 导出：PNPM_VERSION（版本常量）/ ensurePnpm（幂等引导，返回 pnpm 入口绝对路径）
 // / tryHostChannel（宿主通道探测占位）/ runPnpm（spawn 宿主 node + pnpm 入口封装）
-// / DSH_PACKAGE + buildPnpmInstallArgs（pnpm install 参数构造收敛入口：T7a 起
+// / DSH_PACKAGE + buildPnpmInstallArgs（pnpm install 参数构造收敛入口：
 // lib/install.js 唯一安装调用点只传 registry 兜底意图，包名/旗标同源本模块）
 // / isValidPkgSpec（spec 注入面校验：仅接受严格 SemVer 或合法 dist-tag；校验职责在
 // 调用方——installDepsFromPlugin 计算 effectiveSpec 后、传 buildPnpmInstallArgs 前负责）。
-// 消费方（v0.18.2 收敛）：lib/install.js（installDepsFromPlugin 部署 dsh 依赖树 +
-// verifyDepsSmoke 的 pnpm 引导检查）。lib/check.js（npmViewDistTags）与 src/lifecycle.js
-// （patch 模板 {{NPM_CLI_PATH}} 占位符）v0.18.2 起退出——版本检查改 HTTP 直查 npm
-// registry（pnpm view 语义等价），patch 模板不再注入 pnpm 入口（settings 侧检查链路同改）。
+// 消费方：lib/install.js（installDepsFromPlugin 部署 dsh 依赖树 + verifyDepsSmoke 的
+// pnpm 引导检查）。版本检查走 HTTP 直查 npm registry（pnpm view 语义等价）；
+// settings 侧检查链路不经 pnpm 入口。
 //
 // 零运行时依赖：只用 node 内置模块（fs/path/crypto/https/child_process），不引入任何
 // npm 依赖（rspack externalsPresets.node 下保持外部 import）。容错纪律：引导失败抛
@@ -71,7 +70,6 @@ import {
 // （package 导入 worker）——pnpm add 的导入阶段经 new Worker(join(import.meta.dirname,
 // "worker.js")) 加载 worker.js（pnpm.mjs 内联处 workerScriptPath），只提取 pnpm.mjs
 // 会让 add 的导入 worker 崩溃（exit 1，无错误信息）；pnpm view 路径不触发 worker。
-// 实测（2026-09，宿主 node v24→v26）确认两文件均必需。
 
 // 从插件根 package.json 的 packageManager 解析 { version, sha512 }：
 // pnpm@<semver>+sha512.<hex>（corepack use 生成形态；sha512 为 tarball 完整性的 128 hex）。
@@ -97,12 +95,15 @@ const PNPM_MANAGER = parsePnpmManager();
 // 兼容导出（外部取版本号用；install.js smoke 报告等；值 = pm 段解析 version）
 export const PNPM_VERSION = PNPM_MANAGER ? PNPM_MANAGER.version : null;
 
-// tarball 下载源：registry.npmjs.org 官方优先 → registry.npmmirror.com 镜像兜底
-// （同一 tarball；npmmirror 可能 302 到边缘 CDN，downloadToFile 已跟随）。文件 CDN
-// （unpkg/jsdelivr）无 tarball 直链端点，不入列。
+// tarball 下载源（registry 类；unpkg/jsdelivr 等文件 CDN 无 tarball 端点，不入列）：
+// 官方 registry.npmjs.org → 官方国内镜像 npmmirror（302 到 cdn.npmmirror.com，已跟随）
+// → 第三方国内镜像（腾讯云 / 华为云，实测与官方 tarball 逐字节同源）。sha512 校验
+// 兜底：内容不符的源在引导时被拦下自动换下一个，源列表可安全扩充。
 const PNPM_TARBALL_SOURCES = [
   (version) => `https://registry.npmjs.org/pnpm/-/pnpm-${version}.tgz`,
   (version) => `https://registry.npmmirror.com/pnpm/-/pnpm-${version}.tgz`,
+  (version) => `https://mirrors.cloud.tencent.com/npm/pnpm/-/pnpm-${version}.tgz`,
+  (version) => `https://mirrors.huaweicloud.com/repository/npm/pnpm/-/pnpm-${version}.tgz`,
 ];
 const DOWNLOAD_TIMEOUT_MS = 60000; // 单次下载请求超时（重定向跟随共享）
 const STDOUT_CAP = 65536; // runPnpm 内存累积上限（调用方只需尾部/错误提取）
@@ -415,15 +416,11 @@ export async function runPnpm(args, opts = {}) {
   });
 }
 
-// ---- pnpm install 参数构造（T7a：lib/install.js 唯一安装调用点的收敛入口）----
-// v0.20.x 起：install.js 不再手拼 pnpm add 参数，改调 buildPnpmAddArgs（add @spec）。
-// T7a（dshana-embed-headless）：dsh 固定版本声明进插件根 package.json 的 dependencies，
-// 安装语义从「pnpm add @deepseek-ai/dsh@<spec>（版本基线 dshTag，外部可独立升级）」转为
-// 「pnpm install（按声明拉取，版本随插件发版）」——dsh 从外部可升级运行时依赖变为插件
-// 不可分割组成。故本函数废弃 add 形态，改为 buildPnpmInstallArgs：不拼包名/spec，只
-// 声明 install（pnpm 原生文本输出——ndjson reporter 已去除 2026-09-03，用户定稿：
-// 结构化事件层未被消费方解析利用，去掉后原生文本由 lib/install.js 逐行直通日志
-// 通道）；registry 兜底意图由调用方只传 URL。
+// ---- pnpm install 参数构造（lib/install.js 唯一安装调用点的收敛入口）----
+// dsh 固定版本声明进插件根 package.json 的 dependencies——安装语义 = pnpm install
+// （按声明拉取，版本随插件发版），dsh 是插件不可分割组成。本函数不拼包名/spec，只
+// 声明 install，输出为 pnpm 原生文本（由 lib/install.js 逐行直通日志通道）；
+// registry 兜底意图由调用方只传 URL。
 // ⚠️ 本函数保持纯拼接不做校验——声明版本合法性（严格 SemVer 或合法 dist-tag，见
 // isValidPkgSpec）由调用方负责：installDepsFromPlugin 读取插件根 package.json 的
 // dependencies 后校验（注入面收口，防 "npm:evil@1.0.0" / "github:user/repo" /
@@ -432,8 +429,8 @@ export const DSH_PACKAGE = "@deepseek-ai/dsh";
 
 export function buildPnpmInstallArgs({ registry } = {}) {
   // --prod：只装运行时 dependencies（插件根 package.json 有 rspack 等 devDeps 构建树，
-  // 运行时不需要；dsh + cordis 在 dependencies，T7d 起部署目标 = 插件根）。
-  const args = ["install", "--prod"]; // 原生文本输出（ndjson reporter 已去除）
+  // 运行时不需要；dsh + cordis 在 dependencies，部署目标 = 插件根）。
+  const args = ["install", "--prod"]; // 原生文本输出
   if (typeof registry === "string" && registry) {
     args.push("--registry=" + registry);
   }

--- a/src/tools/lib/pnpm.js
+++ b/src/tools/lib/pnpm.js
@@ -37,7 +37,6 @@ import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   createWriteStream,
-  existsSync,
   mkdirSync,
   readFileSync,
   renameSync,
@@ -71,18 +70,24 @@ import {
 // "worker.js")) 加载 worker.js（pnpm.mjs 内联处 workerScriptPath），只提取 pnpm.mjs
 // 会让 add 的导入 worker 崩溃（exit 1，无错误信息）；pnpm view 路径不触发 worker。
 
+// 严格 SemVer（node-semver 校验同款：核心组件与数字 prerelease 标识符禁止前导零；
+// 标识符非空——连续点/空段不匹配）。const 定义须在 parsePnpmManager 之前：模块顶层
+// 解析（PNPM_MANAGER）早于文件后部执行，后置 const 引用会撞 TDZ。
+const SEMVER_STRICT_RE =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
 // 从插件根 package.json 的 packageManager 解析 { version, sha512 }：
 // pnpm@<semver>+sha512.<hex>（corepack use 生成形态；sha512 为 tarball 完整性的 128 hex）。
+// 版本段须过严格 SemVer 判定（isValidSemverSpec：拒前导零 01.25.0 / 空标识符 alpha..1 /
+// prerelease 数字前导零 -01 等畸形——否则绕过解析错误分支，落到误导性「全部源不可用」）；
 // 旧裸版本形态（无 +sha512 段）/ 畸形格式 → null（引导路径给可读错误，不静默回退）。
 function parsePnpmManager() {
   try {
     const pkg = JSON.parse(readFileSync(join(PLUGIN_ROOT, "package.json"), "utf8"));
     const pm = pkg && typeof pkg === "object" ? pkg.packageManager : null;
     if (typeof pm !== "string") return null;
-    const m = pm.match(
-      /^pnpm@([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)\+sha512\.([0-9a-fA-F]{128})$/,
-    );
-    if (!m) return null;
+    const m = pm.match(/^pnpm@([^\s@+]+)\+sha512\.([0-9a-fA-F]{128})$/);
+    if (!m || !isValidSemverSpec(m[1])) return null;
     return { version: m[1], sha512: m[2].toLowerCase() };
   } catch {
     return null; // 文件缺失 / JSON 畸形 → 引导路径统一给可读错误
@@ -301,7 +306,9 @@ async function doEnsurePnpm(opts) {
     return entry;
   }
   // ④ 下载 tarball → sha512 校验（packageManager hash）→ gunzip + tar 提取两文件 →
-  // 逐文件原子落位。完整性链：sha512 覆盖下载全量，解压产物随之可信，无文件级二次校验。
+  // 原子发布：两文件 + 完成标记（.pnpm-ok，最后落位）——标记存在即两文件齐全，读侧
+  // 不见混合对；标记记录 tarball sha512 + 文件 sha256，缓存命中时重算比对（防同版本
+  // hash 变更沿用旧文件 / 缓存文件被篡改截断）。
   mkdirSync(cacheDir, { recursive: true });
   let lastError = null;
   for (const makeUrl of PNPM_TARBALL_SOURCES) {
@@ -313,14 +320,16 @@ async function doEnsurePnpm(opts) {
     try {
       console.log("[pnpm] 引导下载 " + url + " …");
       await downloadToFile(url, tmpTgz);
-      const actual = createHash("sha512").update(readFileSync(tmpTgz)).digest("hex");
+      const tgzBuf = readFileSync(tmpTgz); // 单次读取：同一 buffer 供 sha512 校验与解压
+      const actual = createHash("sha512").update(tgzBuf).digest("hex");
       if (actual !== sha512) {
         throw new Error(
           "tarball sha512 校验失败（期望 " + sha512 + "，实际 " + actual + "）",
         );
       }
       console.log("[pnpm] sha512 校验通过，解压提取 …");
-      const files = extractPnpmFiles(readFileSync(tmpTgz)); // Map<短名, Buffer>
+      const files = extractPnpmFiles(tgzBuf); // Map<短名, Buffer>
+      const digests = {}; // 提取 buffer 直接算 digest（不二次读盘）
       for (const [shortName, buf] of files) {
         const target = join(cacheDir, shortName);
         const tmp = join(
@@ -328,11 +337,18 @@ async function doEnsurePnpm(opts) {
           ".pnpm." + shortName + "." + process.pid + "." + Date.now() + ".tmp",
         );
         writeFileSync(tmp, buf);
+        digests[shortName] = createHash("sha256").update(buf).digest("hex");
         rmSync(target, { force: true }); // 旧缓存（缺失/损坏场景）先清，再原子落位
         renameSync(tmp, target); // 同目录 rename，原子替换
         console.log("[pnpm] 引导完成：" + target);
       }
-      rmSync(tmpTgz, { force: true }); // 下载产物用完即清（缓存只留解压出的两文件）
+      // 完成标记最后落位：两文件已齐 → 标记写入即发布完成（cacheIntact 验收依据）
+      const markerPath = join(cacheDir, ".pnpm-ok");
+      const markerTmp = markerPath + "." + process.pid + "." + Date.now() + ".tmp";
+      writeFileSync(markerTmp, JSON.stringify({ sha512, files: digests }));
+      rmSync(markerPath, { force: true });
+      renameSync(markerTmp, markerPath);
+      rmSync(tmpTgz, { force: true }); // 下载产物用完即清（缓存只留两文件 + 标记）
       lastError = null;
       break;
     } catch (e) {
@@ -357,10 +373,30 @@ async function doEnsurePnpm(opts) {
   return entry;
 }
 
-// 缓存完整性：两引导文件存在即视为完整——下载经 tarball sha512 校验 + 逐文件原子
-// 落位（tmp + rename），不存在部分写入形态；文件缺失/被外部删除 → 重新走下载自愈。
+// 缓存完整性：完成标记 .pnpm-ok 存在且与当前期望一致——标记（两文件之后原子落位）
+// 记录 tarball sha512（须等于 pm 段 hash：同版本 hash 变更时旧文件作废重下）与两文件
+// sha256（重算比对：防篡改/截断/混合对）。任一不符（含旧版无标记缓存）→ 重下自愈。
 function cacheIntact(cacheDir) {
-  return existsSync(join(cacheDir, "pnpm.mjs")) && existsSync(join(cacheDir, "worker.js"));
+  let meta = null;
+  try {
+    meta = JSON.parse(readFileSync(join(cacheDir, ".pnpm-ok"), "utf8"));
+  } catch {
+    return false; // 无标记 / 标记损坏
+  }
+  if (!meta || typeof meta !== "object" || meta.sha512 !== PNPM_MANAGER.sha512) return false;
+  for (const shortName of ["pnpm.mjs", "worker.js"]) {
+    const digest = meta.files && meta.files[shortName];
+    if (typeof digest !== "string") return false;
+    try {
+      const actual = createHash("sha256")
+        .update(readFileSync(join(cacheDir, shortName)))
+        .digest("hex");
+      if (actual !== digest) return false;
+    } catch {
+      return false; // 文件缺失 / 读失败
+    }
+  }
+  return true;
 }
 
 // ---- runPnpm：spawn node（Electron 自带 node 或自定义 nodejsPath，每次 spawn 前解析）+ pnpm 入口 ----
@@ -469,11 +505,6 @@ export function isValidPkgSpec(spec) {
 // 但也不能被 dist-tag 规则放行（会装到非预期包）。
 const SEMVER_LOOSE_SHAPE_RE =
   /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
-
-// 严格 SemVer 判定（与 scripts/version.mjs 同款规则：核心组件与数字 prerelease
-// 标识符必须 0|[1-9]\d*，无前导零；非数字标识符须含至少一个字母或连字符）
-const SEMVER_STRICT_RE =
-  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 
 function isValidSemverSpec(s) {
   const m = String(s).match(SEMVER_STRICT_RE);

--- a/src/tools/lib/pnpm.js
+++ b/src/tools/lib/pnpm.js
@@ -6,12 +6,12 @@
 // devDependencies pnpm），改为运行时按需引导：下载 pnpm npm 包的 dist/pnpm.mjs
 // （自包含入口 CLI，静态 import 全为 node: 内置模块，宿主 electron node 直接执行）
 // + dist/worker.js（package 导入 worker）到数据目录
-// <dataDir>/pnpm-dist/pnpm-{version}/，固定版本 + sha256 校验。
-// 实测确认（宿主 node v24.15.0）：pnpm view 路径只依赖 pnpm.mjs；pnpm install/add 的导入
+// <dataDir>/pnpm-dist/pnpm-{version}/，版本随 packageManager、文件 sha256 静态校验。
+// 实测确认（宿主 node v26.8.1）：pnpm view 路径只依赖 pnpm.mjs；pnpm install/add 的导入
 // 阶段经 new Worker(join(import.meta.dirname, "worker.js")) 加载 worker.js（pnpm.mjs
 // 内联处 workerScriptPath），缺 worker.js 时导入 worker 静默退出 1（无错误信息）——
-// 故引导下载两个文件，缺一即重下。版本与校验同源静态配置（见下方 PNPM_BOOTSTRAP），
-// 与构建期 packageManager 解耦（运行时引导只需 view/install/add 三条路径，锁版本足够）。
+// 故引导下载两个文件，缺一即重下。文件清单与 sha256 静态配置（见下方 PNPM_BOOTSTRAP）；
+// 版本不在此硬编码——单一事实源 = package.json packageManager 字段（见下方解析）。
 //
 // 为什么自给自足：宿主 electron node 不带 npm/corepack/npx（Electron 发行只有 node
 // 运行时），引导是唯一自给自足路径；宿主侧未来可能开放 npm 调用（liliMozi 口头确认，
@@ -40,8 +40,9 @@ import {
   createWriteStream,
   existsSync,
   mkdirSync,
-  rmSync,
+  readFileSync,
   renameSync,
+  rmSync,
 } from "node:fs";
 import { get as httpsGet } from "node:https";
 import { join } from "node:path";
@@ -52,45 +53,68 @@ import {
   resolveNodeExecEnv,
 } from "./state.js";
 
-// ---- 版本单一事实源：package.json packageManager 字段（"pnpm@11.24.0" → "11.24.0"）----
-// 读取定位复用 state.js 的 PLUGIN_ROOT（向上找含 manifest.json 的目录，源码/bundle 两形态均成立）；
-// 解析失败回退硬编码（与 packageManager 同步的兜底值；升级 pnpm 版本时两处都要改）。
-// ---- 运行时引导配置（静态，版本与文件 sha256 同源）----
-// 版本单一事实源 = 本对象；与 package.json 的 packageManager 字段（构建期 pnpm）解耦：
-// 运行时引导的 pnpm 只服务 pnpm add（依赖部署）路径——v0.18.2 起 pnpm view（版本检查）
-// 改 HTTP 直查 npm registry（pnpm view 语义等价），锁 11.24.0 足够；升级 pnpm
-// 时需同时改 version 与对应文件 sha256（实测本地 node_modules/pnpm/dist/* 后更新）。
-// 版本与校验放同一对象，从结构上杜绝「动态版本 × 静态校验」不同步导致的
-// 误导性失败（改 packageManager 只影响构建，不会静默让运行时引导对不上 hash）。
-// ⚠️ 版本兼容：pnpm 11.24.0 的 engines 要求 node >=22.13；宿主 electron node 当前为
-// v24.15.0（满足）。升级 pnpm 时须核对新版本 engines 不超过宿主 node 版本
+// ---- 版本单一事实源：package.json packageManager 字段（pnpm@<version>[+sha512…]）----
+// corepack 语义：版本与 tarball 完整性（sha512）由 packageManager 单一承载。升级 pnpm =
+// 改 packageManager 版本 + `corepack use pnpm@<ver>` 刷新 hash（corepack 作 devDep 引入——
+// Node 25+ 官方不再捆绑 corepack，hash 维护工具需固定来源；devDep 不进运行时）。
+// 运行时引导的 pnpm 版本不在此硬编码：PNPM_VERSION 从插件根 package.json（PLUGIN_ROOT
+// 定位，源码/bundle 两形态均成立）解析，兼容裸版本（pnpm@11.25.0）与带 hash
+// （pnpm@11.25.0+sha512.…）两种形态；解析失败（字段缺失/畸形）引导时报可读错误，
+// 不静默回退——版本已无第二事实源，回退即用错版本。
+// ---- 运行时引导文件（静态，只存清单 + sha256）----
+// 文件 sha256 必须静态：packageManager 的 sha512 是 tarball 粒度，引导下载的是 dist
+// 单文件（pnpm.mjs + worker.js），校验粒度不同无法推导——文件级完整性锚点只能静态留。
+// 升级 pnpm 版本时：改 packageManager → corepack use 刷 hash → 重算两文件 sha256 更新此处。
+// ⚠️ 版本兼容：pnpm 11.25.0 的 engines 要求 node >=22.13；宿主 electron node 当前为
+// v26.8.1（满足）。升级 pnpm 时须核对新版本 engines 不超过宿主 node 版本
 // （宿主 node 版本固定，不做运行时探测；该约束靠此处注释人工把关）。
 // 两个文件：pnpm.mjs（入口 CLI）+ worker.js（package 导入 worker）——pnpm add 的
 // 导入阶段经 new Worker(import.meta.dirname/worker.js) 加载 worker.js（pnpm.mjs
 // 内联处：workerScriptPath = join(import.meta.dirname, "worker.js")），只下载
 // pnpm.mjs 会让 add 的导入 worker 崩溃（exit 1，无错误信息）；pnpm view 路径不触
-// 发 worker，单文件即可。实测（2026-09，宿主 node v24.15.0）确认两个文件均必需。
+// 发 worker，单文件即可。实测（2026-09，宿主 node v24.15.0 → v26.8.1）确认两文件均必需。
 const PNPM_BOOTSTRAP = {
-  version: "11.24.0",
   files: [
     {
       name: "pnpm.mjs",
-      sha256: "ad23cef73b049f61e2450b1ba0c0cf2259114b8ec70f5e09b241b85a0cf0841d",
+      sha256: "ddc64218bc85fb88d28b5def06eb01fafb39cb67f7a9465ce736456658cc7f11",
     },
     {
       name: "worker.js",
-      sha256: "7847564f84d0f9fd088539f679b88fb8dec7195e145b4bbf25b712442b6d99c8",
+      sha256: "81648f68f288deeace8ca799f1d1021bda7493cdc8afa2582600de9129fd9a82",
     },
   ],
 };
 
-// 兼容导出（外部取版本号用；值 = 静态配置 version，与文件 sha256 同源）
-export const PNPM_VERSION = PNPM_BOOTSTRAP.version;
+// 从插件根 package.json 的 packageManager 解析 pnpm 版本（pnpm@<ver> 或 pnpm@<ver>+sha512…）。
+// 正则：版本段 = 严格 semver 主体（含 prerelease），可选 +build（hash）段截断；非 pnpm /
+// 畸形格式不匹配 → null。解析失败返回 null（不 throw）——调用方（引导路径）给可读错误。
+function parsePnpmVersion() {
+  try {
+    const pkg = JSON.parse(readFileSync(join(PLUGIN_ROOT, "package.json"), "utf8"));
+    const pm = pkg && typeof pkg === "object" ? pkg.packageManager : null;
+    const m =
+      typeof pm === "string"
+        ? pm.match(/^pnpm@([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)(?:\+[0-9A-Za-z.-]+)?$/)
+        : null;
+    return m ? m[1] : null;
+  } catch {
+    return null; // 文件缺失 / JSON 畸形 → 引导路径统一给可读错误
+  }
+}
 
-// 下载源：unpkg 直链优先，jsdelivr 兜底（同一文件；两者均可能 302 到边缘 CDN）
+// 模块加载解析一次（packageManager 是插件包静态内容，运行期不变）；null = 解析失败
+// （install.js 等消费方在 ensurePnpm 成功后才读此值，解析失败时引导已抛错，不会取到 null）
+export const PNPM_VERSION = parsePnpmVersion();
+
+// 下载源：unpkg 直链优先 → npmmirror（npm registry 官方镜像，/files/ 包内文件直链，
+// 国内网络可达）→ jsdelivr 收尾。同一文件（npmmirror 与 registry tarball 逐字节一致，
+// 实测 sha256 同源）；均可能 302/跳边缘 CDN。registry.npmjs.org 官方无单文件端点
+// （只供 tarball）未纳入——为 tarball 引入解压分支不值，三家文件 CDN 已覆盖国际+国内。
 const PNPM_CDNS = [
-  (name) => `https://unpkg.com/pnpm@${PNPM_BOOTSTRAP.version}/dist/${name}`,
-  (name) => `https://cdn.jsdelivr.net/npm/pnpm@${PNPM_BOOTSTRAP.version}/dist/${name}`,
+  (name) => `https://unpkg.com/pnpm@${PNPM_VERSION}/dist/${name}`,
+  (name) => `https://registry.npmmirror.com/pnpm/${PNPM_VERSION}/files/dist/${name}`,
+  (name) => `https://cdn.jsdelivr.net/npm/pnpm@${PNPM_VERSION}/dist/${name}`,
 ];
 const DOWNLOAD_TIMEOUT_MS = 60000; // 单次下载请求超时（重定向跟随共享）
 const STDOUT_CAP = 65536; // runPnpm 内存累积上限（调用方只需尾部/错误提取）
@@ -214,9 +238,15 @@ async function doEnsurePnpm(opts) {
   // ① 宿主通道探测（未来接入点；当前恒 null → 走单文件引导）
   const host = await tryHostChannel();
   if (host && typeof host === "string" && host) return host;
+  // 版本解析失败（pm 段缺失/畸形）→ 可读错误，不静默回退（版本已无第二事实源）
+  if (!PNPM_VERSION) {
+    throw new Error(
+      "pnpm 版本解析失败：package.json packageManager 缺失或格式异常（期望 pnpm@<semver>[+sha512…]，由 corepack use 维护）",
+    );
+  }
   // ② 缓存路径 <dataDir>/pnpm-dist/pnpm-{version}/{pnpm.mjs,worker.js}（独立于 dsh-pkg）
   const dataDir = resolveDataDir(opts);
-  const cacheDir = join(dataDir, "pnpm-dist", "pnpm-" + PNPM_BOOTSTRAP.version);
+  const cacheDir = join(dataDir, "pnpm-dist", "pnpm-" + PNPM_VERSION);
   const entry = join(cacheDir, "pnpm.mjs");
   // ③ 缓存命中且全部文件 sha256 与预期一致 → 直接返回（幂等快速路径）
   const cached = await cacheIntact(cacheDir);
@@ -224,8 +254,8 @@ async function doEnsurePnpm(opts) {
     console.log("[pnpm] 命中缓存：" + entry);
     return entry;
   }
-  // ④ 下载：unpkg 优先 → jsdelivr 兜底；逐文件临时文件 → 校验 sha256 → 原子落位
-  // （mkdir + rename）。任一文件两源全败 → 抛可读错误（含两源提示）。
+  // ④ 下载：按 PNPM_CDNS 逐源尝试（unpkg → npmmirror → jsdelivr）；逐文件临时文件 →
+  // 校验 sha256 → 原子落位（mkdir + rename）。任一文件全源失败 → 抛可读错误（含源清单）。
   mkdirSync(cacheDir, { recursive: true });
   for (const file of PNPM_BOOTSTRAP.files) {
     const target = join(cacheDir, file.name);
@@ -275,7 +305,7 @@ async function doEnsurePnpm(opts) {
       throw new Error(
         "pnpm 引导失败（" +
           file.name +
-          "）：两个源均不可用（" +
+          "）：全部 CDN 源均不可用（" +
           PNPM_CDNS.map((f) => f(file.name)).join("、") +
           "），最后错误：" +
           (lastError?.message || lastError) +


### PR DESCRIPTION
## 背景

pnpm 版本管理此前双处维护：package.json `packageManager`（构建期）与 `src/tools/lib/pnpm.js` PNPM_BOOTSTRAP（运行时引导，硬编码 11.24.0 + 文件 sha256），二者解耦且注释自相矛盾。本次收敛为**单一事实源**：版本与完整性全部由 packageManager（corepack 形态）承载。

## 改动

**package.json**
- `packageManager` 补 corepack 格式 hash：`pnpm@11.25.0` → `pnpm@11.25.0+sha512.5cde…956`（corepack use 生成；npm tarball 实测 sha512 一致）
- devDependencies 引入 `corepack@0.36.0`：Node 25+ 官方不再捆绑 corepack，`corepack use` 刷 hash 需要固定来源（devDep 不进运行时）

**src/tools/lib/pnpm.js**
- **PNPM_BOOTSTRAP 常量整个删除**（含两个文件 sha256 静态字段）——完整性链收敛为 `packageManager +sha512（corepack 维护）→ tarball → 解压文件`
- 引导流程重写：下载 npm 包 tarball（registry 官方源）→ sha512 校验（pm 段 hash）→ gunzip + tar 解压提取 `dist/pnpm.mjs` + `dist/worker.js` → 原子落位
- 新增零依赖 tar 提取器 `extractPnpmFiles`（node 无内置 tar；gunzipSync + ustar 头遍历，支持 PAX path / GNU longname，只读目标条目，无 zip-slip 面）
- `parsePnpmVersion` → `parsePnpmManager`：解析 `{ version, sha512 }`；要求 pm 段带 sha512（旧裸版本形态无法校验 tarball，报可读错误提示 corepack use 刷新，不静默回退）
- 下载源：registry.npmjs.org 官方 → registry.npmmirror.com 镜像（tarball 端点）；文件 CDN（unpkg/jsdelivr）无 tarball 直链端点出列
- 缓存完整性改存在性检查（tarball sha512 校验 + tmp/rename 原子落位保证无部分写入形态）
- 宿主 electron node 注释 v24.15.0 → v26.8.1；解耦时代死注释清理

## 验证记录

- 引导真实冒烟（新流程）：官方源下载 tarball 4.9MB → sha512 校验通过 → 解压提取 → 落位；提取文件 sha256 = ddc642…（pnpm.mjs）/ 81648f…（worker.js），与 npm tarball 实测一致
- 缓存命中冒烟：二次调用 2ms 秒回
- `pnpm run build` 通过
- 解析正则：带 hash pm 段解出版本 + sha512；畸形/缺失 → null
- 网络消耗对比：单文件裸传 13.7MB → tarball 4.9MB（gzip）；若走 HTTP 传输压缩单文件可到 2.9MB，但需每文件一次请求且 CDN 压缩率不一——tarball 一次下载全量 + 官方源可用为当前取舍
- 曾验证并否决：corepack 经 rspack 二次打包供运行时（动态 require 逃逸致真实激活路径崩溃）；corepack 定位为 devDep hash 维护工具

## 说明

- 升级 pnpm 的操作收敛为：改 packageManager 版本 → `corepack use pnpm@<ver>` 刷 hash（pnpm.js 零改动）
- 版本号未 bump，合并后按发版流程另行处理（预期 beta）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pnpm setup by validating configured versions and SHA-512 integrity metadata.
  - Added clearer handling for invalid package-manager versions and integrity configuration.

- **Reliability**
  - pnpm bootstrap caches are now validated before reuse, including downloaded and extracted file integrity.
  - Improved cache publication and reuse to prevent incomplete or corrupted setup results.

- **Chores**
  - Added Corepack development tooling and pnpm integrity metadata to the project configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->