### PR TITLE
feat(view): fpFullPanel V4 跨边联动——BroadcastChannel 选中态桥

### DIFF
--- a/src-cordis/plugins/view/SidebarOnlyFrame.tsx
+++ b/src-cordis/plugins/view/SidebarOnlyFrame.tsx
@@ -32,9 +32,14 @@
 //  - 唯一交互残留：SidebarRoot 顶行 rail toggle（panel 图标）点击 → ctx.layout
 //    .toggleSidebar() 只翻转 layout store 偏好（本帧不读 store 几何，无视觉效果）。
 //
-// 已知限制（如实记录，不做 V4 预实现）：
-//  - sidebar.settings occupant（ui-settings-general）点击会弹全视口 1080x700 设置
-//    modal，在本 iframe 内必然溢出——跨边联动（modal 改在主页打开）属 V4 联动协议。
+// 已知限制（如实记录）：
+//  - V4 联动协议落地后（client.js effect 3 + sync-bridge.js）：sidebar 视图的会话选中经
+//    BroadcastChannel 与 main 主页跨边同步（双向 select/clear/握手）；会话增删/重命名/
+//    workspace 列表走 dsh 数据面天然一致，不走桥。
+//  - sidebar.settings occupant（ui-settings-general）的 trigger → 1080x700 modal 打开是
+//    SettingsRoot 组件内本地态，官方无可编程 open/关闭面、main 视图无其宿主（无侧栏）、
+//    槽规则封死干净拦截面——V4 调研结论 = 跨边不可行（待上游支持），本地弹出溢出保持
+//    现状并记录（见 sync-bridge.js 头「settings 跨边」段）。
 //  - main 视图为 V3 修正（client.js：自组 MainFrame 减法式——.dv_frame 只留
 //    .dv_centerCol + .dv_detailsCol、无 sidebar，见 MainFrame.tsx），本帧只服务 sidebar 视图。
 import { useEffect, useRef, useState } from 'react'

--- a/src-cordis/plugins/view/client.js
+++ b/src-cordis/plugins/view/client.js
@@ -25,8 +25,13 @@
 //     sidebar = SidebarOnlyFrame（V2：fp 面板 embedUrl 纯侧栏——单列容器 + 仅 sidebar
 //               子槽；SidebarRoot/workspaces/settings 子槽 occupant 走 roster 官方
 //               bundle，详见 SidebarOnlyFrame.tsx 文件头）
-//   V2 边界如实记录（不做 V4 预实现，见 SidebarOnlyFrame.tsx「已知限制」）：
-//     sidebar.settings modal（1080x700）在本 iframe 内溢出 → 跨边联动属 V4；
+//   联动（V4 跨边联动协议，见 sync-bridge.js 文件头——实现/时序/防回环记录全在那里）：
+//     effect 3 选中态桥：仅 main/sidebar 视图激活（inject 'sessions' 拿 ClientSessions，
+//     订阅其 list store current + BroadcastChannel 'dshana.sync'；握手 boot:true / isRemote
+//     静默 / pending 补开 / clear 双向，见 sync-bridge.js）。full 不参与桥。
+//     settings 跨边（open-settings）：官方 bundle 无干净拦截面（调研结论：不可行，待上游
+//     支持），V4 不落地其拦截，详见 sync-bridge.js 头「settings 跨边」段与交付 2。
+//   V2 边界如实记录：
 //     SidebarRoot rail toggle 只翻转 layout store 偏好（本帧不读 store 几何），无视觉效果；
 //     sidebar 无 rail 折叠语义（collapsed 恒 false）。
 //
@@ -67,6 +72,7 @@ import { AppFrame } from "./vendor/AppFrame.tsx";
 import { SidebarOnlyFrame } from "./SidebarOnlyFrame.tsx";
 import { MainFrame } from "./MainFrame.tsx";
 import { createLayoutStore } from "./vendor/stores.ts";
+import { createSessionSyncBridge } from "./sync-bridge.js";
 import { LayoutController } from "./vendor/service.ts";
 import { ThemePresenter } from "./vendor/theme-presenter.ts";
 
@@ -142,9 +148,11 @@ function frameForView(view) {
 }
 
 // ---- 客户端服务注入：slots（root 注册）+ theme（ThemePresenter 快照）+ locale（t）----
