### PR TITLE
feat(view): fpFullPanel V1 装配者替换——@dsh-hanako/view 接管官方 ui-layout root 装配

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/deepseek-harness"]
+	path = vendor/deepseek-harness
+	url = https://github.com/deepseek-ai/deepseek-harness.git

--- a/scripts/pack.mjs
+++ b/scripts/pack.mjs
@@ -62,7 +62,7 @@ for (const item of staticItems) {
 }
 
 // 1.5) cordis 包 version 一致性校验（防回归，与 manifest 校验对称）：cordis 包（roster
-//   bundle dshana + 8 子插件）version 与 manifest 同批由 version-hook（pnpm version 发版
+//   bundle dshana + 9 子插件）version 与 manifest 同批由 version-hook（pnpm version 发版
 //   流程）同步（单一事实源 = 主 package.json；源码 src-cordis 内随同步维护），pack 时读 dist 产物
 //   校验一致——手改/漏同步即出包版本漂移。
 function assertCordisDistVersions(outDir) {
@@ -71,11 +71,11 @@ function assertCordisDistVersions(outDir) {
   if (!fs.pathExistsSync(cordisRoot)) {
     throw new Error("cordis 产物缺失（dist/cordis 不存在）：先跑 pnpm run build 再打包");
   }
-  // 完整性：必需 9 包（roster bundle dshana + 8 子插件）全部存在且 package.json 版本一致——
+  // 完整性：必需 10 包（roster bundle dshana + 9 子插件）全部存在且 package.json 版本一致——
   // 缺失/部分产物（含 count=0）一律拒包，防 build 失败后残留部分 dist 被误打包
   const required = [
     "dshana",
-    "app", "bridge", "bus", "clipboard", "logger", "provider", "settings", "theme",
+    "app", "bridge", "bus", "clipboard", "logger", "provider", "settings", "theme", "view",
   ];
   let count = 0;
   for (const name of required) {

--- a/scripts/sync-vendor-layout.mjs
+++ b/scripts/sync-vendor-layout.mjs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2026 Nyasers
+//
+// scripts/sync-vendor-layout.mjs — @dsh-hanako/view 的官方 ui-layout client 源码 vendor 同步
+// 源：git submodule vendor/deepseek-harness（仓库内相对路径，可移植——clone 后
+// `git submodule update --init` 即得；不 env、不硬编码本机路径）。
+// 钉版 = submodule 当前 HEAD（唯一事实源，主仓库 gitlink 记录其 commit）：
+//   换依赖版本（dsh 锁版升级）= submodule 内 `git fetch && git checkout <新 tag>`
+//   → 主仓库 `git add vendor/deepseek-harness` → 重跑本脚本 → 审 vendor diff → 提交。
+// 用途：升 dsh 版本/核对 vendor 与上游一致时运行；复制覆盖 src-cordis/plugins/view/vendor/ 整目录。
+// 校验：copy 后逐文件字节比对（源 == 目标），失败 exit 1；submodule 未 init / HEAD 缺文件
+// 即报错退出（fail-closed——vendor 必须能溯源到钉版 commit）。
+// 用法：node scripts/sync-vendor-layout.mjs
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { execFileSync } from "node:child_process";
+import fs from "fs-extra";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+// deepseek-harness 以 submodule 钉在 vendor/（remote = 官方 upstream，gitlink 记录钉版 commit）
+const CHECKOUT = join(ROOT, "vendor", "deepseek-harness");
+const REL_FILES = [
+  "packages/client/ui-layout/src/client/AppFrame.tsx",
+  "packages/client/ui-layout/src/client/AppFrame.module.css",
+  "packages/client/ui-layout/src/client/columns.ts",
+  "packages/client/ui-layout/src/client/DocumentTitle.tsx",
+  "packages/client/ui-layout/src/client/service.ts",
+  "packages/client/ui-layout/src/client/stores.ts",
+  "packages/client/ui-layout/src/client/theme-presenter.ts",
+];
+const DST_DIR = join(ROOT, "src-cordis", "plugins", "view", "vendor");
+
+function git(args) {
+  return execFileSync("git", ["-C", CHECKOUT, ...args], { encoding: "utf8" }).trim();
+}
+function main() {
+  if (!fs.pathExistsSync(join(CHECKOUT, ".git"))) {
+    throw new Error(
+      "submodule 未初始化：" + CHECKOUT + " 缺失。先跑 `git submodule update --init`（或 clone 时加 --recursive）",
+    );
+  }
+  // submodule HEAD 必须等于主仓库即将记录的 gitlink——防本地漂移（submodule 被 checkout
+  // 到别的版本时若静默复制，vendor 会以错钉版记录）。读 **index**（`:path`）而非 HEAD：升版
+  // 流程是 submodule checkout 新 tag → `git add vendor/deepseek-harness` → 跑本脚本，
+  // 此时新 gitlink 在 index 尚未 commit；未 stage 时 index == HEAD，两场景都覆盖。
+  const expectedSha = execFileSync(
+    "git",
+    ["-C", ROOT, "rev-parse", ":vendor/deepseek-harness"],
+    { encoding: "utf8" },
+  ).trim();
+  const actualSha = git(["rev-parse", "HEAD"]);
+  if (actualSha !== expectedSha) {
+    throw new Error(`submodule HEAD 不匹配主仓库 gitlink：期望 ${expectedSha}，实际 ${actualSha}（先 git submodule update 对齐）`);
+  }
+  // 钉版可读名（日志用）：detached at tag → tag 名；否则 describe 形态。内容源一律 HEAD
+  //（HEAD = 主仓库 gitlink 记录的钉版 commit，与 tag 名解耦——tag 可被上游移动，commit 不可变）。
+  let pinned;
+  try {
+    pinned = git(["describe", "--tags", "--exact-match", "HEAD"]);
+  } catch {
+    try {
+      pinned = git(["describe", "--tags", "HEAD"]);
+    } catch {
+      pinned = git(["rev-parse", "--short", "HEAD"]);
+    }
+  }
+  // 原子写：先全部从钉版 commit 读入并暂存（git show HEAD:path，与 submodule 工作树状态
+  // 解耦）——任一文件读取失败即中止，**不触碰 DST_DIR**（避免半更新 vendor 树）；全部读
+  // 成功后才进入写阶段，逐文件写 + 字节校验。
+  const staged = new Map();
+  for (const rel of REL_FILES) {
+    let content;
+    try {
+      content = execFileSync("git", ["-C", CHECKOUT, "show", `HEAD:${rel}`], { encoding: "utf8" });
+    } catch {
+      throw new Error(`submodule HEAD（${pinned}）缺少 ${rel}：钉版不含该文件，确认钉版/路径正确`);
+    }
+    staged.set(rel, content);
+  }
+  fs.ensureDirSync(DST_DIR);
+  for (const [rel, content] of staged) {
+    const target = join(DST_DIR, rel.split("/").pop());
+    fs.writeFileSync(target, content);
+    const back = fs.readFileSync(target, "utf8");
+    if (back !== content) {
+      throw new Error(`复制校验失败：${target}`);
+    }
+    console.log("[sync-vendor]  ", rel, "->", target);
+  }
+  console.log(`[sync-vendor] 完成（${REL_FILES.length} 文件，钉版 ${pinned} @ ${actualSha.slice(0, 12)}）`);
+}
+main();

--- a/src-cordis/build.js
+++ b/src-cordis/build.js
@@ -5,7 +5,7 @@
 // 布局：领域专用随源码——cordis 域脚本/配置全在 src-cordis/（build/ preset + 每包
 // cordis.config.mjs 描述），共享工具（rspack 本体解析/URL 回写/terser/assert + 共享
 // minify-loader）在 scripts/ 根级。产物 dist/cordis/**：
-//   8 子插件：service 半 rspack（index.js bundle）+ client 半 tsdown（settings，closure-factory）
+//   9 子插件：service 半 rspack（index.js bundle）+ client 半 tsdown（settings/view 等，closure-factory）
 //   + dshana roster bundle（package.json + cordis.patch.yml）+ 静态 package.json/client.js
 // 用法：node src-cordis/build.js [RSPACK_ENV=<构建环境目录>]
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -118,6 +118,7 @@ async function buildClientHalves(packages, outRoot) {
       pkgDir,
       outDir: join(outRoot, name),
       externals: cfg.client.externals,
+      defines: cfg.client.defines,
     });
     count += 1;
   }

--- a/src-cordis/build/client-config.mjs
+++ b/src-cordis/build/client-config.mjs
@@ -11,45 +11,126 @@
 //     footer: return module.exports; } });
 //   产物 = client bundle（__ModuleLoader__ 按包名注册，exports 落 module.exports）；
 //   externals（react / react/jsx-runtime 等）保持外部 → 编译为对 factory 参数
-//   require 的调用（loader 模块表注入，不内联不全局化）；资源（CSS/SVG）经 ?inline
-//   文本内联虚拟模块进模块图（规避 tsdown css-guard：虚拟 id 不以 .css 结尾——官方
-//   同款加 .mjs 后缀）。产物无源码内嵌内容字符串（全部走正常构建）。
+//   require 的调用（loader 模块表注入，不内联不全局化）。
+//
+// 资源/编译面（client 描述可选字段，见各包 cordis.config.mjs）：
+//   externals: loader 模块表 require 解析清单（默认 react 系；@dsh-hanako/view 加
+//     @deepseek-ai/dsh-client-store——平台 seed，与官方 ui-layout bundle 同款外部）
+//   defines:   tsdown define（编译期常量替换；各包自声明，如 view 的 DSH_CLIENT_TITLE）
+// 资源内联："./x.css?inline" / "./x.svg?inline" 文本内联虚拟模块（通用文本 loader，
+//   规避 tsdown css-guard：虚拟 id 不以 .css 结尾——官方同款加 .mjs 后缀）；
+//   "./x.module.css"（官方 TSX 组件 CSS Modules 语义，@dsh-hanako/view vendor 官方
+//   ui-layout AppFrame 等源码需要）→ css-modules 虚拟模块（默认导出 local→带前缀 class
+//   映射 + 模块执行时注入 <style data-plugin-css>，纯运行时无 React 路径）。
+// 环境常量：浏览器产物无 process 全局——define 把 process.env 整体替换为空对象、
+// NODE_ENV=production（store 引擎 devFreeze 等按 production 走），官方
+// tsdown.client.ts 同款 define 姿势；产物无源码内嵌内容字符串（全部走正常构建）。
 //
 // 消费方：src-cordis/build.js（package.json build:cordis）编排。
 // tsdown 为 devDep（构建工具不进运行时依赖）。
 import { build } from "tsdown";
 import { dirname, join, resolve } from "node:path";
 import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
 
 const INLINE_QUERY = "?inline";
-const VIRTUAL_PREFIX = "\0hanako-text:";
+const TEXT_PREFIX = "\0hanako-text:";
+const CSS_PREFIX = "\0hanako-css:";
 const VIRTUAL_SUFFIX = ".mjs"; // 规避 tsdown css-guard（匹配 .css 结尾 id，官方同款）
 
-// 通用文本内联虚拟模块：`./x.css?inline` / `./x.svg?inline` → export default 文本
+// 通用文本内联虚拟模块："./x.css?inline" / "./x.svg?inline" → export default 文本
 const textInlinePlugin = {
   name: "hanako-text-inline",
   resolveId(source, importer) {
     if (!source.endsWith(INLINE_QUERY)) return null;
     if (!importer) return null;
     const abs = resolve(dirname(importer), source.slice(0, -INLINE_QUERY.length));
-    return VIRTUAL_PREFIX + abs + VIRTUAL_SUFFIX;
+    return TEXT_PREFIX + abs + VIRTUAL_SUFFIX;
   },
   load(virtualId) {
-    if (!virtualId.startsWith(VIRTUAL_PREFIX)) return null;
-    const file = virtualId.slice(VIRTUAL_PREFIX.length, -VIRTUAL_SUFFIX.length);
-    return `export default ${JSON.stringify(readFileSync(file, "utf8"))};`;
+    if (!virtualId.startsWith(TEXT_PREFIX)) return null;
+    const file = virtualId.slice(TEXT_PREFIX.length, -VIRTUAL_SUFFIX.length);
+    return "export default " + JSON.stringify(readFileSync(file, "utf8")) + ";";
   },
 };
 
+// css-modules 虚拟模块源码：class 名映射（默认导出）+ 样式文本注入 style 标签（幂等）。
+// class 名加 "dv_" 前缀（dshana view；官方产物为 lightningcss [hash]_[local] 哈希名，
+// 本链无哈希——前缀同样规避与全局/dsw 类名撞名）。注入点 = 模块 materialization
+// （factory 执行）——官方 css-modules 同款时机（claimStyles 记账 style[data-plugin]）。
+function cssModuleSource(id, fileId, css) {
+  const locals = new Set();
+  const prefixed = {};
+  const tokenRe = /\.([A-Za-z_][A-Za-z0-9_-]*)/g;
+  let m;
+  while ((m = tokenRe.exec(css)) !== null) locals.add(m[1]);
+  const classMap = {};
+  for (const local of locals) {
+    const pname = "dv_" + local;
+    classMap[local] = pname;
+    prefixed[local] = pname;
+  }
+  // 仅改写已知 local class 选择器（保留 data 属性/伪类等非 class 语法；本包 css 无
+  // url()/带点字符串内容，tokenRe 替换安全——vendor 复核见 scripts/sync-vendor-layout.mjs）
+  const rewritten = css.replace(/\.([A-Za-z_][A-Za-z0-9_-]*)/g, (full, name) =>
+    prefixed[name] ? "." + prefixed[name] : full);
+  const tagId = styleTagId(id, fileId);
+  return [
+    "const css = " + JSON.stringify(rewritten) + ";",
+    "const tagId = " + JSON.stringify(tagId) + ";",
+    "if (typeof document !== 'undefined' && document.querySelector('style[data-plugin-css=' + JSON.stringify(tagId) + ']') === null) {",
+    "  const tag = document.createElement('style');",
+    "  tag.dataset.plugin = " + JSON.stringify(id) + ";",
+    "  tag.dataset.pluginCss = tagId;",
+    "  tag.textContent = css;",
+    "  document.head.appendChild(tag);",
+    "}",
+    "export default " + JSON.stringify(classMap) + ";",
+  ].join("\n");
+}
+
+// style 注入去重键（data-plugin-css）：插件 id + 源文件 basename
+function styleTagId(id, file) {
+  const base = file.split(/[\\/]/).pop() || file;
+  return id + "/" + base;
+}
+
+// css-modules 虚拟 loader："./x.module.css" → 样式注入 + class 映射（见 cssModuleSource）。
+// 插件按包实例化（closure 带包 id）——style 注入的 data-plugin/data-plugin-css 标记需要
+// 归属当前 client bundle 的包名（claimStyles/HMR 记账按 data-plugin 认领）。
+function createCssModulePlugin(id) {
+  return {
+    name: "hanako-css-modules",
+    resolveId(source, importer) {
+      if (!source.endsWith(".module.css")) return null;
+      if (!importer) return null;
+      const abs = resolve(dirname(importer), source);
+      return CSS_PREFIX + abs + VIRTUAL_SUFFIX;
+    },
+    load(virtualId) {
+      if (!virtualId.startsWith(CSS_PREFIX)) return null;
+      const file = virtualId.slice(CSS_PREFIX.length, -VIRTUAL_SUFFIX.length);
+      const css = readFileSync(file, "utf8");
+      return cssModuleSource(id, file, css);
+    },
+  };
+}
+
 /**
  * 打一个包的 client 半（closure-factory 自注册 bundle）。
- * @param {object} opts - { id, pkgDir, outDir, externals }：id = 包名（注册与注入
- *   style 标记用）；pkgDir = 包源码目录（entry = pkgDir/client.js）；outDir = dist 目标
- *   （与 rspack 服务端半同目录共存，只写 client.js）；externals = loader 模块表
- *   require 解析清单（默认 react 系）。
+ * @param {object} opts - { id, pkgDir, outDir, externals, defines }：id = 包名（注册与
+ *   注入 style 标记用）；pkgDir = 包源码目录（entry = pkgDir/client.js）；outDir = dist
+ *   目标（与 rspack 服务端半同目录共存，只写 client.js）；externals = loader 模块表
+ *   require 解析清单（默认 react 系）；defines = 包级 tsdown define 常量（合并进环境
+ *   默认 define）。
  */
-export async function buildClientBundle({ id, pkgDir, outDir, externals = ["react", "react/jsx-runtime"] }) {
+export async function buildClientBundle({ id, pkgDir, outDir, externals = ["react", "react/jsx-runtime"], defines = {} }) {
+  // 环境常量默认（官方 tsdown.client.ts clientBuildEnvironmentDefines 同款姿势：
+  // 空 process.env 兜底 + 显式 NODE_ENV；浏览器无 process 全局，静态读取落到空对象即
+  // undefined 不抛 ReferenceError）
+  const envDefines = {
+    "process.env": "{}",
+    "process.env.NODE_ENV": JSON.stringify("production"),
+  };
   await build({
     name: id + "/client",
     entry: { client: join(pkgDir, "client.js") },
@@ -60,13 +141,14 @@ export async function buildClientBundle({ id, pkgDir, outDir, externals = ["reac
     clean: false,
     sourcemap: false,
     minify: true, // 与 rspack 链 minimize 对齐：产物即时压缩（pack terser 二次压缩兜底）
+    define: { ...envDefines, ...defines }, // 包级 defines 覆盖环境默认（如 DSH_CLIENT_TITLE）
     deps: {
       neverBundle: (spec) => externals.includes(spec), // requested 保持外部，其余内联
     },
-    plugins: [textInlinePlugin],
+    plugins: [textInlinePlugin, createCssModulePlugin(id)],
     outputOptions: {
       entryFileNames: "client.js",
-      banner: `window.__ModuleLoader__.load({ id: ${JSON.stringify(id)}, factory: (require) => {`,
+      banner: "window.__ModuleLoader__.load({ id: " + JSON.stringify(id) + ", factory: (require) => {",
       footer: "return module.exports; } });",
       intro: "var module = { exports: {} }; var exports = module.exports;",
     },

--- a/src-cordis/cordis.patch.yml
+++ b/src-cordis/cordis.patch.yml
@@ -104,8 +104,8 @@
     - id: locale
       name: '@deepseek-ai/dsh-client-locale'
 
-    - id: ui-layout
-      name: '@deepseek-ai/dsh-client-ui-layout'
+    # (ui-layout 已从 roster 移除——root 装配者由 @dsh-hanako/view 接管，见本文件
+    # @dsh-hanako/* 子插件区；其 client src 由 view 插件 vendor 构建期编译进自身 bundle)
 
     - id: ui-renderer
       name: '@deepseek-ai/dsh-client-ui-renderer'
@@ -242,3 +242,9 @@
     # 数据面走 bridge 免鉴权 /api + gateway remote.mux）
     - id: '@dsh-hanako/app'
       name: '@dsh-hanako/app'
+
+    # fpFullPanel 视图装配插件：替代官方 ui-layout 的 root 装配者角色——provide layout
+    # 服务（满足 ui-sidebar 等 inject 方）+ 注册 root = 官方 AppFrame（无参完整视图，
+    # 官方等价）；URL 三态（无参/main/sidebar）路由 V2/V3 扩展
+    - id: '@dsh-hanako/view'
+      name: '@dsh-hanako/view'

--- a/src-cordis/plugins/view/client.js
+++ b/src-cordis/plugins/view/client.js
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2026 Nyasers
+//
+// @dsh-hanako/view 前端 client 模块（装配核心）。
+//
+// 角色（fpFullPanel V1）：替代官方 ui-layout 的「root 装配者」。官方 ui-layout 从
+// cordis.patch.yml roster 移除（其 AppFrame 不再抢 root），本插件接管同一套装配：
+//   inject = ['slots', 'theme', 'locale']（与官方 ui-layout client/index.ts 完全一致——
+//   slots=内置槽注册、theme=ui-theme 服务（ThemePresenter 数据源）、locale=ui-locale 服务）
+//   apply(ctx)：
+//     ① ctx.reflect.provide('layout', <LayoutController>)——ui-sidebar 等 inject
+//        'layout' 服务（ctx.get('layout').toggleSidebar 等面板动作契约），roster 去掉
+//        ui-layout 后必须由本插件 provide 等价服务。
+//     ② ctx.slots.register(root 条目, <视图组件>)——root 槽 single 语义先注册 wins，
+//        ui-layout 移除后本插件是唯一 root 注册方。
+//     ③ ctx.effect(ThemePresenter)——主题快照投影 document（同官方第二 effect）。
+//   V1 只做「无参完整视图」= 注册官方 AppFrame（渲染组件与官方 ui-layout 激活时同一
+//   组件），URL 三态（无参/main/sidebar）路由留骨架——main/sidebar 为 V2/V3，不在
+//   本版范围（出现时 V1 回退完整视图并 warn，行为安全）。
+//
+// 官方源码复用通道（重要——构建期 vendor，见 vendor/README.md）：
+//   官方 npm 副本无 src 物理文件（发布 files 只含 lib/，exports "./src/*" 解析失败），
+//   browser module table 只有整包 row（子路径不可 require）——故 ui-layout 的 client
+//   src（AppFrame.tsx/stores.ts/service.ts/theme-presenter.ts/DocumentTitle.tsx/
+//   columns.ts/AppFrame.module.css）以逐字副本 vendor 进本包（src-cordis/plugins/view/
+//   vendor/，rc.1 钉版），tsdown 构建期编译内联进本包 closure-factory bundle。运行时
+//   外部依赖仅 react / react/jsx-runtime / @deepseek-ai/dsh-client-store（平台 seed，
+//   官方 ui-layout bundle 同款 externals 集，见 cordis.config.mjs）。
+//
+// 开放问题 2 结论（V1 spike，装配副作用接线）：需要，且必须逐项等效——
+//   ① provide('layout')：ui-sidebar.apply 经 ctx.get('layout').toggleSidebar() 发面板
+//      动作；无 provider 该依赖永不就绪。
+//   ② register 的 store 席位 + inject 钩子 layout.attachPanels(actions)：LayoutController
+//      本身是哑门面（service.ts），toggleSidebar/openDetails/closeDetails 全转发到 root
+//      条目 layout store 实例的 bound actions；attachPanels 未接线时 #require() 抛
+//      "layout: panel actions not wired (root entry not mounted)"——接线点在 register 的
+//      inject 钩子（条目首渲染时框架调起），必须随 root 注册同传。
+//   ③ children 四子槽声明（sidebar/conversation/details/shell.overlay）：register 同调
+//      声明 = AppFrame 对这些槽的排他渲染权威；不声明则占位者条目无渲染者（declaring is
+//      claiming）。
+//   ④ AppFrame 内部（viewport/panels 动作）零自接线：三框架 share（runtime/store/
+//      render-slots/locale props）全由 slots 框架经注册注入，几何状态（ResizeObserver +
+//      store）组件自持——官方 apply 除了 ①②③ 与 theme presenter 无其他副作用。
+//   ⑤ theme presenter effect：ui-layout 第二 effect（ThemePresenter）是把 ctx.theme
+//      快照写到 document（color-scheme / data-ds-dark-theme / token 变量 / 字号 / theme-
+//      color meta）的唯一者；roster 移除 ui-layout 后此投影职责随本插件保留，否则无参
+//      视图缺主题 DOM 投影（非官方等价）。
+//
+// 产物形态：tsdown client 链（src-cordis/build/client-config.mjs）构建 package.json
+// exports["./client"] 指向的 client bundle（学官方 dsh clientBundle 预设：intro/banner/
+// footer 包 window.__ModuleLoader__.load({ id, factory })，react/jsx-runtime/
+// @deepseek-ai/dsh-client-store external 走 loader seed 表 require）。
+
+import { AppFrame } from "./vendor/AppFrame.tsx";
+import { createLayoutStore } from "./vendor/stores.ts";
+import { LayoutController } from "./vendor/service.ts";
+import { ThemePresenter } from "./vendor/theme-presenter.ts";
+
+// ---- view 参数读取（URL 三态路由；V1 只实现 full，main/sidebar 回退 full）----
+// 官方 boot 不管 query，本插件直接读 location.search 的 ?dshana-view=<view>；
+// 无参 = 完整三列视图（主页面默认，等价官方 ui-layout 激活态）。
+const FULL = "full";
+const MAIN = "main"; // V3（无侧栏主视图）
+const SIDEBAR = "sidebar"; // V2（fp 面板 embedUrl 纯侧栏）
+
+function readView() {
+  if (typeof location === "undefined") return FULL;
+  const m = /[?&]dshana-view=([^&#]+)/.exec(location.search);
+  if (!m) return FULL;
+  let v;
+  try {
+    v = decodeURIComponent(m[1]);
+  } catch {
+    // malformed percent-encoding（如 ?dshana-view=%）：按无参处理回退完整视图——
+    // 不能抛：readView 抛错会让 apply() 来不及注册 root/layout 服务（页面白屏）
+    return FULL;
+  }
+  return v === MAIN || v === SIDEBAR ? v : FULL;
+}
+
+// root 条目的子槽声明（官方 ui-layout client/index.ts 逐字：frame 的四子槽排他渲染权威；
+// 子槽占位者（sidebar/conversation/details/shell.overlay 的 ui-* 插件）条目 roster 照留）。
+const FULL_CHILDREN = {
+  sidebar: { kind: "single", scope: "root" },
+  conversation: { kind: "single", scope: "session-maybe" },
+  details: { kind: "single", scope: "session" },
+  "shell.overlay": { kind: "list", scope: "root" },
+};
+
+// 视图 → root 组件装配选择。V1 全部回退官方 AppFrame（无参完整视图）：
+//   - full：官方 AppFrame（等价官方 ui-layout 激活）
+//   - main：TODO V3（AppFrame + 初始 panels.sidebar=0 隐藏态；子槽收窄不声明 sidebar）
+//   - sidebar：TODO V2（SidebarOnlyFrame 单列容器 + 官方 SidebarRoot + 仅 sidebar 子槽）
+// 选型函数骨架保留——V2/V3 在 <视图组件> 与 <children> 两处替换即可。
+function frameForView(view) {
+  if (view === FULL) return { component: AppFrame, children: FULL_CHILDREN };
+  return { component: AppFrame, children: FULL_CHILDREN }; // V1 回退：完整视图兜底
+}
+
+// ---- 客户端服务注入：slots（root 注册）+ theme（ThemePresenter 快照）+ locale（t）----
+// 与官方 ui-layout client/index.ts 相同；package.json dsh.client.inject 依官方 ui-layout
+// 的依赖方声明（locale/ui-renderer/ui-session/ui-theme，行到达序见 module graph edges）。
+const inject = ["slots", "theme", "locale"];
+
+/**
+ * 客户端插件主体：provide layout 服务 + 注册 root（官方 AppFrame）+ theme DOM 投影。
+ * @param ctx - 客户端根 context。
+ */
+function apply(ctx) {
+  const view = readView();
+  const layout = new LayoutController();
+  const { component: RootView, children } = frameForView(view);
+  if (view !== FULL) {
+    // V1 未实现 main/sidebar：回退完整视图（行为 = 官方等价），实机无感；V2/V3 落地后
+    // 此分支替换为对应 frame（见 frameForView TODO）。
+    try {
+      console.warn(
+        "[@dsh-hanako/view] dshana-view=" +
+        view +
+        " 尚未实现（V1 只含无参完整视图），本次回退官方完整视图",
+      );
+    } catch {
+      /* 日志失败不阻断 */
+    }
+  }
+
+  // effect 1：layout 服务 + root 注册（open question 2 结论的 ①②③ 一个 register 全给：
+  // provide 用 ctx.reflect（官方同款），register 携 children/store/inject-钩子 attachPanels）。
+  ctx.effect(() => {
+    const disposeService = ctx.reflect.provide("layout", layout);
+    const disposeRegistration = ctx.slots.register(
+      {
+        name: "root",
+        locale: "common",
+        children,
+        // 排他 store 席位：工厂本身（框架按条目实例化，AppFrame 经 useStore/actions 标准
+        // props 拿实例）——与官方 register 同语义（stores.ts 工厂）。
+        store: createLayoutStore,
+        // 钩子唯一副作用 = 把 root store 的 bound actions 接给 ctx.layout 门面（官方
+        // attachPanels 语义；会话/业务动作属各占位者，不在此接）。
+        inject: (actions) => {
+          layout.attachPanels(actions);
+          return {};
+        },
+      },
+      RootView,
+    );
+    return () => {
+      disposeRegistration();
+      // provide() 的 disposer 异步落定；teardown 同步 fire-and-forget（官方同款）。
+      void disposeService();
+    };
+  }, "@dsh-hanako/view: layout 服务 + root 注册（官方 AppFrame 装配）");
+
+  // effect 2：theme DOM 投影（官方 ui-layout 第二 effect 逐字——getter 初始一次 + 事件
+  // 驱动；无 React 路径，纯 DOM 写）。
+  ctx.effect(() => {
+    const presenter = new ThemePresenter();
+    presenter.apply(ctx.theme.getTheme());
+    const off = ctx.on("theme/change", (snapshot) => {
+      presenter.apply(snapshot);
+    });
+    return () => {
+      off();
+      presenter.dispose();
+    };
+  }, "@dsh-hanako/view: theme presenter");
+}
+
+export { apply, inject };

--- a/src-cordis/plugins/view/cordis.config.mjs
+++ b/src-cordis/plugins/view/cordis.config.mjs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2026 Nyasers
+//
+// @dsh-hanako/view 自持构建描述（学官方 dsh 组织：配置随源码走）。
+// 消费方：src-cordis/build.js（package.json build:cordis）扫描本文件 → src-cordis/build/* preset。
+// 约定：本文件存在 = 有 service 半（index.js，rspack 打包）；client 半（browser，tsdown
+// closure-factory 自注册 bundle，src-cordis/build/client-config.mjs）按需声明——
+// 本包 client 半 = 装配核心（client.js 引用 vendor/ 官方 ui-layout 源码逐字副本，见 vendor/README）。
+//
+// externals（loader module table require 解析清单）：react 系为平台 seed；外加
+// @deepseek-ai/dsh-client-store——布局 store 引擎（defineStore），官方平台模块表
+// （web/src/platform.ts PLATFORM_MODULES）seed 词，与官方 ui-layout bundle 同款外部依赖。
+// defines：浏览器产物无 process 全局——process.env 编译期替换（client-config.mjs 默认
+// process.env={} + NODE_ENV=production）；DSH_CLIENT_TITLE 对齐官方产物（官方 client 构建
+// profile 内嵌 'DeepSeek Harness'，AppFrame productTitle 以此为 product title）。
+export default {
+  client: {
+    externals: ["react", "react/jsx-runtime", "@deepseek-ai/dsh-client-store"],
+    defines: {
+      "process.env.DSH_CLIENT_TITLE": JSON.stringify("DeepSeek Harness"),
+    },
+  },
+};

--- a/src-cordis/plugins/view/index.js
+++ b/src-cordis/plugins/view/index.js
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2026 Nyasers
+//
+// @dsh-hanako/view — dsh Web UI 视图装配插件（host 半部）。
+//
+// fpFullPanel V1 装配者替换：官方 ui-layout 的「root 装配者」角色由本插件接管——
+// 官方 AppFrame（完整三列视图）改为由本插件注册进 root 槽，layout 服务（ctx.layout）
+// 改由本插件 provide，浏览器端装配全在 client 半（package.json exports["./client"] →
+// client.js，cordis client 插件规范）。host 半无行为（同官方 ui-layout host apply：
+// index.ts 即空 apply——装配是纯浏览器职责），保留空 apply 仅满足 cordis host 插件面。
+//
+// 本文件为 rspack service 半 entry（src-cordis/build.js → service-config.mjs）：node
+// ESM bundle 保留 name/inject/apply 具名导出即被 cordis loader 无感加载。
+
+export const name = "@dsh-hanako/view";
+
+/** host 半零服务依赖（装配无宿主行为；client 半 inject 见 client.js） */
+export const inject = [];
+
+/** host 半空操作：V1 装配 = client 半职责（view 参数路由、layout 服务、root 注册）。 */
+export function apply() {
+  /* 无操作——浏览器端装配见 ./client.js */
+}

--- a/src-cordis/plugins/view/package.json
+++ b/src-cordis/plugins/view/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@dsh-hanako/view",
+  "version": "1.0.0-beta.4+dsh-0.1.2-rc.1",
+  "private": true,
+  "type": "module",
+  "main": "index.js",
+  "exports": {
+    ".": "./index.js",
+    "./client": "./client.js",
+    "./package.json": "./package.json"
+  },
+  "dsh": {
+    "client": {
+      "inject": [
+        "@deepseek-ai/dsh-client-locale",
+        "@deepseek-ai/dsh-client-ui-renderer",
+        "@deepseek-ai/dsh-client-ui-session",
+        "@deepseek-ai/dsh-client-ui-theme"
+      ],
+      "platform": "web"
+    }
+  },
+  "cordis": {
+    "name": "@dsh-hanako/view"
+  }
+}

--- a/src-cordis/plugins/view/vendor/AppFrame.module.css
+++ b/src-cordis/plugins/view/vendor/AppFrame.module.css
@@ -1,0 +1,119 @@
+.frame {
+  position: relative; /* anchors the drag handles, which straddle column borders */
+  display: grid;
+  grid-template-rows: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: var(--dsw-alias-bg-base);
+  /* Collapse/expand animates the tracks on the deepsuite sider curve
+     (--ds-ease-in-out / --ds-transition-duration-slow, ui-theme base.css). */
+  transition: grid-template-columns var(--ds-transition-duration-slow) var(--ds-ease-in-out);
+}
+
+/* Dragging writes widths at pointer cadence; easing them would detach the
+   column from the handle. */
+.frame[data-dragging] {
+  transition: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .frame {
+    transition: none;
+  }
+}
+
+.sidebarCol {
+  min-width: 0;
+  overflow: hidden;
+  background: var(--dsw-specific-sidebar-fill);
+  border-right: 0.5px solid var(--dsw-alias-border-l3);
+}
+
+.centerCol {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.detailsCol {
+  min-width: 0;
+  overflow: hidden;
+  border-left: 0.5px solid var(--dsw-alias-border-l3);
+}
+
+/* The details subtree stays mounted at zero width, so its border must not paint
+   a 1px seam. The collapsed sidebar instead retains a bordered compact rail. */
+.frame[data-details-collapsed] .detailsCol {
+  border-left: none;
+}
+
+/* Drag handles are frame children (columns clip overflow): an 8px hit strip
+   centered on the column border via inline left, above column content. Details
+   adds a visible 12x32 pill at vertical center; sidebar keeps only the hit strip. */
+.handle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 8px;
+  margin-left: -4px;
+  cursor: col-resize;
+  z-index: 2;
+  touch-action: none;
+  /* Rides the same curve as the tracks so the pill stays on the moving
+     border during collapse/expand; paused while dragging (frame rule). */
+  transition: left var(--ds-transition-duration-slow) var(--ds-ease-in-out);
+}
+
+.frame[data-dragging] .handle {
+  transition: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .handle {
+    transition: none;
+  }
+}
+
+.handle[data-side='details']::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 12px;
+  height: 32px;
+  border-radius: 10px;
+  box-sizing: border-box;
+  background: var(--dsw-alias-button-floating-fill);
+  border: 0.5px solid var(--dsw-alias-border-l2-darkmode-thin);
+  /* Hover affordance: the details pill hides until the pointer is over its
+     column, the strip itself, or a drag. */
+  opacity: 0;
+  transition:
+    opacity var(--ds-transition-duration-slow) var(--ds-ease-in-out),
+    background var(--ds-transition-duration-slow) var(--ds-ease-in-out);
+}
+
+.detailsCol:hover ~ .handle[data-side='details']::after,
+.handle[data-side='details']:hover::after,
+.handle[data-side='details'][data-dragging='true']::after {
+  opacity: 1;
+}
+
+.handle[data-side='details']:hover::after,
+.handle[data-side='details'][data-dragging='true']::after {
+  background: var(--dsw-alias-button-floating-hover);
+  border-color: var(--dsw-alias-border-l3);
+}
+
+.overlayLayer {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  pointer-events: none;
+}
+
+.overlayLayer > * {
+  pointer-events: auto;
+}

--- a/src-cordis/plugins/view/vendor/AppFrame.tsx
+++ b/src-cordis/plugins/view/vendor/AppFrame.tsx
@@ -1,0 +1,218 @@
+/**
+ * Three-column shell frame, registered into the built-in 'root' slot (the web
+ * shell renders only 'root'). Owns the grid tracks (sidebar | center |
+ * details), the drag handles (pointer capture + rAF throttle), the concession
+ * chain (columns.ts), and the child-slot render decisions: the sidebar slot
+ * renders HERE with live parameters from the concession solve, and the
+ * session-aware occupants render in fixed column positions; strict entries
+ * gate themselves on current-session availability while session-maybe
+ * entries retain identity. Pure component: everything arrives
+ * through the three framework shares — zero cordis or framework imports,
+ * zero self-made hooks.
+ */
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import type { ReactNode } from 'react'
+import type {
+  PropsLocale, PropsRenderSlots, PropsRuntime, PropsStore,
+} from '@deepseek-ai/dsh-client-ui-slots'
+import { computeColumns, SIDEBAR_AUTO_COLLAPSE, SIDEBAR_DEFAULT } from './columns.ts'
+import { DocumentTitle } from './DocumentTitle.tsx'
+import type { createLayoutStore } from './stores.ts'
+import css from './AppFrame.module.css'
+
+/** Full composed props: runtime share + child-slot render share + store share. */
+export type AppFrameProps =
+  & PropsRuntime<'root'>
+  & PropsRenderSlots<'sidebar' | 'conversation' | 'details' | 'shell.overlay'>
+  & PropsStore<ReturnType<typeof createLayoutStore>>
+  & PropsLocale<'common'>
+
+/** Center column grid item (session-body building block). */
+function CenterColumn(props: { children?: ReactNode }) {
+  return <div className={css.centerCol}>{props.children}</div>
+}
+
+/** Details column grid item; width 0 keeps the subtree mounted (never unmount on close). */
+function DetailsColumn(props: { children?: ReactNode }) {
+  return <div className={css.detailsCol}>{props.children}</div>
+}
+
+/**
+ * One drag handle: pointer capture, rAF-throttled dx reports against the drag-start origin.
+ * `side` keys the hover-reveal CSS to the owning column.
+ */
+function DragHandle(props: { side: 'sidebar' | 'details'; left: number; onStart: () => void; onDrag: (dx: number) => void; onEnd: () => void }) {
+  const [dragging, setDragging] = useState(false)
+  const origin = useRef(0)
+  const latest = useRef(0)
+  const frame = useRef<number | null>(null)
+  const callbacks = useRef({ onStart: props.onStart, onDrag: props.onDrag, onEnd: props.onEnd })
+  callbacks.current = { onStart: props.onStart, onDrag: props.onDrag, onEnd: props.onEnd }
+
+  const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    e.currentTarget.setPointerCapture(e.pointerId)
+    origin.current = e.clientX
+    latest.current = e.clientX
+    callbacks.current.onStart()
+    setDragging(true)
+  }, [])
+  const onPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!e.currentTarget.hasPointerCapture(e.pointerId)) return
+    latest.current = e.clientX
+    frame.current ??= requestAnimationFrame(() => {
+      frame.current = null
+      callbacks.current.onDrag(latest.current - origin.current)
+    })
+  }, [])
+  const onPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!e.currentTarget.hasPointerCapture(e.pointerId)) return
+    e.currentTarget.releasePointerCapture(e.pointerId)
+    if (frame.current !== null) { cancelAnimationFrame(frame.current); frame.current = null }
+    callbacks.current.onDrag(latest.current - origin.current)
+    setDragging(false)
+    callbacks.current.onEnd()
+  }, [])
+
+  return (
+    <div
+      className={css.handle}
+      style={{ left: props.left }}
+      data-side={props.side}
+      data-dragging={dragging || undefined}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+    />
+  )
+}
+
+/** The three-column frame (see module doc). */
+export function AppFrame({
+  useStore,
+  useSessions,
+  actions,
+  renderSlot,
+  SessionProvider,
+  t,
+}: AppFrameProps) {
+  const panels = useStore(s => s)
+  const detailsSession = useSessions((s) => {
+    const current = s.current
+    return current !== undefined && s.byId[current]?.blank === false ? current : undefined
+  })
+  const documentTitle = useSessions((s) => {
+    const current = s.current
+    return current === undefined ? undefined : s.byId[current]?.title
+  })
+  const frameRef = useRef<HTMLDivElement | null>(null)
+  const [viewport, setViewport] = useState(() => window.innerWidth)
+
+  const lastSession = useRef(detailsSession)
+  useLayoutEffect(() => {
+    if (detailsSession === undefined) return
+    if (lastSession.current !== undefined && lastSession.current !== detailsSession) {
+      actions.closeDetails()
+    }
+    lastSession.current = detailsSession
+  }, [actions, detailsSession])
+
+  // Track the frame's own box (not the window): rAF-throttled ResizeObserver.
+  useEffect(() => {
+    const el = frameRef.current
+    /* v8 ignore next -- the ref is always attached by effect time: the frame div renders unconditionally. */
+    if (el === null) return
+    let raf: number | null = null
+    const observer = new ResizeObserver(() => {
+      raf ??= requestAnimationFrame(() => {
+        raf = null
+        const width = el.getBoundingClientRect().width
+        if (width > 0) setViewport(width)
+      })
+    })
+    observer.observe(el)
+    return () => {
+      observer.disconnect()
+      if (raf !== null) cancelAnimationFrame(raf)
+    }
+  }, [])
+
+  // Narrow viewports auto-collapse the sidebar; the store mirror keeps
+  // toggleSidebar's semantics right (narrow toggles flip the manual
+  // re-expand override, stores.ts). Collapsed is decided here, so the
+  // solver stays breakpoint-free: a narrow re-expand passes the preference
+  // (or the default when the wide preference is closed) and the center
+  // absorbs the squeeze.
+  const narrow = viewport < SIDEBAR_AUTO_COLLAPSE
+  useEffect(() => { actions.setNarrow(narrow) }, [actions, narrow])
+  const sidebarCollapsed = narrow ? !panels.narrowExpanded : panels.sidebar === 0
+  const sidebarPreference = sidebarCollapsed
+    ? 0
+    : panels.sidebar === 0 ? SIDEBAR_DEFAULT : panels.sidebar
+  const cols = computeColumns(viewport, sidebarPreference, detailsSession === undefined ? 0 : panels.details)
+  const colsRef = useRef(cols)
+  colsRef.current = cols
+
+  // The drag base is the rendered width captured at drag start (grabbing a
+  // concession-clamped panel must not jump back to the stored preference);
+  // it stays frozen for the whole gesture so dx deltas do not compound.
+  const sidebarBase = useRef(0)
+  const detailsBase = useRef(0)
+  // Track-level transitions pause for the whole gesture: eased tracks would
+  // detach the column edge from the pointer (AppFrame.module.css).
+  const [dragging, setDragging] = useState(false)
+  const onDragEnd = useCallback(() => { setDragging(false) }, [])
+  const onSidebarStart = useCallback(() => { sidebarBase.current = colsRef.current.sidebar; setDragging(true) }, [])
+  const onDetailsStart = useCallback(() => { detailsBase.current = colsRef.current.details; setDragging(true) }, [])
+  const onSidebarDrag = useCallback((dx: number) => {
+    actions.setSidebar(sidebarBase.current + dx)
+  }, [actions])
+  const onDetailsDrag = useCallback((dx: number) => {
+    actions.setDetails(detailsBase.current - dx)
+  }, [actions])
+  const productTitle = process.env.DSH_CLIENT_TITLE ?? t('brand.localBuild')
+
+  return (
+    <div
+      ref={frameRef}
+      className={css.frame}
+      style={{ gridTemplateColumns: `${cols.sidebar}px minmax(0, 1fr) ${cols.details}px` }}
+      data-sidebar-collapsed={sidebarCollapsed || undefined}
+      data-details-collapsed={cols.details === 0 || undefined}
+      data-dragging={dragging || undefined}
+    >
+      <DocumentTitle
+        productTitle={productTitle}
+        {...documentTitle === undefined ? {} : { title: documentTitle }}
+      />
+      <div className={css.sidebarCol}>
+        {/* Render-site slot call with live concession output: a closed
+            sidebar keeps the mounted slot at the compact-rail width, and the
+            component sees its rendered state as owner params decided here
+            (collapsed follows the resolved rail, so a derived auto-collapse
+            renders the rail UI too). */}
+        {renderSlot('sidebar', {
+          collapsed: sidebarCollapsed,
+          width: cols.sidebar,
+        })}
+      </div>
+      <>
+        {/* Both column occupants stay at fixed tree positions from first
+            paint — no loading gate: a bare status line reads worse than
+            the shell's own pending rendering. The conversation
+            is session-maybe; SessionProvider withholds the strict details
+            entry while no session is current. */}
+        <CenterColumn>{renderSlot('conversation', {})}</CenterColumn>
+        <DetailsColumn>
+          <SessionProvider>{renderSlot('details', {})}</SessionProvider>
+        </DetailsColumn>
+      </>
+      <div className={css.overlayLayer} data-shell-overlay>
+        {renderSlot('shell.overlay', {})}
+      </div>
+      {/* The collapsed rail is fixed-width: no resize handle while closed. */}
+      {!sidebarCollapsed && <DragHandle side="sidebar" left={cols.sidebar} onStart={onSidebarStart} onDrag={onSidebarDrag} onEnd={onDragEnd} />}
+      {cols.details > 0 && <DragHandle side="details" left={viewport - cols.details} onStart={onDetailsStart} onDrag={onDetailsDrag} onEnd={onDragEnd} />}
+    </div>
+  )
+}

