### PR TITLE
feat(view): fpFullPanel V2 sidebar 视图 + fp 嵌入——SidebarOnlyFrame + embedUrl

### DIFF
--- a/src-cordis/plugins/view/SidebarOnlyFrame.module.css
+++ b/src-cordis/plugins/view/SidebarOnlyFrame.module.css
@@ -1,0 +1,7 @@
+/* 单列 sidebar 帧（?dshana-view=sidebar 根容器）：占满 fp 面板 iframe viewport，
+   高 100% + overflow 兜底；sidebar 列（SidebarRoot）自带填充与内嵌滚动区。 */
+.frame {
+  height: 100%;
+  overflow: hidden;
+  background: var(--dsw-alias-bg-base);
+}

--- a/src-cordis/plugins/view/SidebarOnlyFrame.tsx
+++ b/src-cordis/plugins/view/SidebarOnlyFrame.tsx
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2026 Nyasers
+//
+// SidebarOnlyFrame —— sidebar 视图（?dshana-view=sidebar）的 root 帧组件。
+//
+// 角色（fpFullPanel V2）：宿主 fp 面板经 manifest functionPanel.embedUrl 把本页嵌入
+// 窄面板 iframe，本帧 = 该 iframe 内的唯一内容面（无 rail 折叠语义，collapsed 恒
+// false = 恒 wide 渲染）。单列容器占满宿主面板（高 100% / 宽自适应），容器宽经
+// ResizeObserver 实测后作为 sidebar 槽 owner geometry（{ collapsed: false, width }）
+// 传给 renderSlot('sidebar')——官方 SidebarRoot（ui-sidebar roster 条目注册进 sidebar
+// 槽，官方 bundle 自带 SidebarRoot + primitives）按该 width 渲染自身列宽。
+//
+// 设计要点：
+//  - 不自组官方组件：本帧只声明/渲染 'sidebar' 子槽（declaring is claiming——
+//    conversation/details/shell.overlay 不声明，其 ui-* occupant 经 slots.inject 等待
+//    声明生命周期，子树不注册不挂载）；SidebarRoot 及其内部子槽（sidebar.brand.* /
+//    sidebar.workspaces / sidebar.settings / sidebar.footer.action）全由 roster 里
+//    ui-sidebar / ui-workspace / ui-settings-general 的官方 bundle 自注册提供。
+//  - 不 import ui-sidebar / primitives 源码：避免把 primitives 依赖树拖进本包。
+//  - 高度/滚动语义：fp 面板高度 = iframe viewport，本帧 height:100% 撑满；纵向滚动由
+//    SidebarRoot 内嵌滚动区（ui-workspace 会话列表等）自理（开放问题 3 已解除：官方
+//    CSS 原生自适应窄宽，无渲染下限），本帧 overflow:hidden 仅兜底防溢出。
+//  - 与 AppFrame sidebar 列渲染的差异：AppFrame 经 computeColumns 让步链产出列宽并
+//    支持 56px rail 折叠态；本帧无 center/details 列可让步，列宽 = 容器实测宽直传
+//    （不做 SIDEBAR_MIN/MAX 截断——宿主 fp 面板宽度是唯一约束，截断会造成溢出或与
+//    容器脱节）。
+//  - 唯一交互残留：SidebarRoot 顶行 rail toggle（panel 图标）点击 → ctx.layout
+//    .toggleSidebar() 只翻转 layout store 偏好（本帧不读 store 几何，无视觉效果）。
+//
+// 已知限制（V2 如实记录，不做 V4 预实现）：
+//  - sidebar.settings occupant（ui-settings-general）点击会弹全视口 1080x700 设置
+//    modal，在本 iframe 内必然溢出——跨边联动（modal 改在主页打开）属 V4 联动协议。
+//  - main 视图（V3）不做，?dshana-view=main 仍回退完整视图。
+import { useEffect, useRef, useState } from 'react'
+import css from './SidebarOnlyFrame.module.css'
+
+/**
+ * 单列 sidebar 帧：容器宽实测 → renderSlot('sidebar', { collapsed: false, width })。
+ * @param props - 框架组合 props（本帧只消费 renderSlot 子槽渲染 share）。
+ */
+export function SidebarOnlyFrame(props: {
+  renderSlot: (name: 'sidebar', owner: { collapsed: boolean; width: number }) => unknown
+}) {
+  const frameRef = useRef<HTMLDivElement | null>(null)
+  // 首帧以 iframe viewport 宽兜底（iframe 内 innerWidth = 宿主面板内容宽），
+  // ResizeObserver 首报即校正为容器实测宽；宿主面板宽度可调，观察持续跟随。
+  const [width, setWidth] = useState(() => window.innerWidth)
+
+  // 容器框级测量（同 AppFrame frame 自测语义：rAF 节流 + 取边框盒宽）。
+  useEffect(() => {
+    const el = frameRef.current
+    /* v8 ignore next -- effect 运行期 ref 恒已挂载（frame div 无条件渲染）。 */
+    if (el === null) return
+    let raf: number | null = null
+    const observer = new ResizeObserver(() => {
+      raf ??= requestAnimationFrame(() => {
+        raf = null
+        const measured = el.getBoundingClientRect().width
+        if (measured > 0) setWidth(measured)
+      })
+    })
+    observer.observe(el)
+    return () => {
+      observer.disconnect()
+      if (raf !== null) cancelAnimationFrame(raf)
+    }
+  }, [])
+
+  return (
+    <div ref={frameRef} className={css.frame}>
+      {/* sidebar 槽渲染点：collapsed=false 恒 wide（fp 面板唯一内容面，无 rail 语义）；
+          width = 容器实测宽，直通 SidebarRoot 列宽（差异说明见文件头）。 */}
+      {props.renderSlot('sidebar', { collapsed: false, width })}
+    </div>
+  )
+}