-// 与官方 ui-layout client/index.ts 相同；package.json dsh.client.inject 依官方 ui-layout
-// 的依赖方声明（locale/ui-renderer/ui-session/ui-theme，行到达序见 module graph edges）。
-const inject = ["slots", "theme", "locale"];
+// + sessions（V4 跨边联动桥数据源：ctx.sessions.list current 订阅，见 sync-bridge.js 挂载
+// 点选型 B；官方 ui-session 同款经 inject 'sessions' 拿 ClientSessions 实例——provider 为
+// api-session-controller client，行到达序见 module graph edges）。
+// 与官方 ui-layout client/index.ts 相同的部分：slots/theme/locale。
+const inject = ["slots", "theme", "locale", "sessions"];
 
 /**
  * 客户端插件主体：provide layout 服务 + 注册 root（按视图选型帧：full=AppFrame（官方
@@ -199,6 +207,15 @@ function apply(ctx) {
       presenter.dispose();
     };
   }, "@dsh-hanako/view: theme presenter");
+
+  // effect 3（V4 跨边联动协议）：选中态桥。仅 main/sidebar 视图激活（readView 结果判定——
+  // 无参 full = 官方等价形态不参与桥，见 sync-bridge.js 文件头）；subscribe ctx.sessions.list
+  // current + BroadcastChannel 广播/接收（握手/防回环/clear/pending 全在 sync-bridge.js）。
+  // settings 跨边（open-settings）：调研结论为官方 bundle 无干净拦截面（V4 不可行，待上游），
+  // 本 effect 不建 settings 分支——记录见 sync-bridge.js 头与 SidebarOnlyFrame.tsx 已知限制。
+  if (view === MAIN || view === SIDEBAR) {
+    ctx.effect(() => createSessionSyncBridge(ctx), "@dsh-hanako/view: 跨边联动桥（选中态 sync）");
+  }
 }
 
 export { apply, inject };

--- a/src-cordis/plugins/view/sync-bridge.js
+++ b/src-cordis/plugins/view/sync-bridge.js
@@ -1,0 +1,374 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2026 Nyasers
+//
+// sync-bridge.js —— @dsh-hanako/view fpFullPanel V4「跨边联动协议」的选中态桥实现。
+//
+// 目标（view-layouts.md「跨边联动协议」定稿）：同一 dsh 运行时的两个同源 3080 iframe
+// （?dshana-view=sidebar 的 fp 侧栏 与 ?dshana-view=main 的主页）跨边同步「当前选中
+// 会话」。本模块是唯一联动载体，由 client.js 按视图实例化；无参 full 视图（官方等价/
+// 宿主外调试形态）不激活桥。
+//
+// ── 同步面与状态归属（调研定稿，勿重走弯路）──
+// 会话数据（列表/增删/重命名/workspace 范围/running）是 dsh 运行时的事实源：两端都订阅
+// SessionController 事件，天然一致，不桥。只有「选中态」是纯客户端本地态（ClientSessions
+// selection store → localStorage 'dsh.sessions.current'，per-iframe 独立；服务端无选中
+// 广播），所以桥只同步选中态（view-layouts「状态归属原则」）。「新建会话」= 数据面 host
+// 建会话 + 创建方本地 sessions.open(新 id) → 走 select 桥（只建一个，桥不复制创建动作）。
+//
+// ── 挂载点选型（记录）──
+// 候选 A：包装 ClientSessions.open/clear（cordis 服务反射包装）。弃用：①需要拿到并改写
+// 服务实例方法，消费方（ui-workspace 注入的 open 回调等）早已把方法引用绑走，包装不可
+// 靠；②同 ctx 再 reflect.provide('sessions') 有 provider 冲突语义。
+// 候选 B（采用）：订阅 sessions.list store 的 current 变化（list = ClientSessions 的
+// SnapshotStore 投影，current 是事实源——useSessions 标准 hook 同一数据源；open()/clear()/
+// 启动 restore/reconnect resurface 全部经 manager → projectList → list.set 落到同一条
+// 变化流）。桥从 ctx.sessions.list 订阅（createSnapshotStore：subscribe(fn) 无参回调，
+// 侦听器自读 getSnapshot() 比对 current），本地 current 变化即广播；远端消息到来调本地
+// sessions.open(id)/sessions.clear() 应用到同一条流。状态变化单点、无服务改写。
+//
+// ── 通道与消息 ──
+// BroadcastChannel（同源 3080，零依赖）：官方 web 前端不用 BroadcastChannel，dsh-hanako
+// 现有桥（theme/clipboard）是宿主壳页 postMessage 族，均不占名。storage 事件弃用：写方
+// 不触发（localStorage 同文档不事件）且官方不监听，不如 BroadcastChannel 直接双向。
+// 协议（v:1 自校验，非本协议消息忽略）：
+//   { v: 1, type: 'select', sessionId }        —— 选中某会话
+//   { v: 1, type: 'clear' }                    —— 清空选中（无会话视图）
+//   select 消息可带 boot:true（仅「启动握手」的被动宣告，见下；真实用户动作不带）
+//
+// ── 防回环（记录）──
+// 双层：①值去重——本端只在自己 current ≠ 上次已广播值（sentValue）时广播；任何收到的
+// 冗余回声在两端都命中去重而终止。②远端应用静默化——把「远端消息引发的 open/clear」包进
+// suppressToken（isRemote 调用链标志），期间列表变化只采纳（adopt sentValue）不广播。
+// open/clear 同步路径经 manager.notifyNow 同步 flush → projectList → list.set → 本订阅
+// 回调**同步重入**（sessions/notifier.ts 已证实；list 订阅在 set 内同步回调），故 token 在
+// 动作返回时**同步清掉**即可覆盖整个回环链；异步尾（refreshSubagents 等后续同值 list.set）
+// 由值去重兜底。token 不拖到微任务——同步窗口外不应抑制独立本地动作。
+//
+// ── 启动握手（时序，记录）──
+// 两端加载时各自 localStorage 恢复各自选中（互不知晓对方）。桥激活后等待 list phase
+// 'ready'（首个 host baseline 投影），之后：
+//   · 本端有选中 → 广播一次 boot:true 的 select（被动宣告，不算 live 用户动作）；
+//   · 本端无选中 → 不广播（空态不强加给对端 clear）。
+// 握手竞态（双方同时被动宣告不同选中）：boot:true 消息在接收端仍处于被动期（本端从未
+// 做过 live 用户动作）时按「id 字典序 max-wins」采纳（两独立实例无全局时钟，字典序给一个
+// 确定性收敛；空态端直接采纳对方宣告）；一旦任一端发生过真实用户动作（live=true），此后
+// boot 宣告一律忽略（真实动作优先），一切真实消息无条件采纳——顺序真实动作 last-writer。
+// 对端已被采纳的 boot 值引发的自身变化在 suppressToken 内静默，不回弹。收敛后两端一致。
+//
+// ── 数据面瞬时态（masked gap / 删除）──
+// 列表 current 变化也可能来自数据面（当前会话被删/重连重拉瞬断）：projectList 把缺失
+// current mask 为 undefined → 本端会广播 clear，对端 applyRemote(clear)。幂等无害
+// （对端同源数据面同样走向空/回弹），后续 select 再次收敛。远端 select 目标在本端列表
+// 暂缺（如新建会话广播先于本端列表增量到达）→ pending 暂存，列表就绪且 byId 出现后补开，
+// 超时丢弃（防止为永不落地的 id 悬挂）。
+//
+// ── 已知边界（如实记录）──
+// · 子代理（subagent child）current：子会话地址（SubagentAddress）是 per-client catalog
+//   态，对端无保留地址则无法 open（ClientSessions.open → manager.select 对未知 id 抛错，
+//   本桥以 byId 成员检查 + try/catch 兜底并记录），该导航面不桥（延续 view-layouts：
+//   catalog/树浏览属各端浏览态）。需要时扩展 select 消息带地址 + 对端 catalog 加载。
+// · 无参 full 实例不参与桥（client.js readView 结果判定）；full 与 main/sidebar 并存时：
+//   main/sidebar 之间照常联动，full 的选中不向外发也不接受（full = 官方等价形态，
+//   官方语义即 per-window 独立选中，行为如实记录）。
+// · BroadcastChannel 按 origin+name 广播：127.0.0.1:3080 单 dsh 运行时内安全；同端口
+//   不可并存第二运行时（绑定冲突），跨 profile/跨端口不同源不串扰。
+//
+// ── settings 跨边（V4 设计第 4 项）调研结论（记录，详见交付 2）──
+// ui-settings-general（sidebar.settings occupant）的 trigger → modal（1080x700）打开是
+// SettingsRoot 组件内 useState 本地态，无服务/事件/store 可编程打开；shell 仅存在于
+// ui-sidebar occupant 子树内（main 视图 V3 无侧栏 → occupant 不挂载，无宿主）；槽规则
+// （ui-slots：slot key 全局限单声明者；single occupant 同 priority 二次注册抛；shadow
+// occupant 子槽声明与官方重复即抛）封死所有干净拦截面。→ V4 落地 settings 跨边不可行，
+// 记为待上游支持。本模块预留 open-settings 消息形态常量，待官方提供 root 可挂 settings
+// shell 槽位或可编程 open 服务后启用（见 OPEN_SETTINGS_MESSAGE）。
+//
+// ================== 纯核心（可 node 单测，见 tests/sync-bridge.test.mjs）==================
+
+const PENDING_TIMEOUT_MS = 10000;
+
+/**
+ * 校验并规范化当前列表快照的选中值：current 有效（在 byId 中）才有选中。
+ * @param {object} snap - sessions.list.getSnapshot() 的返回。
+ * @returns {string | undefined} 当前会话 id（masked/空 = undefined）。
+ */
+function currentOf(snap) {
+  const current = snap.current;
+  if (current === undefined || snap.byId === undefined || snap.byId[current] === undefined) return undefined;
+  return current;
+}
+
+/**
+ * 选中态桥核心：与传输/存储解耦的状态机（挂载点选型 B，见文件头）。
+ * 行为：本地 list.current 变化广播；远端 select/clear 应用到本地并静默；
+ * 启动握手（boot:true 被动宣告 + 被动期字典序 max-wins）；pending 补开。
+ * @param {object} opts
+ * @param {object} opts.list - SnapshotStore 面：{ subscribe(fn), getSnapshot() }。
+ * @param {(id: string) => void} opts.open - 本地选中（ClientSessions.open）。
+ * @param {() => void} opts.clear - 本地清空（ClientSessions.clear）。
+ * @param {(msg: object) => void} opts.post - 发送一条协议消息。
+ * @returns {{ dispose: () => void }} 销毁句柄。
+ */
+export function createSyncCore(opts) {
+  const { list, open, clear, post } = opts;
+  /** list 就绪（首个 host baseline 投影）标志。 */
+  let booted = false;
+  /** 是否发生过真实本地用户动作（此后 boot 宣告作废、真实消息无条件采纳）。 */
+  let live = false;
+  /** 是否已同步过任何值（区分「从未同步」与「同步为空」）。 */
+  let sentAnything = false;
+  /** 本端已广播/已采纳的值（undefined 也是合法值；配合 sentAnything 判「从未同步」）。 */
+  let sentValue = undefined;
+  /** isRemote 防回环 token：远端 open/clear 应用链上非空，期间列表变化只采纳不广播。 */
+  let suppressToken = null;
+  /** 远端 select 目标在本端暂缺 → pending 补开（id + 超时）。 */
+  let pendingId = undefined;
+  let pendingTimer = undefined;
+  let disposed = false;
+
+  function clearPending() {
+    if (pendingTimer !== undefined) {
+      clearTimeout(pendingTimer);
+      pendingTimer = undefined;
+    }
+    pendingId = undefined;
+  }
+
+  /** 记下本端当前事实（同步完成值），供去重与后续变化比较。 */
+  function adopt(value) {
+    sentAnything = true;
+    sentValue = value;
+  }
+
+  function postValue(value, extra) {
+    if (value === undefined) post({ v: 1, type: 'clear', ...extra });
+    else post({ v: 1, type: 'select', sessionId: value, ...extra });
+  }
+
+  /**
+   * 应用一个远端动作（isRemote 调用链）。open/clear 同步路径触发 manager
+   * notifyNow → projectList → list.set → 本订阅回调**同步重入**，在 token 下静默采纳。
+   * token 在动作返回时**同步清掉**（链是同步的；异步尾由值去重兜底——远端 open 触发的
+   * refreshSubagents 等后续 list.set 携带同一 current，命中 sentValue 去重不再广播）。
+   * 不能拖到微任务再清：会把抑制窗口延伸到同 tick 的独立本地动作（实机跨任务天然隔开，
+   * 但同步窗口内应精确限定在本次远端应用）。
+   * @param {() => void} action
+   */
+  function applyRemote(action) {
+    suppressToken = {};
+    try {
+      action();
+    } catch (error) {
+      // ClientSessions.open 对未知/未保留地址会话抛错（manager.select 校验）；桥已按
+      // byId 预检，仍可能撞 catalog 保留地址边界——忽略并如实留痕（不打断联动主链）。
+      if (typeof console !== 'undefined') {
+        console.warn('[dshana.sync] remote apply failed:', error && error.message ? error.message : error);
+      }
+    } finally {
+      suppressToken = null;
+    }
+  }
+
+  /** pending 补开：目标 id 已就绪（ready + byId 命中）才真正 open。 */
+  function maybeApplyPending() {
+    if (pendingId === undefined || disposed) return;
+    const snap = list.getSnapshot();
+    if (snap.phase !== 'ready') return;
+    if (snap.byId === undefined || snap.byId[pendingId] === undefined) return;
+    const id = pendingId;
+    clearPending();
+    applyRemote(() => open(id));
+    adopt(currentOf(list.getSnapshot())); // 以实际落定为准（open 抛错/mask 时保持真值）
+  }
+
+  /** 列表订阅回调（createSnapshotStore subscribe 无参回调，侦听器自读快照）。 */
+  function onListChanged() {
+    if (disposed) return;
+    const snap = list.getSnapshot();
+    maybeApplyPending();
+    const firstReady = !booted;
+    if (!booted) {
+      if (snap.phase !== 'ready') return;
+      booted = true;
+    }
+    const value = currentOf(snap);
+    // 值去重：与上次已同步值一致 → 不广播（含对端冗余回声终止点）。
+    if (sentAnything && value === sentValue) return;
+    if (suppressToken !== null) {
+      // isRemote 链上变化：静默采纳（对端会自行广播，本端不回弹）。
+      adopt(value);
+      return;
+    }
+    if (firstReady) {
+      // 首个 ready 投影上的值 = 持久化恢复（非用户动作），分类看 tick 而非 sentAnything：
+      // 即便此前 adopt(undefined)/pending 已置 sentAnything，也不把恢复误标成真实动作。
+      if (pendingId !== undefined) { adopt(value); return; } // 有远端 pending 待补开：不宣告
+      if (value === undefined) { adopt(value); return; } // 空态：不强加 clear
+      postValue(value, { boot: true }); // 启动握手：boot:true 被动宣告一次
+      adopt(value);
+      return;
+    }
+    // 真实本地变化（用户点击/新建进入/清空）→ live + 无条件广播。
+    live = true;
+    postValue(value);
+    adopt(value);
+  }
+
+  /** 远端消息入口（BroadcastChannel message 载荷已过 v 校验）。 */
+  function onRemoteMessage(msg) {
+    if (disposed || msg === null || typeof msg !== 'object' || msg.v !== 1) return;
+    if (msg.type === 'select') {
+      if (typeof msg.sessionId !== 'string' || msg.sessionId === '') return;
+      handleRemoteSelect(msg.sessionId, msg.boot === true);
+      return;
+    }
+    if (msg.type === 'clear') handleRemoteClear(msg.boot === true);
+  }
+
+  function handleRemoteSelect(id, boot) {
+    const snap = list.getSnapshot();
+    const ours = currentOf(snap);
+    if (boot) {
+      // 启动握手宣告：真实动作优先——本端已 live 则旧宣告作废；
+      // 被动期双宣告 → id 字典序 max-wins 确定性收敛。
+      if (live) return;
+      if (ours !== undefined && !(id > ours)) return;
+    } else if (ours === id) {
+      adopt(ours);
+      return;
+    }
+    if (snap.phase !== 'ready' || snap.byId === undefined || snap.byId[id] === undefined) {
+      // 目标暂缺（新建会话广播先于本端列表增量）：pending 补开。
+      clearPending();
+      pendingId = id;
+      pendingTimer = setTimeout(() => { clearPending(); }, PENDING_TIMEOUT_MS);
+      if (boot && ours !== undefined) adopt(ours); // 未采纳，保留本端事实
+      else if (!sentAnything) adopt(undefined); // 无既有值：pending 落定前按空态对齐
+      return;
+    }
+    applyRemote(() => open(id));
+    adopt(currentOf(list.getSnapshot())); // open 成功 = id；抛错/mask = 真值
+  }
+
+  function handleRemoteClear(boot) {
+    if (boot) return; // 握手从不发 clear（空态不强加）；防御性忽略。
+    const snap = list.getSnapshot();
+    if (currentOf(snap) === undefined) {
+      adopt(undefined);
+      return;
+    }
+    applyRemote(() => clear());
+    adopt(currentOf(list.getSnapshot()));
+  }
+
+  const off = list.subscribe(onListChanged);
+  // 启动立即评估一次：list 已 ready（本插件晚激活/热载）时不等下一次通知即握手。
+  onListChanged();
+
+  return {
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      off();
+      clearPending();
+      suppressToken = null;
+    },
+    /** 远端消息入口（浏览器载体/测试邮袋共用）。 */
+    receive: onRemoteMessage,
+    // 测试/诊断内省面（非公开 API；生产不依赖）。
+    _debug() {
+      return { booted, live, sentAnything, sentValue, pendingId };
+    },
+  };
+}
+
+// ================== 浏览器接线（@dsh-hanako/view client.js 调用）==================
+
+/** BroadcastChannel 频道名（v:1 协议内）；单 dsh 运行时同源 3080 内广播。 */
+export const SYNC_CHANNEL = 'dshana.sync';
+
+/**
+ * 实例化跨边联动桥（浏览器面接线）：订阅 ctx.sessions.list + BroadcastChannel 载体。
+ * 仅 main/sidebar 视图激活（client.js 按 readView 结果调用）；full 不建桥。
+ * @param {object} ctx - 客户端 root context（已 inject 'sessions'）。
+ * @returns {() => void} disposer。
+ */
+export function createSessionSyncBridge(ctx) {
+  const sessions = ctx.sessions;
+  if (sessions === undefined || sessions.list === undefined) {
+    // sessions 服务未就绪理论上不发生（inject 'sessions' 已等 provider）；
+    // 防御性降级 = 无联动（等同 full 视图语义），不抛。
+    return () => {};
+  }
+  const channel = createChannel();
+  if (channel === null) {
+    // 无 BroadcastChannel 环境（node e2e 等）：桥不激活。
+    return () => {};
+  }
+  const core = createSyncCore({
+    list: sessions.list,
+    open: (id) => sessions.open(id),
+    clear: () => sessions.clear(),
+    post: (msg) => channel.post(msg),
+  });
+  channel.onMessage((msg) => core.receive(msg));
+  return () => {
+    channel.close();
+    core.dispose();
+  };
+}
+
+/** BroadcastChannel 载体封装（channel 缺失/null 时静默降级）。 */
+function createChannel() {
+  if (typeof BroadcastChannel === 'undefined') return null;
+  let channel;
+  try {
+    channel = new BroadcastChannel(SYNC_CHANNEL);
+  } catch (error) {
+    return null;
+  }
+  const listeners = new Set();
+  const onMessage = (event) => {
+    for (const listener of [...listeners]) {
+      try {
+        listener(event && event.data);
+      } catch (error) {
+        // 单个侦听器失败不影响其余（官方 notifySubscribers 同款纪律）。
+        if (typeof console !== 'undefined') {
+          console.error('[dshana.sync] message listener failed:', error);
+        }
+      }
+    }
+  };
+  try {
+    channel.addEventListener('message', onMessage);
+  } catch (error) {
+    try { channel.onmessage = onMessage; } catch { /* 双保险失败则降级 */ }
+  }
+  return {
+    post(msg) {
+      try {
+        channel.postMessage(msg);
+      } catch (error) {
+        // 发送失败（极端环境）只记录——联动退化为单端本地语义。
+        if (typeof console !== 'undefined') {
+          console.warn('[dshana.sync] post failed:', error && error.message ? error.message : error);
+        }
+      }
+    },
+    onMessage(listener) {
+      listeners.add(listener);
+    },
+    close() {
+      listeners.clear();
+      try {
+        channel.removeEventListener('message', onMessage);
+      } catch { /* ignore */ }
+      try { channel.close(); } catch { /* ignore */ }
+    },
+  };
+}
+
+// ---- settings 跨边协议预留（V4 交付 2 结论：上游不可行，见模块头）----
+// 待官方提供 root 可挂 settings shell 槽位或可编程 open/close 服务后，sidebar 视图经
+// 本频道发 { v:1, type:'open-settings' }，main 视图据此打开官方 settings modal。
+export const OPEN_SETTINGS_MESSAGE = { v: 1, type: 'open-settings' };