--- a/src-cordis/plugins/view/vendor/DocumentTitle.tsx
+++ b/src-cordis/plugins/view/vendor/DocumentTitle.tsx
@@ -1,0 +1,23 @@
+import { useEffect } from 'react'
+
+/** Props for the browser title projection. */
+export interface DocumentTitleProps {
+  /** Durable title of the selected session, or undefined for the product title. */
+  title?: string
+  /** Build-configured or localized product title. */
+  productTitle: string
+}
+
+/**
+ * Project the selected durable session title into the browser title and
+ * restore the build-selected product title when unmounted.
+ * @param props - Selected session title projection.
+ * @returns No rendered content.
+ */
+export function DocumentTitle({ title, productTitle }: DocumentTitleProps): null {
+  useEffect(() => {
+    document.title = title === undefined ? productTitle : `${title} — ${productTitle}`
+    return () => { document.title = productTitle }
+  }, [productTitle, title])
+  return null
+}

--- a/src-cordis/plugins/view/vendor/README.md
+++ b/src-cordis/plugins/view/vendor/README.md
@@ -1,0 +1,43 @@
+# vendor/dsh-client-ui-layout（@dsh-hanako/view 构建期官方源码副本）
+
+本目录是 @deepseek-ai/dsh-client-ui-layout 的 **client 半源码逐字副本**（构建期 vendor，
+不随包发布——只作为本插件 client 半（tsdown）的编译输入被内联进 @dsh-hanako/view 的
+closure-factory bundle；dist/cordis/view 下不出现这些文件）。
+
+## 为什么 vendor（不用运行时依赖）
+
+- 官方 npm 包（dsh-client-ui-layout）发布 files 只含 lib/（closure-factory 浏览器 bundle），
+  无 src 物理文件——exports 虽声明 "./src/*": "./src/*" 但解析失败，浏览器 module table 也
+  只有包级 row（id = 包名，exports = 整包 client 模块），子路径模块无法 require。
+- 官方 ui-layout 从 roster 移除后其 row 不再存在；即便保留，其 client 模块导出的是
+  apply/inject（cordis 插件面），AppFrame/store/service 等内部符号不对外导出，无法按组件复用。
+- 因此本插件自持官方装配核心的逐字源码：AppFrame/createLayoutStore/LayoutController/
+  ThemePresenter/DocumentTitle/columns 全部在构建期编译进本包 bundle，运行时零官方依赖
+  （仅 react / react/jsx-runtime / @deepseek-ai/dsh-client-store 平台 seed 走 module table，
+  与官方 ui-layout bundle 的 externals 集一致）。
+
+## 来源与版本钉
+
+- 上游仓库：deepseek-ai/deepseek-harness（remote = official），以 **git submodule** 钉在
+  仓库 `vendor/deepseek-harness`（gitlink 记录钉版 commit；`git submodule update --init` 即得）
+- 来源文件：packages/client/ui-layout/src/client/**（7 个文件：AppFrame.tsx、
+  AppFrame.module.css、columns.ts、DocumentTitle.tsx、service.ts、stores.ts、
+  theme-presenter.ts）
+- 版本钉：submodule HEAD = **dsh-v0.1.2-rc.1**（dsh-hanako 锁 @deepseek-ai/dsh 0.1.2-rc.1；
+  当前 HEAD commit a66e470204）。升 dsh 版本 = submodule 内 checkout 新 tag → 主仓库
+  `git add vendor/deepseek-harness` → 重跑 sync 脚本 → 审 diff → 提交（sync 脚本从
+  submodule HEAD 读钉版，无第二事实源）。
+- 复制方式：scripts/sync-vendor-layout.mjs（幂等，从 submodule 钉版 commit 复制 + 逐文件
+  字节校验；复制后 git status 应无 vendor 副本改动）。
+
+## 改动纪律
+
+vendor 文件**保持上游逐字**（唯一例外=无：import 路径、css 引用、编译期 env 访问均原样；
+构建链负责 css-modules 语义与 process.env 替换）。同步脚本整目录覆盖，任何本地手改会被冲掉。
+
+## 许可
+
+上游为 MIT（packages/client/ui-layout/package.json "license": "MIT"；store 引擎
+@deepseek-ai/dsh-client-store 仅以平台 seed 方式运行时消费，未 vendor 其源码）。
+副本保留 MIT 归属（deepseek-ai/deepseek-harness, Copyright 见上游 LICENSE），
+@dsh-hanako/view 插件本体（client.js/index.js/package.json/cordis.config.mjs）为 MPL-2.0。

--- a/src-cordis/plugins/view/vendor/columns.ts
+++ b/src-cordis/plugins/view/vendor/columns.ts
@@ -1,0 +1,77 @@
+/**
+ * Pure concession-chain column solver for the three-column AppFrame.
+ * Chain order is fixed by contract: keep center >= CENTER_MIN by shrinking
+ * details, then auto-closing it (derived zero width — preferred width
+ * preferences are never rewritten, so widening the window restores them).
+ * The sidebar never concedes: its rendered width is always the drag
+ * preference (or the collapsed rail), and center absorbs any remaining
+ * deficit as the last resort. Inputs are the layout store's plain width
+ * preferences (0 = closed); a closed sidebar resolves to the fixed
+ * SIDEBAR_COLLAPSED control rail while closed details resolve to zero width.
+ * The SIDEBAR_AUTO_COLLAPSE breakpoint is consumed by AppFrame, which decides
+ * the effective sidebar preference before solving; the solver itself stays
+ * breakpoint-free.
+ */
+
+/** Resolved widths for one frame; center may drop below CENTER_MIN only at the final fallback. */
+export interface Columns { sidebar: number; center: number; details: number }
+
+// Contract-frozen geometry: the three-column concession chain's fixed points.
+/** Center column floor; only the final fallback may go below it. */
+export const CENTER_MIN = 640
+/** Sidebar drag clamp floor. */
+export const SIDEBAR_MIN = 264
+/** Sidebar drag clamp ceiling. */
+export const SIDEBAR_MAX = 420
+/** Sidebar width before any user drag. */
+export const SIDEBAR_DEFAULT = 280
+/** Closed-sidebar rail: a 24px icon column between 16px horizontal paddings. */
+export const SIDEBAR_COLLAPSED = 56
+/** Viewport width below which the sidebar auto-collapses to the rail (deepsuite
+ * LG breakpoint); a manual toggle below it re-expands over the squeezed center
+ * (stores.ts narrowExpanded). */
+export const SIDEBAR_AUTO_COLLAPSE = 1024
+/** Details drag clamp floor. */
+export const DETAILS_MIN = 300
+/** Details drag clamp ceiling. */
+export const DETAILS_MAX = 520
+/** Details width before any user drag. */
+export const DETAILS_DEFAULT = 360
+
+/**
+ * Clamp a panel width into its contract range.
+ * @param px - requested width.
+ * @param min - range lower bound.
+ * @param max - range upper bound.
+ * @returns the clamped width.
+ */
+export function clampWidth(px: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, Math.round(px)))
+}
+
+/**
+ * Solve the three column widths for one viewport frame. Pure: no hysteresis —
+ * the output is a function of (viewport, preferences) only, so recovery on
+ * re-widening is automatic. Preferences re-clamp here because they cross the
+ * store boundary and callers may still supply stale ranges.
+ * @param viewport - available frame width in px.
+ * @param sidebar - sidebar width preference in px (0 = closed).
+ * @param details - details width preference in px (0 = closed).
+ * @returns resolved widths; details 0 means visually closed (never unmounted), while a closed sidebar keeps its compact rail.
+ */
+export function computeColumns(viewport: number, sidebar: number, details: number): Columns {
+  // The sidebar is fixed at its preference (or the rail) — it never concedes.
+  const s = sidebar === 0 ? SIDEBAR_COLLAPSED : clampWidth(sidebar, SIDEBAR_MIN, SIDEBAR_MAX)
+  const d0 = details === 0 ? 0 : clampWidth(details, DETAILS_MIN, DETAILS_MAX)
+
+  // Step 1: everything fits at preferred widths.
+  if (s + d0 + CENTER_MIN <= viewport) return { sidebar: s, center: viewport - s - d0, details: d0 }
+
+  // Step 2: shrink details toward its minimum.
+  const d1 = d0 === 0 ? 0 : Math.max(DETAILS_MIN, viewport - s - CENTER_MIN)
+  if (s + d1 + CENTER_MIN <= viewport) return { sidebar: s, center: CENTER_MIN, details: d1 }
+
+  // Step 3: auto-close details (derived — preferences untouched); center
+  // absorbs any remaining deficit (may drop below CENTER_MIN).
+  return { sidebar: s, center: Math.max(0, viewport - s), details: 0 }
+}