--- a/src-cordis/plugins/view/client.js
+++ b/src-cordis/plugins/view/client.js
@@ -3,7 +3,7 @@
 //
 // @dsh-hanako/view 前端 client 模块（装配核心）。
 //
-// 角色（fpFullPanel V1）：替代官方 ui-layout 的「root 装配者」。官方 ui-layout 从
+// 角色（fpFullPanel V1→V2）：替代官方 ui-layout 的「root 装配者」。官方 ui-layout 从
 // cordis.patch.yml roster 移除（其 AppFrame 不再抢 root），本插件接管同一套装配：
 //   inject = ['slots', 'theme', 'locale']（与官方 ui-layout client/index.ts 完全一致——
 //   slots=内置槽注册、theme=ui-theme 服务（ThemePresenter 数据源）、locale=ui-locale 服务）
@@ -12,11 +12,19 @@
 //        'layout' 服务（ctx.get('layout').toggleSidebar 等面板动作契约），roster 去掉
 //        ui-layout 后必须由本插件 provide 等价服务。
 //     ② ctx.slots.register(root 条目, <视图组件>)——root 槽 single 语义先注册 wins，
-//        ui-layout 移除后本插件是唯一 root 注册方。
+//        ui-layout 移除后本插件是唯一 root 注册方；register 同携四/单子槽声明 +
+//        store（createLayoutStore）+ inject 钩子 attachPanels（开放问题 2 结论）。
 //     ③ ctx.effect(ThemePresenter)——主题快照投影 document（同官方第二 effect）。
-//   V1 只做「无参完整视图」= 注册官方 AppFrame（渲染组件与官方 ui-layout 激活时同一
-//   组件），URL 三态（无参/main/sidebar）路由留骨架——main/sidebar 为 V2/V3，不在
-//   本版范围（出现时 V1 回退完整视图并 warn，行为安全）。
+//   视图矩阵（frameForView 选型；URL 参数 ?dshana-view=<view>，无参 = full）：
+//     full    = 官方 AppFrame（四子槽，官方等价；无参主页面默认）
+//     sidebar = SidebarOnlyFrame（V2：fp 面板 embedUrl 纯侧栏——单列容器 + 仅 sidebar
+//               子槽；SidebarRoot/workspaces/settings 子槽 occupant 走 roster 官方
+//               bundle，详见 SidebarOnlyFrame.tsx 文件头）
+//     main    = V3 未实现，回退 full（warn）
+//   V2 边界如实记录（不做 V4 预实现，见 SidebarOnlyFrame.tsx「已知限制」）：
+//     sidebar.settings modal（1080x700）在本 iframe 内溢出 → 跨边联动属 V4；
+//     SidebarRoot rail toggle 只翻转 layout store 偏好（本帧不读 store 几何），无视觉效果；
+//     sidebar 无 rail 折叠语义（collapsed 恒 false）。
 //
 // 官方源码复用通道（重要——构建期 vendor，见 vendor/README.md）：
 //   官方 npm 副本无 src 物理文件（发布 files 只含 lib/，exports "./src/*" 解析失败），
@@ -52,15 +60,17 @@
 // @deepseek-ai/dsh-client-store external 走 loader seed 表 require）。
 
 import { AppFrame } from "./vendor/AppFrame.tsx";
+import { SidebarOnlyFrame } from "./SidebarOnlyFrame.tsx";
 import { createLayoutStore } from "./vendor/stores.ts";
 import { LayoutController } from "./vendor/service.ts";
 import { ThemePresenter } from "./vendor/theme-presenter.ts";
 
