### PR TITLE
feat(view): fpFullPanel V3 main 真无侧栏——自组 MainFrame 减法式

### DIFF
--- a/src-cordis/plugins/view/MainFrame.tsx
+++ b/src-cordis/plugins/view/MainFrame.tsx
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2026 Nyasers
+//
+// MainFrame —— main 视图（?dshana-view=main）的 root 帧组件（fpFullPanel V3 修正）。
+//
+// 角色：main = 无侧栏「主页」视图（V4 联动协议的宿主主页端）。V3 旧版（16293c5）以官方
+// AppFrame + createMainLayoutStore(init sidebar:0) 实现——实机验证发现官方
+// panels.sidebar=0 的语义是 **56px rail 折叠态**（SidebarRoot 仍在，可展开 280），并非
+// 「隐藏 sidebar」。用户裁定：main 要**真无侧栏**（无 rail、无 SidebarRoot）——按
+// SidebarOnlyFrame（8ee74f6）同款减法式自组本帧：.dv_frame 只留
+// .dv_centerCol + .dv_detailsCol，.sidebarCol 及其整条渲染链从结构上减除。
+//
+// 减法式结构（同 SidebarOnlyFrame 模式）：复用官方 AppFrame 的列上下文 CSS（import
+// vendor/AppFrame.module.css；同 bundle 幂等注入，full/main/sidebar 引用同一 vendor css
+// 不重复注 style）。DOM = .frame（inline gridTemplateColumns 两列）> (.centerCol >
+// conversation 槽) + (.detailsCol > SessionProvider > details 槽)；shell.overlay 槽照常
+// 在 frame 内 overlayLayer 渲染（AppFrame 同构）。sidebar 槽由 client.js MAIN_CHILDREN
+// **不声明**（declaring is claiming）→ ui-sidebar occupant 不注册不挂载，SidebarRoot 与
+// rail 图标条不存在；本帧也不 import ui-sidebar/primitives 源码。
+//
+// 几何（两列自解，不用官方三列 computeColumns——其解含 sidebar 列，sidebar=0 也会解出
+// SIDEBAR_COLLAPSED 56px rail 占宽，不可用；窄视口折叠语义 SIDEBAR_AUTO_COLLAPSE 属
+// sidebar，main 无 sidebar 故整体去掉）：
+//   details 开 = 存在当前会话（useSessions current 且 blank!==false）且 panels.details>0
+//     → details = clampWidth(panels.details, DETAILS_MIN 300, DETAILS_MAX 520)，
+//     center = minmax(0,1fr) 吸收余宽（下限 0）；
+//   details 关 = 0 宽（detailsCol 零宽保挂载不卸载，.frame[data-details-collapsed] 去
+//     1px seam 边框，同官方）；center 全宽。
+//
+// 保留的官方渲染链（自 vendor AppFrame.tsx 减法复制；AppFrame 保留原样供 full 视图用）：
+//   details 会话感知（detailsSession 判定 + 会话切换 actions.closeDetails）、viewport
+//   框级自测（ResizeObserver + rAF）、DocumentTitle 投影（productTitle + 会话标题）、
+//   details 拖拽 handle（.handle side=details：pointer capture + rAF 节流 dx）与
+//   data-dragging 过渡暂停、overlay 层。sidebar 相关（sidebar 槽渲染、sidebar 拖拽
+//   handle、narrow/setNarrow/rail 折叠、data-sidebar-collapsed）全部减除。
+//   复制片段来自 MIT 上游（deepseek-ai/deepseek-harness，dsh-v0.1.2-rc.1，见
+//   vendor/README.md 来源与许可）。
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import type { ReactNode } from 'react'
+import type {
+  PropsLocale, PropsRenderSlots, PropsRuntime, PropsStore,
+} from '@deepseek-ai/dsh-client-ui-slots'
+import { clampWidth, DETAILS_MAX, DETAILS_MIN } from './vendor/columns.ts'
+import { DocumentTitle } from './vendor/DocumentTitle.tsx'
+import type { createLayoutStore } from './vendor/stores.ts'
+import css from './vendor/AppFrame.module.css'
+
+/** Full composed props: runtime share + child-slot render share + store share
+ * （与官方 AppFrame 同源框架 shares；子槽并集不含 sidebar——main 无 sidebar 渲染点）。 */
+export type MainFrameProps =
+  & PropsRuntime<'root'>
+  & PropsRenderSlots<'conversation' | 'details' | 'shell.overlay'>
+  & PropsStore<ReturnType<typeof createLayoutStore>>
+  & PropsLocale<'common'>
+
+/** Center column grid item（官方同构）。 */
+function CenterColumn(props: { children?: ReactNode }) {
+  return <div className={css.centerCol}>{props.children}</div>
+}
+
+/** Details column grid item; width 0 keeps the subtree mounted (never unmount on close)。 */
+function DetailsColumn(props: { children?: ReactNode }) {
+  return <div className={css.detailsCol}>{props.children}</div>
+}
+
+/** 拖拽 handle：官方 DragHandle 减法复制（side 仅 details 使用；pointer capture +
+ * rAF-throttled dx，side 键控 hover-reveal CSS 归属列）。 */
+function DragHandle(props: { side: 'details'; left: number; onStart: () => void; onDrag: (dx: number) => void; onEnd: () => void }) {
+  const [dragging, setDragging] = useState(false)
+  const origin = useRef(0)
+  const latest = useRef(0)
+  const frame = useRef<number | null>(null)
+  const callbacks = useRef({ onStart: props.onStart, onDrag: props.onDrag, onEnd: props.onEnd })
+  callbacks.current = { onStart: props.onStart, onDrag: props.onDrag, onEnd: props.onEnd }
+
+  const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    e.currentTarget.setPointerCapture(e.pointerId)
+    origin.current = e.clientX
+    latest.current = e.clientX
+    callbacks.current.onStart()
+    setDragging(true)
+  }, [])
+  const onPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!e.currentTarget.hasPointerCapture(e.pointerId)) return
+    latest.current = e.clientX
+    frame.current ??= requestAnimationFrame(() => {
+      frame.current = null
+      callbacks.current.onDrag(latest.current - origin.current)
+    })
+  }, [])
+  const onPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!e.currentTarget.hasPointerCapture(e.pointerId)) return
+    e.currentTarget.releasePointerCapture(e.pointerId)
+    if (frame.current !== null) { cancelAnimationFrame(frame.current); frame.current = null }
+    callbacks.current.onDrag(latest.current - origin.current)
+    setDragging(false)
+    callbacks.current.onEnd()
+  }, [])
+
+  return (
+    <div
+      className={css.handle}
+      style={{ left: props.left }}
+      data-side={props.side}
+      data-dragging={dragging || undefined}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+    />
+  )
+}
+
+/**
+ * 两列无侧栏主帧（减法式）：.frame 内只留 center/details 两列 + overlay 层，无
+ * .sidebarCol。官方三列让步链（含 SIDEBAR_COLLAPSED rail 占宽）不适用——几何自解两列
+ * （见文件头「几何」段）；窄视口折叠语义（SIDEBAR_AUTO_COLLAPSE/setNarrow）无 sidebar
+ * 故减除，不读 narrow/narrowExpanded。
+ * @param props - 框架组合 props（与官方 AppFrame 同款 destructure：useStore/useSessions/
+ *   actions/renderSlot/SessionProvider/t；register 按 root 条目注入，见 client.js）。
+ */
+export function MainFrame({
+  useStore,
+  useSessions,
+  actions,
+  renderSlot,
+  SessionProvider,
+  t,
+}: MainFrameProps) {
+  const panels = useStore(s => s)
+  // details 会话感知：当前会话存在且非 blank（同官方 AppFrame 判定）→ details 列可用。
+  const detailsSession = useSessions((s) => {
+    const current = s.current
+    return current !== undefined && s.byId[current]?.blank === false ? current : undefined
+  })
+  // 浏览器标题 = 当前会话标题（若有）投影（同官方）。
+  const documentTitle = useSessions((s) => {
+    const current = s.current
+    return current === undefined ? undefined : s.byId[current]?.title
+  })
+  const frameRef = useRef<HTMLDivElement | null>(null)
+  const [viewport, setViewport] = useState(() => window.innerWidth)
+
+  // 会话切换即收 details（同官方 useLayoutEffect 段：跨会话不残留上一会话 details 列）。
+  const lastSession = useRef(detailsSession)
+  useLayoutEffect(() => {
+    if (detailsSession === undefined) return
+    if (lastSession.current !== undefined && lastSession.current !== detailsSession) {
+      actions.closeDetails()
+    }
+    lastSession.current = detailsSession
+  }, [actions, detailsSession])
+
+  // 帧框级测量（同官方 frame 自测语义：ResizeObserver + rAF 节流 + 取边框盒宽）。
+  useEffect(() => {
+    const el = frameRef.current
+    /* v8 ignore next -- the ref is always attached by effect time: the frame div renders unconditionally. */
+    if (el === null) return
+    let raf: number | null = null
+    const observer = new ResizeObserver(() => {
+      raf ??= requestAnimationFrame(() => {
+        raf = null
+        const width = el.getBoundingClientRect().width
+        if (width > 0) setViewport(width)
+      })
+    })
+    observer.observe(el)
+    return () => {
+      observer.disconnect()
+      if (raf !== null) cancelAnimationFrame(raf)
+    }
+  }, [])
+
+  // 两列几何：details 开 = 有当前会话且 store 偏好 >0 → 偏好 clamp 进契约区间；
+  // center 轨 minmax(0,1fr) 吸收余宽（下限 0）。details 关 = 0 宽、center 全宽。
+  // 拖拽基准 = 拖动开始时的已渲染宽（被 clamp 过的列边不得回跳 store 偏好，官方同款）；
+  // 手势期间帧级过渡暂停（data-dragging → CSS transition:none）。
+  const detailsWidth = detailsSession !== undefined && panels.details > 0
+    ? clampWidth(panels.details, DETAILS_MIN, DETAILS_MAX)
+    : 0
+  const colsRef = useRef({ details: detailsWidth, viewport })
+  colsRef.current = { details: detailsWidth, viewport }
+
+  const detailsBase = useRef(0)
+  const [dragging, setDragging] = useState(false)
+  const onDragEnd = useCallback(() => { setDragging(false) }, [])
+  const onDetailsStart = useCallback(() => { detailsBase.current = colsRef.current.details; setDragging(true) }, [])
+  const onDetailsDrag = useCallback((dx: number) => {
+    actions.setDetails(detailsBase.current - dx)
+  }, [actions])
+  const productTitle = process.env.DSH_CLIENT_TITLE ?? t('brand.localBuild')
+
+  return (
+    <div
+      ref={frameRef}
+      className={css.frame}
+      style={{ gridTemplateColumns: 'minmax(0, 1fr) ' + detailsWidth + 'px' }}
+      data-details-collapsed={detailsWidth === 0 || undefined}
+      data-dragging={dragging || undefined}
+    >
+      <DocumentTitle
+        productTitle={productTitle}
+        {...documentTitle === undefined ? {} : { title: documentTitle }}
+      />
+      {/* 减法：无 .sidebarCol。conversation（session-maybe）固定 center 列位；details
+          （strict）由 SessionProvider 在无当前会话时 withheld——同官方结构。 */}
+      <CenterColumn>{renderSlot('conversation', {})}</CenterColumn>
+      <DetailsColumn>
+        <SessionProvider>{renderSlot('details', {})}</SessionProvider>
+      </DetailsColumn>
+      <div className={css.overlayLayer} data-shell-overlay>
+        {renderSlot('shell.overlay', {})}
+      </div>
+      {/* 仅 details 拖拽 handle（sidebar 无 rail/列，不存在 resize）。 */}
+      {detailsWidth > 0 && <DragHandle side="details" left={viewport - detailsWidth} onStart={onDetailsStart} onDrag={onDetailsDrag} onEnd={onDragEnd} />}
+    </div>
+  )
+}