--- a/src-cordis/plugins/view/vendor/service.ts
+++ b/src-cordis/plugins/view/vendor/service.ts
@@ -1,0 +1,69 @@
+/**
+ * LayoutController: the cross-plugin panel-action face behind ctx.layout.
+ * Panel geometry itself lives in the root entry's layout store (stores.ts);
+ * the current-session selection lives with the runtime sessions service, and
+ * the per-session active view dissolved into ui-conversation's session store
+ * (its only consumer). What remains here is the contract other plugins'
+ * apply worlds reach for panel transitions (sidebar toggle from ui-sidebar,
+ * details open/close from ui-conversation) — writes stay inside the store's
+ * declared action set, delivered as the registration's bound actions.
+ */
+import type { BoundActions } from '@deepseek-ai/dsh-client-ui-slots'
+import type { createLayoutStore } from './stores.ts'
+
+/** The layout store's bound action set (framework-baked, draft params peeled). */
+export type PanelActions = BoundActions<ReturnType<typeof createLayoutStore>>
+
+/**
+ * The outward layout face (`ctx.layout`): the panel transitions other
+ * plugins may trigger — and exactly what a test fake must supply. The
+ * attachPanels wiring hook stays on the concrete class (root-entry assembly
+ * only).
+ */
+export interface ILayout {
+  /** Toggle the sidebar panel (closed ⟷ contract default width). */
+  toggleSidebar(): void
+  /** Open the details panel (no-op when already open). */
+  openDetails(): void
+  /** Close the details panel. */
+  closeDetails(): void
+}
+
+/** Cross-plugin panel-action face (ctx.layout). */
+export class LayoutController implements ILayout {
+  #panels: PanelActions | undefined
+
+  /**
+   * Adopt the root entry's bound store actions. Called from the root
+   * registration's inject hook (a sanctioned assembly side effect), so the
+   * face is live from the entry's first render; on entry re-register the
+   * fresh actions overwrite the stale set.
+   * @param actions - bound actions of the entry's layout store instance.
+   */
+  attachPanels(actions: PanelActions): void {
+    this.#panels = actions
+  }
+
+  /** Toggle the sidebar panel (closed ⟷ contract default width). */
+  toggleSidebar(): void {
+    this.#require().toggleSidebar()
+  }
+
+  /** Open the details panel (no-op when already open). */
+  openDetails(): void {
+    this.#require().openDetails()
+  }
+
+  /** Close the details panel. */
+  closeDetails(): void {
+    this.#require().closeDetails()
+  }
+
+  #require(): PanelActions {
+    // Callers are UI gestures, which cannot fire before the root entry
+    // rendered (the inject hook runs in its first render) — reaching this
+    // unwired is a boot-order bug, not a race to tolerate.
+    if (this.#panels === undefined) throw new Error('layout: panel actions not wired (root entry not mounted)')
+    return this.#panels
+  }
+}