-// ---- view 参数读取（URL 三态路由；V1 只实现 full，main/sidebar 回退 full）----
+// ---- view 参数读取（URL 三态路由；V2 已实现 full/sidebar，main 回退 full）----
 // 官方 boot 不管 query，本插件直接读 location.search 的 ?dshana-view=<view>；
-// 无参 = 完整三列视图（主页面默认，等价官方 ui-layout 激活态）。
+// 无参 = 完整三列视图（主页面默认，等价官方 ui-layout 激活态）；
+// sidebar = 纯侧栏视图（V2，manifest functionPanel.embedUrl 指向本页带该参数）。
 const FULL = "full";
-const MAIN = "main"; // V3（无侧栏主视图）
+const MAIN = "main"; // V3（无侧栏主视图，本期回退 full）
 const SIDEBAR = "sidebar"; // V2（fp 面板 embedUrl 纯侧栏）
 
 function readView() {
@@ -78,23 +88,30 @@ function readView() {
   return v === MAIN || v === SIDEBAR ? v : FULL;
 }
 
-// root 条目的子槽声明（官方 ui-layout client/index.ts 逐字：frame 的四子槽排他渲染权威；
-// 子槽占位者（sidebar/conversation/details/shell.overlay 的 ui-* 插件）条目 roster 照留）。
+// root 条目的子槽声明。FULL = 官方 ui-layout client/index.ts 逐字四子槽（frame 的
+// 排他渲染权威）；SIDEBAR 只声明 sidebar——declaring is claiming：conversation/details/
+// shell.overlay 不声明则其 ui-* occupant（ui-conversation/ui-chat 等，经 slots.inject
+// 等待声明生命周期）子树不注册不挂载；数据/服务面（sessions/workspaces 等）是 service
+// 不依赖槽，照常激活。sidebar 槽内部子槽（brand/workspaces/settings/footer.action）由
+// occupant（ui-sidebar）自身的 register 声明，不受本表收窄影响。
 const FULL_CHILDREN = {
   sidebar: { kind: "single", scope: "root" },
   conversation: { kind: "single", scope: "session-maybe" },
   details: { kind: "single", scope: "session" },
   "shell.overlay": { kind: "list", scope: "root" },
 };
+const SIDEBAR_CHILDREN = {
+  sidebar: { kind: "single", scope: "root" },
+};
 
-// 视图 → root 组件装配选择。V1 全部回退官方 AppFrame（无参完整视图）：
+// 视图 → root 组件装配选择。
 //   - full：官方 AppFrame（等价官方 ui-layout 激活）
-//   - main：TODO V3（AppFrame + 初始 panels.sidebar=0 隐藏态；子槽收窄不声明 sidebar）
-//   - sidebar：TODO V2（SidebarOnlyFrame 单列容器 + 官方 SidebarRoot + 仅 sidebar 子槽）
-// 选型函数骨架保留——V2/V3 在 <视图组件> 与 <children> 两处替换即可。
+//   - sidebar（V2）：SidebarOnlyFrame（单列容器 + 官方 SidebarRoot 经 sidebar 槽渲染）
+//   - main：V3 未实现 → 回退 AppFrame 完整视图（warn，行为安全）
 function frameForView(view) {
   if (view === FULL) return { component: AppFrame, children: FULL_CHILDREN };
-  return { component: AppFrame, children: FULL_CHILDREN }; // V1 回退：完整视图兜底
+  if (view === SIDEBAR) return { component: SidebarOnlyFrame, children: SIDEBAR_CHILDREN };
+  return { component: AppFrame, children: FULL_CHILDREN }; // V3 main 回退：完整视图兜底
 }
 
 // ---- 客户端服务注入：slots（root 注册）+ theme（ThemePresenter 快照）+ locale（t）----
@@ -103,21 +120,19 @@ function frameForView(view) {
 const inject = ["slots", "theme", "locale"];
 
 /**
- * 客户端插件主体：provide layout 服务 + 注册 root（官方 AppFrame）+ theme DOM 投影。
+ * 客户端插件主体：provide layout 服务 + 注册 root（按视图选型帧：full=AppFrame、
+ * sidebar=SidebarOnlyFrame）+ theme DOM 投影。
  * @param ctx - 客户端根 context。
  */
 function apply(ctx) {
   const view = readView();
   const layout = new LayoutController();
   const { component: RootView, children } = frameForView(view);
-  if (view !== FULL) {
-    // V1 未实现 main/sidebar：回退完整视图（行为 = 官方等价），实机无感；V2/V3 落地后
-    // 此分支替换为对应 frame（见 frameForView TODO）。
+  if (view === MAIN) {
+    // V3 未实现 main 视图：回退完整视图（行为 = 官方等价），实机无感。
     try {
       console.warn(
-        "[@dsh-hanako/view] dshana-view=" +
-        view +
-        " 尚未实现（V1 只含无参完整视图），本次回退官方完整视图",
+        "[@dsh-hanako/view] dshana-view=main 尚未实现（V2 含 full/sidebar），本次回退官方完整视图",
       );
     } catch {
       /* 日志失败不阻断 */
@@ -150,7 +165,7 @@ function apply(ctx) {
       // provide() 的 disposer 异步落定；teardown 同步 fire-and-forget（官方同款）。
       void disposeService();
     };
-  }, "@dsh-hanako/view: layout 服务 + root 注册（官方 AppFrame 装配）");
+  }, "@dsh-hanako/view: layout 服务 + root 注册（按 dshana-view 选型 frame 装配）");
 
   // effect 2：theme DOM 投影（官方 ui-layout 第二 effect 逐字——getter 初始一次 + 事件
   // 驱动；无 React 路径，纯 DOM 写）。

--- a/src/assets/webui-shell.jinja2
+++ b/src/assets/webui-shell.jinja2
@@ -368,40 +368,8 @@
               return fetch(hanaApiUrl(path), Object.assign({}, init || {}, { headers: headers }));
             },
           },