--- a/src-cordis/plugins/view/sync-bridge.js
+++ b/src-cordis/plugins/view/sync-bridge.js
@@ -183,13 +183,17 @@ export function createSyncCore(opts) {
   /** 列表订阅回调（createSnapshotStore subscribe 无参回调，侦听器自读快照）。 */
   function onListChanged() {
     if (disposed) return;
-    const snap = list.getSnapshot();
-    maybeApplyPending();
+    // 先 gate booted（phase 判定不依赖后续快照），再 maybeApplyPending——pending 补开
+    // （远端 select 目标本端暂缺 → open）会改变 current/sentValue，之后必须重读快照，
+    // 否则 value 取自补开前的旧快照，sentValue 与真实 current 脱节（后续误标 live
+    // 广播 + 忽略 boot 致对端无法收敛）。
     const firstReady = !booted;
     if (!booted) {
-      if (snap.phase !== 'ready') return;
+      if (list.getSnapshot().phase !== 'ready') return;
       booted = true;
     }
+    maybeApplyPending();
+    const snap = list.getSnapshot();
     const value = currentOf(snap);
     // 值去重：与上次已同步值一致 → 不广播（含对端冗余回声终止点）。
     if (sentAnything && value === sentValue) return;

--- a/tests/sync-bridge.test.mjs
+++ b/tests/sync-bridge.test.mjs
@@ -212,6 +212,10 @@ test("pending 补开：远端 select 先于本端 baseline 到达 → baseline �
   deliver();
   await flush();
   assert.equal(b.current(), "late", "B 在 baseline 后补开 A 宣告的会话");
+  // 补开落定后 sentValue 必须与真实 current 对齐（CodeRabbit #70）：snap 若取自
+  // maybeApplyPending 之前会脱节——后续无关 list 通知误标 live 广播 + 忽略 boot 致
+  // 对端无法收敛。
+  assert.equal(b.core._debug().sentValue, "late", "pending 补开后 sentValue 与 current 对齐");
   a.core.dispose(); b.core.dispose();
 });
 

--- a/tests/sync-bridge.test.mjs
+++ b/tests/sync-bridge.test.mjs
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2026 Nyasers
+//
+// tests/sync-bridge.test.mjs —— fpFullPanel V4 跨边联动选中态桥（sync-bridge.js）核心
+// 态机单测。零依赖：Node 内置 node:test + node:assert（同 errclass.test.mjs 纪律——
+// 验收命令 node --test tests/ 自动发现）。
+//
+// 被测面 = createSyncCore（纯状态机，传输/存储解耦注入）：
+//   · 双向实时 select/clear 传播 + 防回环（值去重 + isRemote 静默）不震荡；
+//   · 启动握手：单端恢复宣告 / 双端分歧恢复字典序收敛（boot:true max-wins）；
+//   · live 端忽略迟到 boot 宣告（真实动作优先）；
+//   · 远端 select 目标本端暂缺 → pending 补开（列表就绪且 byId 出现后 open）；
+//   · open 抛错（catalog 未知地址兜底）不炸桥；非协议消息忽略；
+//   · 数据面删除当前会话（mask）两端一致回空后再次收敛；
+//   · dispose 停摆；无 BroadcastChannel 环境（node）接线层静默降级 noop。
+// 浏览器接线（BroadcastChannel 载体/ctx.sessions 注入）属宿主实机验证面，此处不 mock。
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  createSyncCore,
+  createSessionSyncBridge,
+  SYNC_CHANNEL,
+} from "../src-cordis/plugins/view/sync-bridge.js";
+
+/** 最小 SnapshotStore 面（模拟 createSnapshotStore 默认 sync flush：set 同步通知）。 */
+function makeSessions(initialIds = []) {
+  const byId = {};
+  for (const id of initialIds) byId[id] = { id };
+  let phase = "pending";
+  let current;
+  const listeners = new Set();
+  const list = {
+    getSnapshot: () => ({ phase, byId, current }),
+    subscribe: (fn) => {
+      listeners.add(fn);
+      return () => { listeners.delete(fn); };
+    },
+  };
+  const notify = () => { for (const fn of [...listeners]) fn(); };
+  return {
+    list,
+    /** 模拟首个 host baseline 落库（pending → ready，可携持久化恢复 current）。 */
+    ready(ids, restored) {
+      for (const id of ids) byId[id] = { id };
+      phase = "ready";
+      if (restored !== undefined && byId[restored] !== undefined) current = restored;
+      notify();
+    },
+    /** 数据面增量：会话在 host 出现（新建/恢复），与选择无关。 */
+    arrive(id) {
+      byId[id] = { id };
+      notify();
+    },
+    /** 数据面删除：行移除；若为当前会话则 current mask 回 undefined（projectList 语义）。 */
+    remove(id) {
+      delete byId[id];
+      if (current === id) { current = undefined; notify(); }
+      else notify();
+    },
+    /** 用户动作入口（真实链路 = ui 经 sessions.open 直达服务，桥只旁听 list）。 */
+    open(id) {
+      if (byId[id] === undefined) throw new Error("sessions.select: unknown session " + id);
+      current = id;
+      notify();
+    },
+    clear() {
+      current = undefined;
+      notify();
+    },
+    current() { return current; },
+    has(id) { return byId[id] !== undefined; },
+  };
+}
+
+/** 两参与者直连邮袋（同步排空 + bounded——防回环失败的震荡会被 max 拦下并断言失败）。 */
+function makePair() {
+  const bus = { a2b: [], b2a: [], posted: 0 };
+  const aS = makeSessions();
+  const bS = makeSessions();
+  const sides = {};
+  sides.a = {
+    sessions: aS,
+    posts: [],
+    remoteOpens: [],
+    remoteClears: [],
+  };
+  sides.b = {
+    sessions: bS,
+    posts: [],
+    remoteOpens: [],
+    remoteClears: [],
+  };
+  for (const name of ["a", "b"]) {
+    const side = sides[name];
+    const peer = name === "a" ? "b" : "a";
+    side.core = createSyncCore({
+      list: side.sessions.list,
+      open: (id) => { side.remoteOpens.push(id); side.sessions.open(id); },
+      clear: () => { side.remoteClears.push(1); side.sessions.clear(); },
+      post: (msg) => {
+        side.posts.push(msg);
+        bus.posted += 1;
+        bus[name + "2" + peer].push(msg);
+      },
+    });
+    side._receive = (msg) => side.core.receive(msg);
+    side.current = () => side.sessions.current();
+  }
+  /** 投递到邮袋清空（消息可级联；同步推演 + 轮次上限防震荡）。 */
+  function deliver(max = 40) {
+    let rounds = 0;
+    while ((bus.a2b.length > 0 || bus.b2a.length > 0) && rounds < max) {
+      rounds += 1;
+      while (bus.a2b.length > 0) sides.b._receive(bus.a2b.shift());
+      while (bus.b2a.length > 0) sides.a._receive(bus.b2a.shift());
+    }
+    assert.ok(bus.a2b.length === 0 && bus.b2a.length === 0,
+      "bus did not quiesce within " + max + " rounds (echo loop?)");
+  }
+  return { aS, bS, a: sides.a, b: sides.b, deliver };
+}
+
+const flush = () => new Promise((resolve) => { queueMicrotask(resolve); });
+const bootFlags = (posts) => posts.filter((m) => m.type === "select")
+  .map((m) => ({ id: m.sessionId, boot: m.boot === true }));
+
+test("实时双向：A 点会话 → B 跟随；B 切会话 → A 跟随；远端应用静默不回发", async () => {
+  const { aS, bS, a, b, deliver } = makePair();
+  aS.ready(["s1", "s2", "s3"]);
+  bS.ready(["s1", "s2", "s3"]);
+  deliver(); // 双端空态：无握手宣告
+
+  aS.open("s1"); // 用户级动作直达 sessions（真实 ui 路径）
+  deliver();
+  assert.equal(b.current(), "s1", "B 跟随 A 的选中");
+  assert.equal(a.current(), "s1", "A 保持自身选中");
+  await flush();
+
+  // B 反向切 s2：A 跟随。
+  assert.equal(a.posts.length, 1, "前段 A 只发过 select s1");
+  assert.equal(b.posts.length, 0, "前段 B 无广播（纯接收方）");
+  bS.open("s2");
+  deliver();
+  assert.equal(a.current(), "s2");
+  assert.equal(b.current(), "s2");
+  // 只有广播方（B）多发一条 select s2；接收方（A）的远端应用链静默 → 不回发（isRemote + 值去重）。
+  assert.equal(b.posts.length, 1, "B 恰好多发一条 select s2");
+  assert.equal(a.posts.length, 1, "接收方远端应用链不回发消息");
+});
+
+test("清空双向：一端 clear → 另一端清空", () => {
+  const { aS, bS, a, b, deliver } = makePair();
+  aS.ready(["s1"], "s1");
+  bS.ready(["s1"], "s1");
+  deliver(); // 同值宣告收敛
+  assert.equal(a.current(), "s1");
+  assert.equal(b.current(), "s1");
+  aS.clear();
+  deliver();
+  assert.equal(b.current(), undefined, "B 跟随 A 的 clear");
+  assert.equal(a.current(), undefined);
+});
+
+test("启动握手：单端恢复选中 → 空态端采纳；空态端不宣告 clear", () => {
+  const { aS, bS, a, b, deliver } = makePair();
+  aS.ready(["restored"], "restored");
+  assert.deepEqual(bootFlags(a.posts), [{ id: "restored", boot: true }], "A 发 boot:true 宣告");
+  bS.ready(["restored"]); // 同一运行时：两端列表同（B 只是空态无恢复）
+  assert.equal(b.posts.length, 0, "空态端不广播 clear");
+  deliver();
+  assert.equal(b.current(), "restored", "B 采纳 A 的恢复宣告");
+  a.core.dispose(); b.core.dispose();
+});
+
+test("启动握手竞态：双端不同恢复 → id 字典序 max-wins 收敛一致", () => {
+  const { aS, bS, a, b, deliver } = makePair();
+  // 同一运行时：两端列表同（都含两会话），仅持久化恢复 current 不同（交叉握手）。
+  aS.ready(["restored-a", "restored-b"], "restored-a");
+  bS.ready(["restored-a", "restored-b"], "restored-b"); // 'restored-b' > 'restored-a'
+  deliver();
+  assert.equal(a.current(), "restored-b", "双方收敛到较大 id");
+  assert.equal(b.current(), "restored-b");
+  a.core.dispose(); b.core.dispose();
+});
+
+test("真实动作优先：A live 广播覆盖被动收敛；A 忽略迟到 boot 宣告不回退", () => {
+  const { aS, bS, a, b, deliver } = makePair();
+  // 字典序 zeta > alpha：双 passive 恢复 → 收敛 zeta。
+  aS.ready(["alpha", "zeta"], "alpha");
+  bS.ready(["alpha", "zeta"], "zeta");
+  deliver();
+  assert.equal(a.current(), "zeta");
+  assert.equal(b.current(), "zeta");
+  // A 用户真实点 alpha（小于 zeta）→ 无条件传播到 B。
+  aS.open("alpha");
+  deliver();
+  assert.equal(b.current(), "alpha", "live 动作覆盖被动收敛值");
+  // A 此后忽略任何迟到 boot（含旧宣告 zeta 的回放）。
+  a._receive({ v: 1, type: "select", sessionId: "zeta", boot: true });
+  assert.equal(a.current(), "alpha", "live 端忽略迟到 boot 宣告");
+  assert.equal(b.current(), "alpha");
+  a.core.dispose(); b.core.dispose();
+});
+
+test("pending 补开：远端 select 先于本端 baseline 到达 → baseline 后补 open", async () => {
+  const { aS, bS, a, b, deliver } = makePair();
+  aS.ready(["late"], "late"); // A ready + 选中 late（宣告 boot:true 已入邮袋）
+  bS.arrive("late");          // B 数据面已有 late 行，但 phase 仍 pending
+  deliver();                  // A 的 boot 宣告到 B → B 走 pending（phase 非 ready）
+  assert.equal(b.current(), undefined, "pending 未落定前不选中");
+  bS.ready(["late"]);         // B baseline 落库
+  deliver();
+  await flush();
+  assert.equal(b.current(), "late", "B 在 baseline 后补开 A 宣告的会话");
+  a.core.dispose(); b.core.dispose();
+});
+
+test("远端 open 抛错（未知/未保留 catalog 地址兜底）不炸桥、不影响后续", () => {
+  const { aS, bS, a, b, deliver } = makePair();
+  aS.ready(["ok", "weird"], "ok");
+  bS.ready(["ok", "weird"], "ok");
+  deliver();
+  const realOpen = bS.open.bind(bS);
+  bS.open = (id) => {
+    if (id === "weird") throw new Error("sessions.select: unknown session weird");
+    realOpen(id);
+  };
+  b._receive({ v: 1, type: "select", sessionId: "weird" }); // 抛 → 核心 catch
+  b._receive({ v: 1, type: "select", sessionId: "ok" });
+  assert.equal(b.current(), "ok");
+  assert.equal(a.current(), "ok");
+});
+
+test("非协议/脏消息忽略不抛", () => {
+  const { bS, b } = makePair();
+  bS.ready(["s1"], "s1");
+  b._receive({ v: 2, type: "select", sessionId: "s1" });
+  b._receive({ type: "select", sessionId: "s1" });
+  b._receive(null);
+  b._receive("garbage");
+  b._receive({ v: 1, type: "mystery" });
+  b._receive({ v: 1, type: "select", sessionId: "" });
+  assert.equal(b.current(), "s1");
+});
+
+test("数据面删除当前会话（mask）→ 两端回空；再选 → 再次收敛", () => {
+  const { aS, bS, a, b, deliver } = makePair();
+  aS.ready(["gone", "alive"], "gone");
+  bS.ready(["gone", "alive"], "gone");
+  deliver();
+  assert.equal(a.current(), "gone");
+  assert.equal(b.current(), "gone");
+  // host 删除当前会话：两端数据面同步 remove → current mask undefined。
+  aS.remove("gone");
+  bS.remove("gone");
+  deliver();
+  assert.equal(a.current(), undefined);
+  assert.equal(b.current(), undefined);
+  aS.open("alive");
+  deliver();
+  assert.equal(b.current(), "alive");
+  assert.equal(a.current(), "alive");
+});
+
+test("dispose 停止订阅与广播", () => {
+  const { aS, bS, a, b, deliver } = makePair();
+  aS.ready(["s1"]);
+  bS.ready(["s1"]);
+  a.core.dispose();
+  const before = a.posts.length + b.posts.length;
+  aS.open("s1");
+  deliver();
+  assert.equal(a.posts.length + b.posts.length, before, "dispose 后不再广播");
+});
+
+test("接线层：ctx.sessions 缺失 → 静默降级 noop；有 sessions → 建桥并可 dispose", () => {
+  assert.equal(SYNC_CHANNEL, "dshana.sync");
+  // sessions 服务缺失：不抛、noop。
+  const disposeMissing = createSessionSyncBridge({});
+  assert.equal(typeof disposeMissing, "function");
+  disposeMissing();
+  // 有 sessions（Node 18+ 自带 BroadcastChannel 全局，真开一个 channel 验证闭环）。
+  const stubCtx = {
+    sessions: {
+      list: { subscribe: () => () => {}, getSnapshot: () => ({ phase: "ready", byId: {}, current: undefined }) },
+      open: () => {},
+      clear: () => {},
+    },
+  };
+  const dispose = createSessionSyncBridge(stubCtx);
+  assert.equal(typeof dispose, "function");
+  dispose();
+});