--- a/src-cordis/plugins/view/vendor/stores.ts
+++ b/src-cordis/plugins/view/vendor/stores.ts
@@ -1,0 +1,72 @@
+/**
+ * The root entry's transient layout store: panel geometry as plain widths in
+ * px (0 = closed). Module level exports the factory only — a module-level
+ * handle would pin the store's identity in the module
+ * cache (a de-facto singleton surviving plugin reloads). register() receives
+ * the factory (exclusive use: the framework instantiates per entry), AppFrame
+ * derives its PropsStore share from the return type, and the service face
+ * receives the bound actions through the registration's inject hook.
+ */
+import { defineStore, type EngineStoreHandle } from '@deepseek-ai/dsh-client-store'
+import {
+  clampWidth, DETAILS_DEFAULT, DETAILS_MAX, DETAILS_MIN,
+  SIDEBAR_DEFAULT, SIDEBAR_MAX, SIDEBAR_MIN,
+} from './columns.ts'
+
+/**
+ * Layout store state: panel width preferences in px (0 = closed), plus the
+ * narrow-viewport pair — `narrow` mirrors AppFrame's breakpoint reading
+ * (viewport < SIDEBAR_AUTO_COLLAPSE) so toggleSidebar can pick semantics, and
+ * `narrowExpanded` is the manual override that re-expands the auto-collapsed
+ * sidebar over the squeezed center without rewriting the width preference.
+ */
+type LayoutState = { sidebar: number; details: number; narrow: boolean; narrowExpanded: boolean }
+
+/**
+ * Annotation twin of the actions literal below (the export needs a declared
+ * return type); drift fails assignability at the defineStore call.
+ */
+type LayoutActions = {
+  setSidebar: (draft: LayoutState, px: number) => void
+  setDetails: (draft: LayoutState, px: number) => void
+  toggleSidebar: (draft: LayoutState) => void
+  setNarrow: (draft: LayoutState, narrow: boolean) => void
+  openDetails: (draft: LayoutState) => void
+  closeDetails: (draft: LayoutState) => void
+}
+
+/**
+ * Create the layout panel store handle. The preference IS the width, so
+ * closing a panel forgets its drag width — reopening restores the contract
+ * default. Actions are the complete write set: drag writes clamp
+ * into the panel's contract range and never cross the open/closed line;
+ * open/close transitions write 0 / the default explicitly. Below the
+ * auto-collapse breakpoint (AppFrame feeds setNarrow) the sidebar toggle
+ * flips the narrowExpanded override instead of the preference.
+ * @returns the store handle (spec + type + identity + factory in one).
+ */
+export function createLayoutStore(): EngineStoreHandle<LayoutState, LayoutActions>  {
+  const handle = defineStore({
+    init: (): LayoutState => ({ sidebar: SIDEBAR_DEFAULT, details: 0, narrow: false, narrowExpanded: false }),
+    actions: {
+      setSidebar: (d, px: number) => { d.sidebar = clampWidth(px, SIDEBAR_MIN, SIDEBAR_MAX) },
+      setDetails: (d, px: number) => { d.details = clampWidth(px, DETAILS_MIN, DETAILS_MAX) },
+      // Narrow toggles flip only the override: the width preference survives
+      // untouched, so re-widening restores the pre-squeeze layout.
+      toggleSidebar: (d) => {
+        if (d.narrow) d.narrowExpanded = !d.narrowExpanded
+        else d.sidebar = d.sidebar === 0 ? SIDEBAR_DEFAULT : 0
+      },
+      // Crossing the breakpoint in either direction drops the override: the
+      // narrow default is auto-collapsed, the wide state is the preference.
+      setNarrow: (d, narrow: boolean) => {
+        if (d.narrow === narrow) return
+        d.narrow = narrow
+        d.narrowExpanded = false
+      },
+      openDetails: (d) => { if (d.details === 0) d.details = DETAILS_DEFAULT },
+      closeDetails: (d) => { d.details = 0 },
+    },
+  })
+  return handle
+}