-          panel: {
-            set: function (props) {
-              // 面板不可用（宿主无 functionPanel / 未响应）时静默降级
-              return hanaRequest("hana.panel.set", props, 4000).catch(function () { return { accepted: 0, dropped: [] }; });
-            },
-          },
         };
       })();
-      // ---- 功能面板（status 常驻；actions 段已退役——T4 无手动入口）----
-      function panelStatusView() {
-        var st = { word: "未就绪", tone: "danger", delta: "自动进行中" };
-        if (!boot) return st;
-        if (boot.ready) { st.word = "运行中"; st.tone = "success"; st.delta = "端口 " + panelPort; return st; }
-        if (viewOf(boot) === "action") { st.word = "需要处理"; st.delta = "自举暂停"; return st; }
-        var d = boot.deps || {};
-        if (d.status === "installing" || d.status === "running") { st.word = "自举中"; st.tone = "warning"; st.delta = "依赖安装/核对"; return st; }
-        if (boot.phase === "booting") { st.word = "自举中"; st.tone = "warning"; st.delta = "启动 Web Host"; return st; }
-        st.word = "自举中"; st.tone = "warning";
-        return st;
-      }
-      function pushPanel() {
-        try {
-          if (!hana || !hana.panel || !hana.panel.set) return;
-          if (!boot) return; // 快照未到（未知态）不推——避免把「未就绪」误报给宿主侧栏；
-          // 快照到达后必经 applyBoot → pushPanel 以真实状态补推
-          var st = panelStatusView();
-          hana.panel.set({
-            sections: [
-              { kind: "status", id: "dshana-status", label: "DSHana", value: st.word, delta: st.delta, deltaTone: st.tone },
-            ],
-            refresh: { intervalMs: 30000 },
-          }).catch(function () { /* 面板不可用静默降级 */ });
-        } catch (err) { /* 面板不可用静默降级 */ }
-      }
       // 监听 dsh iframe（跨源）发来的复制请求 → 宿主能力 → 回执
       window.addEventListener("message", function (e) {
         var m = e.data;
@@ -622,7 +590,6 @@
           clearClocks();
           clearReadyTimer();
           if (!readyReceived) { mountReady(); }
-          pushPanel();
           return;
         }
         readyReceived = false; // 非 ready 快照：撤销就绪标志，使后续 ready 恢复时能完整走 mountReady（data-view 恢复 + attach）
@@ -637,7 +604,6 @@
         else stopInstallTick();
         startRetryClock();
         armFallbackTimer();
-        pushPanel();
       }
       var bootRefreshing = false; // 快照拉取防并发（事件风暴/安装 tick/兜底共用）
       function refreshBoot() {
@@ -676,7 +642,6 @@
           frame.src = "http://127.0.0.1:{{= it.port }}/";
         }
         startThemePush();
-        pushPanel();
       }
       // ---- 事件流（/webui/events，SSE 式 chunked）----
       var streamAbort = null;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -71,8 +71,9 @@
         "siteNavEntry": true,
         "fpFullPanel": true,
         "functionPanel": {
-          "id": "dshana-panel",
-          "label": "DSHana"
+          "id": "dshana-sidebar",
+          "label": "DSHana",
+          "embedUrl": "http://127.0.0.1:3080/?dshana-view=sidebar"
         }
       }
     ]