### PR DESCRIPTION
## 概述

fpFullPanel V4（spec：`specs/current/dshana-v2-fpfullpanel/view-layouts.md`「跨边联动协议」）：**BroadcastChannel 选中态桥**。fp sidebar 与 main 主页（两个同源 3080 iframe）跨边同步 session 选中态——通用广播（任何实例选中态变化 → 全员同步），机制不预设方向。至此 fpFullPanel 视图线（V1-V4）核心闭环。

## 改动清单

**新增**
- `src-cordis/plugins/view/sync-bridge.js`（374 行）：BroadcastChannel 桥——channel `dshana.sync`，协议 `{v:1, type:'select'|'clear'|'boot', sessionId?}`；方案/时序/边界全记录在文件头
- `tests/sync-bridge.test.mjs`（11 用例，node:test 零依赖）：双向实时 select/clear、防回环静默、单端/双端恢复握手、live 优先 + 迟到 boot 忽略、pending 补开、脏消息忽略、dispose 停摆、无 BroadcastChannel 降级

**修改**
- `src-cordis/plugins/view/client.js`：inject 加 `sessions`；effect 3 按视图激活桥（仅 sidebar/main 实例，无参 full 不参与——readView 判定）
- `src-cordis/plugins/view/SidebarOnlyFrame.tsx`：已知限制段更新为 V4 状态