--- a/src-cordis/plugins/view/vendor/theme-presenter.ts
+++ b/src-cordis/plugins/view/vendor/theme-presenter.ts
@@ -1,0 +1,68 @@
+/**
+ * Global theme DOM applier: projects the resolved ThemeSnapshot onto the
+ * document — `html { color-scheme }` for native UA chrome (scrollbars, form
+ * controls), `body[data-ds-dark-theme]` for the token palette, the active
+ * theme's alias-token overrides as inline CSS variables on body, the content
+ * font-size axis (`--dsh-content-font-size`), and one presenter-owned
+ * `meta[name="theme-color"]` for surrounding browser UI. Pure DOM writes, no
+ * React involvement; the presenter only ever retracts what it wrote itself,
+ * so foreign attributes, metadata, and inline styles survive.
+ */
+import type { ThemeSnapshot } from '@deepseek-ai/dsh-client-ui-theme/client'
+
+/** Body attribute selecting the dark base palette in the token stylesheets. */
+export const DARK_ATTRIBUTE = 'data-ds-dark-theme'
+
+/** Body variable carrying the user's content font size in px. */
+export const CONTENT_FONT_SIZE_VARIABLE = '--dsh-content-font-size'
+
+/** Applies theme snapshots to the document; one instance per plugin fiber. */
+export class ThemePresenter {
+  /** Token names this presenter wrote in the last apply (its retraction set). */
+  private appliedTokens: string[] = []
+  /** The single metadata node this presenter inserts and removes. */
+  private readonly themeColorMeta: HTMLMetaElement
+
+  /** Create the presenter-owned metadata node before the first snapshot arrives. */
+  constructor() {
+    this.themeColorMeta = document.createElement('meta')
+    this.themeColorMeta.name = 'theme-color'
+  }
+
+  /**
+   * Project a snapshot onto the document: set root `color-scheme` and the body
+   * palette attribute from `active.colorScheme` (never the id — `system` is
+   * resolved upstream), publish the content font-size axis, then replace the
+   * previously applied token variables with `active.tokens`. Browser
+   * theme-color metadata follows the computed body background after those
+   * writes, so the rendered palette remains the color authority.
+   * @param snapshot - resolved theme snapshot from ctx.theme.
+   */
+  apply(snapshot: ThemeSnapshot): void {
+    const scheme = snapshot.active.colorScheme
+    document.documentElement.style.colorScheme = scheme
+    const body = document.body
+    if (scheme === 'dark') body.setAttribute(DARK_ATTRIBUTE, '')
+    else body.removeAttribute(DARK_ATTRIBUTE)
+    body.style.setProperty(CONTENT_FONT_SIZE_VARIABLE, `${snapshot.fontSize}px`)
+    for (const name of this.appliedTokens) body.style.removeProperty(name)
+    this.appliedTokens = []
+    for (const [name, value] of Object.entries(snapshot.active.tokens)) {
+      body.style.setProperty(name, value)
+      this.appliedTokens.push(name)
+    }
+    this.themeColorMeta.content = getComputedStyle(body).backgroundColor
+    if (!this.themeColorMeta.isConnected) document.head.append(this.themeColorMeta)
+  }
+
+  /** Retract root color-scheme, the palette attribute, token variables, the font-size axis, and the owned metadata node. */
+  dispose(): void {
+    document.documentElement.style.removeProperty('color-scheme')
+    const body = document.body
+    body.removeAttribute(DARK_ATTRIBUTE)
+    body.style.removeProperty(CONTENT_FONT_SIZE_VARIABLE)
+    for (const name of this.appliedTokens) body.style.removeProperty(name)
+    this.appliedTokens = []
+    this.themeColorMeta.remove()
+  }
+}