--- a/src-cordis/plugins/view/MainFrame.tsx
+++ b/src-cordis/plugins/view/MainFrame.tsx
@@ -14,9 +14,11 @@
 // vendor/AppFrame.module.css；同 bundle 幂等注入，full/main/sidebar 引用同一 vendor css
 // 不重复注 style）。DOM = .frame（inline gridTemplateColumns 两列）> (.centerCol >
 // conversation 槽) + (.detailsCol > SessionProvider > details 槽)；shell.overlay 槽照常
-// 在 frame 内 overlayLayer 渲染（AppFrame 同构）。sidebar 槽由 client.js MAIN_CHILDREN
-// **不声明**（declaring is claiming）→ ui-sidebar occupant 不注册不挂载，SidebarRoot 与
-// rail 图标条不存在；本帧也不 import ui-sidebar/primitives 源码。
+// 在 frame 内 overlayLayer 渲染（AppFrame 同构）。sidebar 槽在 client.js MAIN_CHILDREN
+// 中**声明但本帧不渲染**（声明保 ui-sidebar 直接 register 不炸——它是 register 非 inject
+// 惰性，槽不声明会抛错致 client 链崩，实机踩过；渲染端不调 renderSlot('sidebar') →
+// occupant 挂载不渲染，SidebarRoot 与 rail 图标条不进入 DOM）；本帧也不 import
+// ui-sidebar/primitives 源码。
 //
 // 几何（两列自解，不用官方三列 computeColumns——其解含 sidebar 列，sidebar=0 也会解出
 // SIDEBAR_COLLAPSED 56px rail 占宽，不可用；窄视口折叠语义 SIDEBAR_AUTO_COLLAPSE 属