## 实现要点

**挂载点选 B（订阅 list store current），弃 A（包装 open/clear）**：A 需改写服务实例方法而 ui-workspace 等早已绑走方法引用，且同 ctx 再 provide `sessions` 有 provider 冲突；B 订阅 `sessions.list`（createSnapshotStore subscribe）——open/clear/启动 restore/reconnect resurface 全部经 `manager → projectList → list.set` 同一条投影流，`list.current` 即 useSessions 事实源，一个订阅点覆盖所有选中变化路径。

**防回环双层**：① current 值去重（sentValue——冗余回声两端命中去重终止）；② isRemote 应用链同步静默（suppressToken 在远端 open/clear 同步链内静默采纳不回发）。修过微任务清 token 错误（抑制窗口拖进同 tick 独立本地动作）。

**握手**：等 list phase `ready`（首个 baseline）→ 有持久化恢复广播 `boot:true`；双恢复竞态按 id 字典序 max-wins；任一端真实用户动作（live）后无条件采纳且忽略迟到 boot。远端 select 目标本端暂缺 → pending 补开（baseline 就绪后 open，10s 超时）。

**状态归属**：会话数据单一事实源 = dsh 运行时（增删/重命名/workspace 两端经服务事件天然一致不桥）；桥只同步选中态（select/clear）；新建 = 数据面建 + 创建方 open → 走 select 桥。