--- a/src/lib/lifecycle.js
+++ b/src/lib/lifecycle.js
@@ -376,7 +376,7 @@ function buildProviderRoutes() {
 // vX（dshana-profile-bundle 重构，spec：specs/current/dshana-profile-bundle/spec.md
 // D1/D2/D4/D5）：profile 目录改为运行时初始化的用户自有真实目录（用户可自装插件），
 // 不再整树 junction 挂插件产物。产物 = scope 树（dist/cordis/**，
-// 含 bundle @dsh-hanako/dshana 与 8 子插件，见 build.mjs buildCordis）：
+// 含 bundle @dsh-hanako/dshana 与 9 子插件，见 src-cordis/build.js buildCordis）：
 //   profileDir = $DSH_HOME/profiles/dshana：官方 initProfile 生成（manifest
 //   dsh.profile.bundles=[@deepseek-ai/dsh-base, @dsh-hanako/dshana]、用户层
 //   cordis.patch.yml 模板、pnpm-workspace.yaml；cordis.yml 空根由 dsh boot 自维护）+
@@ -397,7 +397,7 @@ export async function ensureDshanaProfile(cfg) {
   const g = getSingleton();
   const append = (msg) => g.appendLog?.("hana", msg);
   const srcRoot = join(PLUGIN_ROOT, "cordis"); // 打包产物 cordis/（scope 树形态：@dsh-hanako 平铺目录，无 node_modules 层）
-  const scopeSrc = srcRoot; // 产物 scope 根 = cordis 资产根（9 包平铺 dist/cordis/*，链接名 @dsh-hanako 供 cordis 解析）
+  const scopeSrc = srcRoot; // 产物 scope 根 = cordis 资产根（10 包平铺 dist/cordis/*，链接名 @dsh-hanako 供 cordis 解析）
   const dshHome = join(cfg.dataDir, "dsh-home");
   // 官方生成工具 initProfile（@deepseek-ai/dsh-app-boot 导出，与 loadLayeredEnv 同模块）：
   // 复用 loadInprocDsh 拿 appBoot（dsh 依赖缺失/版本无 initProfile 时无法官方生成 →

--- a/src/lib/profile-seed.js
+++ b/src/lib/profile-seed.js
@@ -4,9 +4,9 @@
 // lib/profile-seed.js — dshana profile 运行时种子化/迁移/scope 链接（lib 提取）
 // 从 src/lifecycle.js ensureDshanaProfile 剥离的纯路径逻辑（设计 specs/current/
 // dshana-profile-bundle/spec.md D1/D2/D4/D5）：profile 目录（$DSH_HOME/profiles/dshana）
-// 由插件运行时初始化为用户自有真实目录（不再整树 junction 挂插件产物），8 个
+// 由插件运行时初始化为用户自有真实目录（不再整树 junction 挂插件产物），9 个
 // @dsh-hanako/* 子插件 + bundle @dsh-hanako/dshana 经单条 scope 目录链接暴露（scopeSrc =
-// PLUGIN_ROOT/cordis——9 包平铺于 cordis 资产根，链接名 @dsh-hanako 供 cordis 解析）。
+// PLUGIN_ROOT/cordis——10 包平铺于 cordis 资产根，链接名 @dsh-hanako 供 cordis 解析）。
 //
 // 官方生成工具（2026-09-04 定案）：profile 文件（manifest package.json / 用户层
 // cordis.patch.yml / pnpm-workspace.yaml）由 @deepseek-ai/dsh-app-boot 的 initProfile


### PR DESCRIPTION
## 概述

fpFullPanel 转型 V1（spec：`specs/current/dshana-v2-fpfullpanel/`，执行蓝图 `view-layouts.md` 拆解 V1）：**装配者替换 + 官方等价回归**。官方 `ui-layout` 从 roster 移除，新建 cordis client+host 插件 `@dsh-hanako/view` 接管同一套 root 装配，无参完整视图渲染与官方等价。

目标终态：宿主 functionPanel 嵌 dsh sidebar、主页视图分离（URL 三态）。本次只做 V1，main/sidebar 视图留骨架（V2/V3 后续）。

## 改动清单

**新建 `@dsh-hanako/view`（`src-cordis/plugins/view/`）**
- `package.json`：host+client 声明（exports `.`/`./client`、`cordis.name`）；`dsh.client.inject` 对齐官方 ui-layout 依赖方（locale/ui-renderer/ui-session/ui-theme）
- `index.js`：host 半空 apply（装配纯浏览器职责，同官方 ui-layout host）
- `client.js`：装配核心——provide `layout`（LayoutController 哑门面）+ `slots.register(root)` = 官方 AppFrame（四子槽声明 + `createLayoutStore` + inject 钩子 `layout.attachPanels(actions)`）+ ThemePresenter 主题 DOM 投影；`?dshana-view=` 三态路由留骨架，main/sidebar 回退完整视图
- `cordis.config.mjs`：client externals = react 系 + `@deepseek-ai/dsh-client-store`（平台 seed，官方 bundle 同款集）；defines `DSH_CLIENT_TITLE` 对齐官方产物
- `vendor/`：官方 ui-layout client src 逐字副本 7 文件（rc.1 钉版）+ README（溯源/钉版/许可）

**修改**
- `src-cordis/cordis.patch.yml`：移除 `ui-layout` insert（留注释），`@dsh-hanako/*` 区末 insert `@dsh-hanako/view`
- `src-cordis/build/client-config.mjs`：预设扩展——`.module.css` CSS Modules 虚拟 loader（`dv_` class 前缀化 + 幂等 `<style data-plugin-css>` 注入）+ tsdown `define` 支持（`process.env`→`{}`/NODE_ENV + 包级 defines）；settings 零行为变化（产物 13.76kB 不变）
- `src-cordis/build.js`：buildClientHalves 透传 `cfg.client.defines`
- `scripts/pack.mjs`：必需包清单 + `view`（10 包）；`src/lib/lifecycle.js`、`profile-seed.js` 注释计数同步
- `scripts/sync-vendor-layout.mjs`：新增，幂等 vendor 同步（`git show dsh-v0.1.2-rc.1:<path>` + 字节校验，fail-closed 缺 tag 即拒）

## Spike 结论

1. **官方 src 构建期解析通道 = 钉版 vendor 入库**：官方 npm 副本无 src 物理文件（发布 files 只含 lib/，`exports "./src/*"` 解析失败）、浏览器 module table 只认整包 row（子路径不可 require）→ ui-layout client 模块不导出 AppFrame/store/service 内部符号，本插件必须自持装配核心源码。否决 file:/git devDep（外部 monorepo 安装耦合、lockfile 非 registry 源）；落地方案 = rc.1 源码逐字 vendor 进包并 git 提交（可复现、可审 diff、可溯源），tsdown 构建期编译内联，运行时外部仅 react 系 + dsh-client-store 三个 seed。
2. **开放问题 2（attachPanels 接线）= 需要，且必须逐项等效**：LayoutController 是哑门面（未接线 `#require()` 即抛）；接线点在 root 注册的 inject 钩子 `layout.attachPanels(actions)`；provide('layout') 供 ui-sidebar 等 inject 方；theme presenter effect（官方 ui-layout 第二 effect）是主题 DOM 投影唯一者，移除后须随 view 插件保留。已全部等效落实。

## 验证记录

- **构建**：`node src-cordis/build.js` 全绿——静态组装 10 目录（9 子插件 + dshana）、service 半 rspack 9 个 ESM bundle、client 半 tsdown 2 个 closure-factory（view 10,419B gzip 4.05kB；settings 13.76kB 不变）
- **产物核对**：view client.js 头 `__ModuleLoader__.load({id:"@dsh-hanako/view"…})`；externals 仅 react/react/jsx-runtime/@deepseek-ai/dsh-client-store 三 seed；含 attachPanels/theme presenter/dv_ 前缀 CSS 注入/DSH_CLIENT_TITLE define 生效/process.env 折叠
- **vendor 逐字核对**：`node scripts/sync-vendor-layout.mjs` 重跑幂等（git status 无改动 = 与上游 `dsh-v0.1.2-rc.1` tag 逐字节一致）
- **YAML 校验**：cordis.patch.yml 65 条目、view 在、ui-layout 无
- **实机等价回归**：产物部署安装副本后重载，打开 DSHana 无参页面——渲染与改动前**无差异**（三栏布局、外观一致；装配者替换对用户无感 = 官方等价达成）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a responsive three-column application layout with sidebar, conversation, details, and overlay areas.
  * Added draggable, collapsible panels with persistent sizing and layout controls.
  * Added theme synchronization, responsive styling, reduced-motion support, and session-based browser titles.
  * Added full, main, and sidebar views with graceful fallback for invalid values.
  * Added client-build support for CSS modules and environment settings.
* **Bug Fixes**
  * Prevented malformed view URLs from aborting application startup.
* **Documentation**
  * Updated package and bundle documentation for the expanded plugin roster.
* **Chores**
  * Added validation and synchronization checks for bundled layout assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->