### PR DESCRIPTION
## 概述

fpFullPanel V2（spec：`specs/current/dshana-v2-fpfullpanel/view-layouts.md` 拆解）：**sidebar 视图 + fp 嵌入**。`?dshana-view=sidebar` → 新的 `SidebarOnlyFrame` root 帧（单列容器 + 容器宽实测 → 渲染官方 SidebarRoot），manifest `functionPanel.embedUrl` 指向该视图。零 vendor 增量（sidebar 槽 occupant 机制：ui-sidebar 官方 bundle 自注册 SidebarRoot）。

## 改动清单

**新增**
- `src-cordis/plugins/view/SidebarOnlyFrame.tsx`：sidebar 视图 root 帧——单列容器占满 fp iframe，ResizeObserver（rAF 节流）实测容器宽 → `renderSlot('sidebar', { collapsed: false, width })` 直通官方 SidebarRoot 列宽；collapsed 恒 false（fp 面板无 rail 折叠语义）
- `src-cordis/plugins/view/SidebarOnlyFrame.module.css`：`.frame` 高 100% + overflow hidden（滚动由 SidebarRoot 内嵌区自理）

**修改**
- `src-cordis/plugins/view/client.js`：`frameForView` 补 SIDEBAR 分支 → SidebarOnlyFrame + children 收窄 `{ sidebar }`（declaring is claiming：conversation/details/shell.overlay 不声明 → 其 occupant 不挂载）；readView sidebar 不再回退 full
- `src/manifest.json`：`functionPanel` 加 `embedUrl: http://127.0.0.1:3080/?dshana-view=sidebar`；`id` 定名 `dshana-sidebar`

**机制要点（已查证）**：sidebar 槽是 layout-owned occupant——官方 ui-sidebar `slots.register({name:'sidebar'}, SidebarRoot)`，AppFrame 用 `renderSlot('sidebar', {collapsed, width})` 渲染；ui-sidebar roster 照留（含 primitives 内联），故 V2 不需要 vendor ui-sidebar/primitives。

## 验证记录

- **构建**：全量 build 绿（build:src + build:cordis），dist/cordis/view/client.js 11,613B 含 SidebarOnlyFrame（dv_frame css 注入 + ResizeObserver + dshana-view 分支）
- **schema 核对**：`specs/reference/cards-schema-0.817.86.md`（新增，0.817.86 cards 校验器实读）——dshana 卡 14 字段白名单全过；`functionPanel.embedUrl` 经 Oce loopback 校验合法（http + 127.0.0.1 + 无 userinfo；path/query 允许）
- **sidebar 视图**：浏览器直开 `http://127.0.0.1:3080/?dshana-view=sidebar` 渲染有效
- **宿主 fpFullPanel 未生效（宿主侧问题，如实记录）**：dsh-hanako 装 v1 插件目录、宿主走 v1 plugin-manager 加载（日志佐证），`fpFullPanel/functionPanel.embedUrl` 属 v2 apps 体系——宿主 FP 面板显示「等待应用推送内容」（未走 embedUrl iframe 渲染）。embedUrl 声明 schema 合法、无校验 warn，疑似宿主 v1/v2 装载分流问题，待宿主支持或插件迁移 v2 apps 装载后生效。非本 PR 代码缺陷。

## 已知限制（记录，不预实现）

- settings modal（sidebar.settings occupant）1080x700 在窄 iframe 内溢出 → 跨边联动属 V4
- SidebarRoot rail toggle 无视觉效果（collapsed 恒 false，不读 store 几何）
- main 视图（V3）未做，`?dshana-view=main` 回退完整视图
- embedUrl 静态端口 3080（宿主约束：manifest 静态字段，改 webPort 需同步改声明）

## 壳页面板推送退役（同分支第二 commit 8dd8631）

- fpFullPanel 方向下宿主 FP 由 functionPanel.embedUrl 占据，壳页 hana.panel.set 的 DSHana status 推送（旧诊断壳遗留）整体删除：hana 桥 panel.set、panelStatusView/pushPanel 定义 + 三处调用点全清
- hana 桥 api.fetch（壳页 boot-state/events 数据面）保留不受影响


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a sidebar-only view with responsive sizing and full-height layout.
  - Cards can now open the DSHana sidebar directly through the embedded sidebar view.
  - Full and sidebar view modes are supported.

- **Bug Fixes**
  - Improved sidebar sizing updates when the container changes dimensions.

- **Limitations**
  - Main view selection is not yet available and falls back to the full view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->