## settings 跨边：不可行（调研结论，协议已预留）

ui-settings-general（`sidebar.settings` occupant）trigger → modal 是 `SettingsRoot` 内 **useState 本地态**——无服务/事件/store/URL 可编程打开；modal 宿主只存在于 ui-sidebar occupant 子树（main 无侧栏不挂载该 occupant，收到 open-settings 也无宿主可开）；槽规则封死拦截面（slot key 全局限单声明者、single occupant 二次注册抛、跨 priority shadow 与官方子槽声明冲突）。**建议上游支持**：官方为 ui-settings-general 提供可编程 open/close 服务（或 root 可声明/可渲染的 settings shell 槽位）。V4 预留 `{type:'open-settings'}` 消息与接入说明，待上游支持后落地。

## 验证记录

- **单测**：`tests/sync-bridge.test.mjs` 11/11 pass（含双向 select/clear、防回环、握手收敛、live 优先、pending 补开、脏消息、dispose、降级）
- **构建**：build:cordis 绿，产物 16.66 kB（gzip 5.33），含协议关键字 `dshana.sync`
- **实机（browser 双页）**：`/?dshana-view=sidebar` + `/?dshana-view=main` 两 tab——sidebar 点「Review findings…」→ main tab 标题与内容同步打开该会话（DocumentTitle 投影跟随）；sidebar 自身高亮同步。会话真正打开（内容渲染）非仅标题。
- **已知边界**：full 无参不参与桥（与 main/sidebar 并存时 full 保持官方 per-window 独立）；settings trigger 溢出 modal 现状保持（待上游，见上）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic synchronization of selected sessions between the main and sidebar views.
  - Session selections and clearing now remain consistent across supported views, including recovery when views start with different selections.
  - The full view remains unchanged.

- **Documentation**
  - Clarified that settings modal state does not synchronize between views and remains local pending future support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->