### PR TITLE
chore(tools): query.js cwd-key 注释示例去本机路径

### DIFF
--- a/src/tools/subtool/query.js
+++ b/src/tools/subtool/query.js
@@ -73,8 +73,8 @@ function mapSessionItems(sessions) {
   return items;
 }
 
-// cwd-key 编码：cwd 绝对路径 → "--" + 路径段按 "-" 连接 + "--"（如 E:\Hanako\workspace →
-// --E-Hanako-workspace--，与 dsh session-persistence 落盘目录命名一致）
+// cwd-key 编码：cwd 绝对路径 → "--" + 路径段按 "-" 连接 + "--"（如 D:\work\proj →
+// --D--work--proj--，与 dsh session-persistence 落盘目录命名一致）
 function encodeCwdKey(cwd) {
   const clean = String(cwd ?? "").replace(":", "").replace(/[\\/]/g, "-");
   return "--" + clean + "--";

--- a/src/tools/subtool/query.js
+++ b/src/tools/subtool/query.js
@@ -74,7 +74,7 @@ function mapSessionItems(sessions) {
 }
 
 // cwd-key 编码：cwd 绝对路径 → "--" + 路径段按 "-" 连接 + "--"（如 D:\work\proj →
-// --D--work--proj--，与 dsh session-persistence 落盘目录命名一致）
+// --D-work-proj--，与 dsh session-persistence 落盘目录命名一致）
 function encodeCwdKey(cwd) {
   const clean = String(cwd ?? "").replace(":", "").replace(/[\\/]/g, "-");
   return "--" + clean + "--";


### PR DESCRIPTION
src/tools/subtool/query.js encodeCwdKey 的注释示例用了本机真实路径（E:\Hanako\workspace），改通用占位路径 D:\work\proj，避免仓库内暴露本机目录布局。单行注释改动，无行为变化。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Corrected the `encodeCwdKey` documentation example for the Windows path `D:\work\proj`.
  - The example now displays the encoded form as `--D-work-proj--`, making the expected hyphen-separated format clearer and more accurate for users referencing the documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->