@@ -98,6 +100,16 @@ function DragHandle(props: { side: 'details'; left: number; onStart: () => void;
     callbacks.current.onEnd()
   }, [])
 
+  const onPointerCancel = useCallback(() => {
+    // pointercancel：浏览器接管手势（平移/缩放/触屏打断）——同一指针流不再有
+    // pointerup，capture 已隐式释放（onPointerUp 的 hasPointerCapture 守卫会提前
+    // return，不能复用）。cleanup 必须照跑：残留 rAF/ dragging 会把帧卡在拖拽态
+    // （data-dragging 不褪、过渡不恢复）。流的最后位置无意义，不补最后一拍 drag。
+    if (frame.current !== null) { cancelAnimationFrame(frame.current); frame.current = null }
+    setDragging(false)
+    callbacks.current.onEnd()
+  }, [])
+
   return (
     <div
       className={css.handle}
@@ -107,6 +119,7 @@ function DragHandle(props: { side: 'details'; left: number; onStart: () => void;
       onPointerDown={onPointerDown}
       onPointerMove={onPointerMove}
       onPointerUp={onPointerUp}
+      onPointerCancel={onPointerCancel}
     />
   )
 }

--- a/src-cordis/plugins/view/SidebarOnlyFrame.module.css
+++ b/src-cordis/plugins/view/SidebarOnlyFrame.module.css
@@ -1,7 +1,0 @@
-/* 单列 sidebar 帧（?dshana-view=sidebar 根容器）：占满 fp 面板 iframe viewport，
-   高 100% + overflow 兜底；sidebar 列（SidebarRoot）自带填充与内嵌滚动区。 */
-.frame {
-  height: 100%;
-  overflow: hidden;
-  background: var(--dsw-alias-bg-base);
-}

--- a/src-cordis/plugins/view/SidebarOnlyFrame.tsx
+++ b/src-cordis/plugins/view/SidebarOnlyFrame.tsx
@@ -3,12 +3,17 @@
 //
 // SidebarOnlyFrame —— sidebar 视图（?dshana-view=sidebar）的 root 帧组件。
 //
-// 角色（fpFullPanel V2）：宿主 fp 面板经 manifest functionPanel.embedUrl 把本页嵌入
-// 窄面板 iframe，本帧 = 该 iframe 内的唯一内容面（无 rail 折叠语义，collapsed 恒
-// false = 恒 wide 渲染）。单列容器占满宿主面板（高 100% / 宽自适应），容器宽经
-// ResizeObserver 实测后作为 sidebar 槽 owner geometry（{ collapsed: false, width }）
-// 传给 renderSlot('sidebar')——官方 SidebarRoot（ui-sidebar roster 条目注册进 sidebar
-// 槽，官方 bundle 自带 SidebarRoot + primitives）按该 width 渲染自身列宽。
+// 角色（fpFullPanel V2，减法式修正）：宿主 fp 面板经 manifest functionPanel.embedUrl
+// 把本页嵌入窄面板 iframe，本帧 = 该 iframe 内的唯一内容面（无 rail 折叠语义，
+// collapsed 恒 false = 恒 wide 渲染）。
+//
+// 减法式结构（相对 V2 加法式自组壳的修正）：**复用官方 AppFrame 的 frame/sidebarCol
+// 列上下文**（import vendor AppFrame.module.css）——DOM = .frame > .sidebarCol >
+// (sidebar 槽)，center/details 列从结构上减掉（“.dv_frame 里只留 .dv_sidebarCol”）。
+// SidebarRoot 因此与 full 视图的 sidebar 列同构渲染：sidebarCol 层的专属 fill 背景、
+// border-right、overflow 裁剪语义不丢失（V2 自组壳让 SidebarRoot 裸挂 frame，丢列层）。
+// .frame 为 grid（官方 gridTemplateRows:100% + overflow:hidden + base 背景），本帧单列
+// 布局以 inline gridTemplateColumns: minmax(0,1fr) 占满（子槽收窄见下）。
 //
 // 设计要点：
 //  - 不自组官方组件：本帧只声明/渲染 'sidebar' 子槽（declaring is claiming——
@@ -17,25 +22,29 @@
 //    sidebar.workspaces / sidebar.settings / sidebar.footer.action）全由 roster 里
 //    ui-sidebar / ui-workspace / ui-settings-general 的官方 bundle 自注册提供。
 //  - 不 import ui-sidebar / primitives 源码：避免把 primitives 依赖树拖进本包。
-//  - 高度/滚动语义：fp 面板高度 = iframe viewport，本帧 height:100% 撑满；纵向滚动由
-//    SidebarRoot 内嵌滚动区（ui-workspace 会话列表等）自理（开放问题 3 已解除：官方
-//    CSS 原生自适应窄宽，无渲染下限），本帧 overflow:hidden 仅兜底防溢出。
-//  - 与 AppFrame sidebar 列渲染的差异：AppFrame 经 computeColumns 让步链产出列宽并
-//    支持 56px rail 折叠态；本帧无 center/details 列可让步，列宽 = 容器实测宽直传
+//  - 高度/滚动语义：fp 面板高度 = iframe viewport，本帧 height:100% 撑满（.frame
+//    height:100% 官方既有）；纵向滚动由 SidebarRoot 内嵌滚动区（ui-workspace 会话列表
+//    等）自理（开放问题 3 已解除：官方 CSS 原生自适应窄宽，无渲染下限），.frame/.sidebarCol
+//    的 overflow:hidden 兑底防溢出。
+//  - 列宽直传：无 center/details 列可让步，列宽 = 容器实测宽直传 renderSlot
 //    （不做 SIDEBAR_MIN/MAX 截断——宿主 fp 面板宽度是唯一约束，截断会造成溢出或与
 //    容器脱节）。
 //  - 唯一交互残留：SidebarRoot 顶行 rail toggle（panel 图标）点击 → ctx.layout
 //    .toggleSidebar() 只翻转 layout store 偏好（本帧不读 store 几何，无视觉效果）。
 //
-// 已知限制（V2 如实记录，不做 V4 预实现）：
+// 已知限制（如实记录，不做 V4 预实现）：
 //  - sidebar.settings occupant（ui-settings-general）点击会弹全视口 1080x700 设置
 //    modal，在本 iframe 内必然溢出——跨边联动（modal 改在主页打开）属 V4 联动协议。
-//  - main 视图（V3）不做，?dshana-view=main 仍回退完整视图。
+//  - main 视图为 V3 修正（client.js：自组 MainFrame 减法式——.dv_frame 只留
+//    .dv_centerCol + .dv_detailsCol、无 sidebar，见 MainFrame.tsx），本帧只服务 sidebar 视图。
 import { useEffect, useRef, useState } from 'react'
-import css from './SidebarOnlyFrame.module.css'
+// 复用官方 AppFrame 的列上下文 CSS（.frame/.sidebarCol）：sidebar 视图与 full 视图的
+// sidebar 列同构渲染。同 bundle 幂等注入（css-modules 虚拟 loader 按包+文件去重，
+// full/sidebar 两视图引用同一 vendor css 不重复注 style）。
+import css from './vendor/AppFrame.module.css'
 
 /**
- * 单列 sidebar 帧：容器宽实测 → renderSlot('sidebar', { collapsed: false, width })。
+ * 单列 sidebar 帧（减法式）：.frame 内只留 .sidebarCol → renderSlot('sidebar')。
  * @param props - 框架组合 props（本帧只消费 renderSlot 子槽渲染 share）。
  */
 export function SidebarOnlyFrame(props: {
@@ -67,10 +76,13 @@ export function SidebarOnlyFrame(props: {
   }, [])
 
   return (
-    <div ref={frameRef} className={css.frame}>
-      {/* sidebar 槽渲染点：collapsed=false 恒 wide（fp 面板唯一内容面，无 rail 语义）；
-          width = 容器实测宽，直通 SidebarRoot 列宽（差异说明见文件头）。 */}
-      {props.renderSlot('sidebar', { collapsed: false, width })}
+    <div ref={frameRef} className={css.frame} style={{ gridTemplateColumns: 'minmax(0, 1fr)' }}>
+      {/* 减法：.frame 内只留官方 .sidebarCol 列（fill/边框/裁剪上下文与 full 视图 sidebar
+          列同构），center/details 列从结构上减除；sidebar 槽渲染点 collapsed 恒 false
+          （fp 面板唯一内容面，无 rail 语义），width = 容器实测宽直通 SidebarRoot。 */}
+      <div className={css.sidebarCol}>
+        {props.renderSlot('sidebar', { collapsed: false, width })}
+      </div>
     </div>
   )
 }

--- a/src-cordis/plugins/view/client.js
+++ b/src-cordis/plugins/view/client.js
@@ -3,7 +3,7 @@
 //
 // @dsh-hanako/view 前端 client 模块（装配核心）。
 //
-// 角色（fpFullPanel V1→V2）：替代官方 ui-layout 的「root 装配者」。官方 ui-layout 从
+// 角色（fpFullPanel V1→V3）：替代官方 ui-layout 的「root 装配者」。官方 ui-layout 从
 // cordis.patch.yml roster 移除（其 AppFrame 不再抢 root），本插件接管同一套装配：
 //   inject = ['slots', 'theme', 'locale']（与官方 ui-layout client/index.ts 完全一致——
 //   slots=内置槽注册、theme=ui-theme 服务（ThemePresenter 数据源）、locale=ui-locale 服务）
@@ -13,14 +13,18 @@
 //        ui-layout 后必须由本插件 provide 等价服务。
 //     ② ctx.slots.register(root 条目, <视图组件>)——root 槽 single 语义先注册 wins，
 //        ui-layout 移除后本插件是唯一 root 注册方；register 同携四/单子槽声明 +
-//        store（createLayoutStore）+ inject 钩子 attachPanels（开放问题 2 结论）。
+//        store（视图共用官方 createLayoutStore——main 无 sidebar 几何消费面后不再需要
+//        初始态覆写，createMainLayoutStore 退役，见下）+ inject 钩子 attachPanels
+//        （开放问题 2 结论）。
 //     ③ ctx.effect(ThemePresenter)——主题快照投影 document（同官方第二 effect）。
 //   视图矩阵（frameForView 选型；URL 参数 ?dshana-view=<view>，无参 = full）：
 //     full    = 官方 AppFrame（四子槽，官方等价；无参主页面默认）
+//     main    = 自组 MainFrame（V3 修正，减法式——.dv_frame 只留 .dv_centerCol +
+//               .dv_detailsCol，无 .sidebarCol；修正 16293c5「AppFrame + sidebar:0」=
+//               rail 56 折叠态而非隐藏，见 MainFrame.tsx 文件头与下）
 //     sidebar = SidebarOnlyFrame（V2：fp 面板 embedUrl 纯侧栏——单列容器 + 仅 sidebar
 //               子槽；SidebarRoot/workspaces/settings 子槽 occupant 走 roster 官方
 //               bundle，详见 SidebarOnlyFrame.tsx 文件头）
-//     main    = V3 未实现，回退 full（warn）
 //   V2 边界如实记录（不做 V4 预实现，见 SidebarOnlyFrame.tsx「已知限制」）：
 //     sidebar.settings modal（1080x700）在本 iframe 内溢出 → 跨边联动属 V4；
 //     SidebarRoot rail toggle 只翻转 layout store 偏好（本帧不读 store 几何），无视觉效果；
@@ -61,16 +65,18 @@
 
 import { AppFrame } from "./vendor/AppFrame.tsx";
 import { SidebarOnlyFrame } from "./SidebarOnlyFrame.tsx";
+import { MainFrame } from "./MainFrame.tsx";
 import { createLayoutStore } from "./vendor/stores.ts";
 import { LayoutController } from "./vendor/service.ts";
 import { ThemePresenter } from "./vendor/theme-presenter.ts";
 
-// ---- view 参数读取（URL 三态路由；V2 已实现 full/sidebar，main 回退 full）----
+// ---- view 参数读取（URL 三态路由；V3 三态齐：full/main/sidebar）----
 // 官方 boot 不管 query，本插件直接读 location.search 的 ?dshana-view=<view>；
 // 无参 = 完整三列视图（主页面默认，等价官方 ui-layout 激活态）；
+// main = 无侧栏主视图（V3 修正：MainFrame 减法式——center + details 两列，真无 sidebar）；
 // sidebar = 纯侧栏视图（V2，manifest functionPanel.embedUrl 指向本页带该参数）。
 const FULL = "full";
-const MAIN = "main"; // V3（无侧栏主视图，本期回退 full）
+const MAIN = "main"; // V3 修正（真无侧栏主视图：MainFrame，结构无 sidebar 列/槽）
 const SIDEBAR = "sidebar"; // V2（fp 面板 embedUrl 纯侧栏）
 
 function readView() {
@@ -89,11 +95,11 @@ function readView() {
 }
 
 // root 条目的子槽声明。FULL = 官方 ui-layout client/index.ts 逐字四子槽（frame 的
-// 排他渲染权威）；SIDEBAR 只声明 sidebar——declaring is claiming：conversation/details/
-// shell.overlay 不声明则其 ui-* occupant（ui-conversation/ui-chat 等，经 slots.inject
-// 等待声明生命周期）子树不注册不挂载；数据/服务面（sessions/workspaces 等）是 service
-// 不依赖槽，照常激活。sidebar 槽内部子槽（brand/workspaces/settings/footer.action）由
-// occupant（ui-sidebar）自身的 register 声明，不受本表收窄影响。
+// 排他渲染权威）；MAIN（无侧栏主视图）与 FULL 差一子槽——不含 sidebar；SIDEBAR 只声明
+// sidebar。declaring is claiming：未声明的槽其 ui-* occupant（ui-sidebar 等，经
+// slots.inject 等待声明生命周期）子树不注册不挂载；数据/服务面（sessions/workspaces
+// 等）是 service 不依赖槽，照常激活。sidebar 槽内部子槽（brand/workspaces/settings/
+// footer.action）由 occupant（ui-sidebar）自身的 register 声明，不受本表收窄影响。
 const FULL_CHILDREN = {
   sidebar: { kind: "single", scope: "root" },
   conversation: { kind: "single", scope: "session-maybe" },
@@ -104,14 +110,35 @@ const SIDEBAR_CHILDREN = {
   sidebar: { kind: "single", scope: "root" },
 };
 
-// 视图 → root 组件装配选择。
-//   - full：官方 AppFrame（等价官方 ui-layout 激活）
-//   - sidebar（V2）：SidebarOnlyFrame（单列容器 + 官方 SidebarRoot 经 sidebar 槽渲染）
-//   - main：V3 未实现 → 回退 AppFrame 完整视图（warn，行为安全）
+// main 视图子槽声明：conversation/details/shell.overlay + **sidebar**（scope 与 FULL 同）。
+// sidebar 槽必须声明：ui-sidebar 是**直接 register**（非 ui-chat 那种 inject 惰性）——
+// 槽不声明则其 slots.register('sidebar') 抛错、整个 client 链加载失败（实机踩过）。
+// 渲染端为自组 MainFrame（减法式，.frame 只留 center/details 列），**不调
+// renderSlot('sidebar')** → ui-sidebar occupant 挂载但从不渲染，SidebarRoot/rail 图标
+// 条不进入 DOM（声明保注册、渲染决定有无）。
+const MAIN_CHILDREN = {
+  sidebar: { kind: "single", scope: "root" },
+  conversation: { kind: "single", scope: "session-maybe" },
+  details: { kind: "single", scope: "session" },
+  "shell.overlay": { kind: "list", scope: "root" },
+};
+
+// createMainLayoutStore 退役（V3 修正动因——rail ≠ 隐藏）：16293c5 曾用官方 AppFrame +
+// init sidebar:0 的 createMainLayoutStore 实现 main，实机验证官方 panels.sidebar=0 语义
+// = **56px rail 折叠态**（computeColumns 解出 SIDEBAR_COLLAPSED 56，SidebarRoot 仍在、
+// 可展开 280），不是「隐藏 sidebar」。修正后 main 用自组 MainFrame：.frame 结构上无
+// sidebar 列/槽（sidebar 槽不声明 → occupant 不挂载），store 无 sidebar 几何消费面——
+// 回归官方 createLayoutStore 即可（details 初始 0 官方默认，open/close 语义照旧）。
+
+// 视图 → root 装配选择：{ component, children, store }（store = 该视图 root 条目的排他
+// store 工厂，三视图同用官方 createLayoutStore；children = 子槽声明，declaring is
+// claiming 保 register 不炸）。full = 官方 AppFrame 四子槽；main = 自组 MainFrame +
+// 四子槽声明（sidebar 声明保 ui-sidebar register，渲染端不调 renderSlot('sidebar') →
+// 无 rail DOM）；sidebar（V2）= SidebarOnlyFrame + 仅 sidebar 子槽。
 function frameForView(view) {
-  if (view === FULL) return { component: AppFrame, children: FULL_CHILDREN };
-  if (view === SIDEBAR) return { component: SidebarOnlyFrame, children: SIDEBAR_CHILDREN };
-  return { component: AppFrame, children: FULL_CHILDREN }; // V3 main 回退：完整视图兜底
+  if (view === FULL) return { component: AppFrame, children: FULL_CHILDREN, store: createLayoutStore }
+  if (view === MAIN) return { component: MainFrame, children: MAIN_CHILDREN, store: createLayoutStore }
+  return { component: SidebarOnlyFrame, children: SIDEBAR_CHILDREN, store: createLayoutStore }
 }
 
 // ---- 客户端服务注入：slots（root 注册）+ theme（ThemePresenter 快照）+ locale（t）----
@@ -120,24 +147,15 @@ function frameForView(view) {
 const inject = ["slots", "theme", "locale"];
 
 /**
- * 客户端插件主体：provide layout 服务 + 注册 root（按视图选型帧：full=AppFrame、
- * sidebar=SidebarOnlyFrame）+ theme DOM 投影。
+ * 客户端插件主体：provide layout 服务 + 注册 root（按视图选型帧：full=AppFrame（官方
+ * 四子槽）、main=MainFrame（减法式两列无侧栏）、sidebar=SidebarOnlyFrame（单列）；store
+ * 三视图共用官方 createLayoutStore）+ theme DOM 投影。
  * @param ctx - 客户端根 context。
  */
 function apply(ctx) {
   const view = readView();
   const layout = new LayoutController();
-  const { component: RootView, children } = frameForView(view);
-  if (view === MAIN) {
-    // V3 未实现 main 视图：回退完整视图（行为 = 官方等价），实机无感。
-    try {
-      console.warn(
-        "[@dsh-hanako/view] dshana-view=main 尚未实现（V2 含 full/sidebar），本次回退官方完整视图",
-      );
-    } catch {
-      /* 日志失败不阻断 */
-    }
-  }
+  const { component: RootView, children, store } = frameForView(view);
 
   // effect 1：layout 服务 + root 注册（open question 2 结论的 ①②③ 一个 register 全给：
   // provide 用 ctx.reflect（官方同款），register 携 children/store/inject-钩子 attachPanels）。
@@ -148,9 +166,10 @@ function apply(ctx) {
         name: "root",
         locale: "common",
         children,
-        // 排他 store 席位：工厂本身（框架按条目实例化，AppFrame 经 useStore/actions 标准
-        // props 拿实例）——与官方 register 同语义（stores.ts 工厂）。
-        store: createLayoutStore,
+        // 排他 store 席位：官方 createLayoutStore 工厂（三视图同用，frameForView 携带）。
+        // 框架按条目铸 handle 并实例化，帧组件经 useStore/actions 标准 props 拿实例——
+        // 与官方 register 同语义（stores.ts 工厂）。
+        store,
         // 钩子唯一副作用 = 把 root store 的 bound actions 接给 ctx.layout 门面（官方
         // attachPanels 语义；会话/业务动作属各占位者，不在此接）。
         inject: (actions) => {


### PR DESCRIPTION
## 概述

fpFullPanel V3（spec：`specs/current/dshana-v2-fpfullpanel/view-layouts.md`）：**main 视图（真无侧栏主页）**。`?dshana-view=main` → 自组 `MainFrame` 减法式帧（`.dv_frame` 只留 center/details 列，无 sidebar 列/rail）。至此 URL 三态齐：full（官方 AppFrame）/ main（无侧栏主页）/ sidebar（纯侧栏）。

## 演进修正动因（rail ≠ 隐藏）

初版用官方 AppFrame + `createMainLayoutStore`（init `sidebar:0`）实现 main，实机验证发现官方 `panels.sidebar=0` 语义 = **56px rail 折叠态**（`computeColumns` 解出 `SIDEBAR_COLLAPSED 56`，SidebarRoot 仍在、可展开 280），不是「隐藏 sidebar」。修正为自组 MainFrame 减法式——与 SidebarOnlyFrame 同设计语言：**DOM 结构上减除 sidebar 列**。

## 改动清单

**新增**
- `src-cordis/plugins/view/MainFrame.tsx`（~260 行）：main 视图减法式帧——复用 vendor `AppFrame.module.css` 的 `.frame/.centerCol/.detailsCol/.overlayLayer/.handle`（幂等注入）；DOM = `.frame > .centerCol + .detailsCol`，无 `.sidebarCol`；保留官方渲染链不缩水：details 会话感知（`useSessions` + 会话切换 `actions.closeDetails`）、viewport ResizeObserver 框级自测、DocumentTitle 投影、`shell.overlay` 层、details 拖拽 handle

**修改**
- `src-cordis/plugins/view/client.js`：MAIN 分支 → `MainFrame` + 四子槽声明（含 sidebar——**ui-sidebar 是直接 register 非 inject 惰性**，槽不声明其 register 抛错致整个 client 链加载失败，实机踩过；渲染端 MainFrame 不调 `renderSlot('sidebar')` → occupant 挂载不渲染，无 rail DOM）；`createMainLayoutStore` 退役（无 sidebar 几何消费面，store 回归官方 `createLayoutStore`）；注释全面同步
- `src-cordis/plugins/view/SidebarOnlyFrame.tsx` + 删 `SidebarOnlyFrame.module.css`：同步减法式修正——`.dv_frame` 只留 `.dv_sidebarCol`（复用 vendor CSS，sidebarCol 层 fill/边框/裁剪语义不丢）

**零改动**：vendor/*（AppFrame.tsx/columns.ts/stores.ts/module.css 逐字保留，full 视图继续用官方 AppFrame）

## 两列几何

details 开（detailsSession 且 `panels.details>0`）= `clampWidth(pref, 300, 520)`，center `minmax(0,1fr)` 吸收余宽；关 = 0 宽（零宽保挂载 + `data-details-collapsed` 去 seam）。不用官方 `computeColumns`（其解含 sidebar 列，`sidebar=0` 也解出 56 rail 占宽——正是本次修正的语义）。

## 验证记录

- **构建**：build:cordis 全绿；产物 13.8KB——含 `dv_centerCol/dv_detailsCol/dv_handle/dv_overlayLayer`、无 `sidebar:0` 旧覆写、无「尚未实现/回退」warn
- **实机**：浏览器直开 `/?dshana-view=main`——center（会话/输入区）全宽渲染，**全程无 rail/SidebarRoot 痕迹**（截图核对）；`/?dshana-view=sidebar` 减法式正常（fill/边框恢复）；full 无参等价未回归
- **机制修正实证**：children 不含 sidebar 槽 → ui-sidebar register 抛错 client 链崩（修复前截图）；含声明 + 不渲染 → 正常

## 边界

- main 是 V4 联动协议的「主页」端，本期只做视图本身（BroadcastChannel 联动 V4）
- details 会话切换 closeDetails、拖拽等行为对齐官方 AppFrame details 部分


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated main view with conversation and details panels.
  - Details panels can be resized and remain available when reopened.
  - The document title now reflects the current session and product.
  - Added support for selecting full, main, and sidebar-only views.

- **Improvements**
  - Updated the sidebar-only view for more consistent layout behavior and improved overflow handling.
  - Details automatically close when switching sessions.
  - Improved resize interaction cleanup for interrupted pointer gestures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->