### PR TITLE
refactor(view): 选中态桥单向收敛——sidebar→main 下行（emit/receive 角色）

### DIFF
--- a/src-cordis/plugins/view/MainFrame.tsx
+++ b/src-cordis/plugins/view/MainFrame.tsx
@@ -3,7 +3,9 @@
 //
 // MainFrame —— main 视图（?dshana-view=main）的 root 帧组件（fpFullPanel V3 修正）。
 //
-// 角色：main = 无侧栏「主页」视图（V4 联动协议的宿主主页端）。V3 旧版（16293c5）以官方
+// 角色：main = 无侧栏「主页」视图（V4 联动协议的宿主主页端——单向收敛后为选中态桥的
+// receive 接收端：接收 sidebar 下行 select/clear 应用到本地，本地变化不回发，见
+// sync-bridge.js 头）。V3 旧版（16293c5）以官方
 // AppFrame + createMainLayoutStore(init sidebar:0) 实现——实机验证发现官方
 // panels.sidebar=0 的语义是 **56px rail 折叠态**（SidebarRoot 仍在，可展开 280），并非
 // 「隐藏 sidebar」。用户裁定：main 要**真无侧栏**（无 rail、无 SidebarRoot）——按

--- a/src-cordis/plugins/view/SidebarOnlyFrame.tsx
+++ b/src-cordis/plugins/view/SidebarOnlyFrame.tsx
@@ -33,9 +33,10 @@
 //    .toggleSidebar() 只翻转 layout store 偏好（本帧不读 store 几何，无视觉效果）。
 //
 // 已知限制（如实记录）：
-//  - V4 联动协议落地后（client.js effect 3 + sync-bridge.js）：sidebar 视图的会话选中经
-//    BroadcastChannel 与 main 主页跨边同步（双向 select/clear/握手）；会话增删/重命名/
-//    workspace 列表走 dsh 数据面天然一致，不走桥。
+//  - V4 联动单向收敛后（client.js effect 3 + sync-bridge.js）：sidebar 视图 = 发射端——
+//    会话选中变化经 BroadcastChannel 下行广播（含启动握手 boot 宣告），main 主页接收并
+//    open 跟随（receive），反向不回发（main 无切换 UI）；full 不参与桥。会话增删/重命名/
+//    workspace 列表走 dsh 数据面天然一致，不走桥（详见 sync-bridge.js 头「单向收敛」段）。
 //  - sidebar.settings occupant（ui-settings-general）的 trigger → 1080x700 modal 打开是
 //    SettingsRoot 组件内本地态，官方无可编程 open/关闭面、main 视图无其宿主（无侧栏）、
 //    槽规则封死干净拦截面——V4 调研结论 = 跨边不可行（待上游支持），本地弹出溢出保持

--- a/src-cordis/plugins/view/client.js
+++ b/src-cordis/plugins/view/client.js
@@ -25,10 +25,12 @@
 //     sidebar = SidebarOnlyFrame（V2：fp 面板 embedUrl 纯侧栏——单列容器 + 仅 sidebar
 //               子槽；SidebarRoot/workspaces/settings 子槽 occupant 走 roster 官方
 //               bundle，详见 SidebarOnlyFrame.tsx 文件头）
-//   联动（V4 跨边联动协议，见 sync-bridge.js 文件头——实现/时序/防回环记录全在那里）：
-//     effect 3 选中态桥：仅 main/sidebar 视图激活（inject 'sessions' 拿 ClientSessions，
-//     订阅其 list store current + BroadcastChannel 'dshana.sync'；握手 boot:true / isRemote
-//     静默 / pending 补开 / clear 双向，见 sync-bridge.js）。full 不参与桥。
+//   联动（V4 跨边联动协议 → **单向收敛**，见 sync-bridge.js 文件头——动因/时序/防回环
+//     记录全在那里）：
+//     effect 3 选中态桥：sidebar = 发射端（emit，本地选中变化 → 广播，不收远端）；main =
+//     接收端（receive，远端 → 本地 open/clear 应用，不外发）；full 不参与（readView 判定）。
+//     实现见 sync-bridge.js（createSessionSyncBridge(ctx, mode) 按视图角色分派；双向→
+//     单向下行的收敛记录、与 view-layouts 定稿的偏差在 sync-bridge.js 头）。
 //     settings 跨边（open-settings）：官方 bundle 无干净拦截面（调研结论：不可行，待上游
 //     支持），V4 不落地其拦截，详见 sync-bridge.js 头「settings 跨边」段与交付 2。
 //   V2 边界如实记录：
@@ -72,7 +74,7 @@ import { AppFrame } from "./vendor/AppFrame.tsx";
 import { SidebarOnlyFrame } from "./SidebarOnlyFrame.tsx";
 import { MainFrame } from "./MainFrame.tsx";
 import { createLayoutStore } from "./vendor/stores.ts";
-import { createSessionSyncBridge } from "./sync-bridge.js";
+import { BRIDGE_MODE_EMIT, BRIDGE_MODE_RECEIVE, createSessionSyncBridge } from "./sync-bridge.js";
 import { LayoutController } from "./vendor/service.ts";
 import { ThemePresenter } from "./vendor/theme-presenter.ts";
 
@@ -150,7 +152,8 @@ function frameForView(view) {
 // ---- 客户端服务注入：slots（root 注册）+ theme（ThemePresenter 快照）+ locale（t）----
 // + sessions（V4 跨边联动桥数据源：ctx.sessions.list current 订阅，见 sync-bridge.js 挂载
 // 点选型 B；官方 ui-session 同款经 inject 'sessions' 拿 ClientSessions 实例——provider 为
-// api-session-controller client，行到达序见 module graph edges）。
+// api-session-controller client，行到达序见 module graph edges）。effect 3 按视图角色用
+// 同一数据源：sidebar 读 list current 广播（emit），main 只应用远端 open/clear（receive）。
 // 与官方 ui-layout client/index.ts 相同的部分：slots/theme/locale。
 const inject = ["slots", "theme", "locale", "sessions"];
 
@@ -208,13 +211,22 @@ function apply(ctx) {
     };
   }, "@dsh-hanako/view: theme presenter");
 
-  // effect 3（V4 跨边联动协议）：选中态桥。仅 main/sidebar 视图激活（readView 结果判定——
-  // 无参 full = 官方等价形态不参与桥，见 sync-bridge.js 文件头）；subscribe ctx.sessions.list
-  // current + BroadcastChannel 广播/接收（握手/防回环/clear/pending 全在 sync-bridge.js）。
-  // settings 跨边（open-settings）：调研结论为官方 bundle 无干净拦截面（V4 不可行，待上游），
-  // 本 effect 不建 settings 分支——记录见 sync-bridge.js 头与 SidebarOnlyFrame.tsx 已知限制。
-  if (view === MAIN || view === SIDEBAR) {
-    ctx.effect(() => createSessionSyncBridge(ctx), "@dsh-hanako/view: 跨边联动桥（选中态 sync）");
+  // effect 3（V4 单向收敛）选中态桥：按视图角色分派——sidebar = 发射端（emit）、main =
+  // 接收端（receive）、full 不参与（readView 结果判定——无参 full 是宿主外等价形态，
+  // 见 sync-bridge.js 文件头角色段）。角色语义：切换现实源只有 sidebar，故 bridge 只做
+  // sidebar → main 单向下行；main 无切换 UI（无反向源），full 不建桥。settings 跨边
+  // （open-settings）：调研结论为官方 bundle 无干净拦截面（V4 不可行，待上游），本
+  // effect 不建 settings 分支——记录见 sync-bridge.js 头与 SidebarOnlyFrame.tsx 已知限制。
+  if (view === SIDEBAR) {
+    ctx.effect(
+      () => createSessionSyncBridge(ctx, BRIDGE_MODE_EMIT),
+      "@dsh-hanako/view: 跨边联动桥（sidebar → emit 发射端）",
+    );
+  } else if (view === MAIN) {
+    ctx.effect(
+      () => createSessionSyncBridge(ctx, BRIDGE_MODE_RECEIVE),
+      "@dsh-hanako/view: 跨边联动桥（main → receive 接收端）",
+    );
   }
 }
 

--- a/src-cordis/plugins/view/sync-bridge.js
+++ b/src-cordis/plugins/view/sync-bridge.js
@@ -1,19 +1,42 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2026 Nyasers
 //
-// sync-bridge.js —— @dsh-hanako/view fpFullPanel V4「跨边联动协议」的选中态桥实现。
+// sync-bridge.js —— @dsh-hanako/view fpFullPanel 选中态桥（「跨边联动协议」的落地载体）。
 //
-// 目标（view-layouts.md「跨边联动协议」定稿）：同一 dsh 运行时的两个同源 3080 iframe
-// （?dshana-view=sidebar 的 fp 侧栏 与 ?dshana-view=main 的主页）跨边同步「当前选中
-// 会话」。本模块是唯一联动载体，由 client.js 按视图实例化；无参 full 视图（官方等价/
-// 宿主外调试形态）不激活桥。
+// 方向（V4 单向收敛定稿，refactor/sync-unidirectional）：**sidebar → main 单向下行**。
+// 同一 dsh 运行时的两个同源 3080 iframe（?dshana-view=sidebar 的 fp 侧栏 与
+// ?dshana-view=main 的主页）之间，只同步「当前选中会话」，且方向唯一：
+//   · sidebar 实例 = 发射端（emitter）：本地选中变化 → 广播（含启动握手 boot 宣告）；
+//     不接收远端消息（桥激活时不订阅频道，核心 receive() 亦为无操作——双保险）。
+//   · main 实例 = 接收端（receiver）：收到远端 select/clear → 本地 open/clear 应用；
+//     不广播（本地变化不外发，receiver 是跟随方——导航源唯一在 emitter）。
+//   · full（无参，宿主外等价形态）不激活桥（client.js readView 判定已排除，保持）。
+//
+// ── V4 → 单向收敛（动因与裁决，勿重走弯路）──
+// V4（PR #70）落地的是**双向通用广播桥**（两端都订阅本地变化广播 + 接收远端应用 + 启动
+// 握手 max-wins 收敛），与 view-layouts.md「跨边联动协议」原定稿的「通用广播」一致。
+// 实机暴露官方竞态噪音：AgentPresetSeatController（ui-agent-preset，在会话 scope 上订阅
+// sessions.list）被会话切换窗口内的任意 list.set 触发 seat.apply() → 读 inactive scope
+// 抛「cannot get required service in inactive context」（uncaught in promise，功能不
+// 阻断）。V4 双向桥放大触发频率：main/sidebar 两端都可能因对端消息 open → 交叉/并发
+// list.set（含回声静默失败时的冗余 set），落点翻倍。用户裁定收敛方向：**只留 sidebar →
+// main 单向下行**——理由：① 切换的现实源只有 sidebar（会话列表 UI 所在；main 无切换
+// UI、full 是宿主外形态）；② 砍掉 main 的广播源与 sidebar 的接收路径 → 消除交叉
+// list.set 的竞态放大面。收敛后列表订阅源单侧化：同一会话切换只产生 sidebar 一次
+// open 的落点，main 侧为纯应用。官方 scope 销毁窗口本身仍在（见「已知边界」），本桥
+// 只能降频不能根除。
+// 与 view-layouts.md「通用广播」定稿的偏差及理由：原定稿「状态归属原则」末句写双向
+// （主页当前会话变化 → 广播 → fp 侧栏高亮跟随）。单向收敛后该交互不存在——main 无
+// 会话切换入口，其选中变化只来自数据面事件或远端应用，无需回发；spec（specs/ 不入
+// git）以本文件头 + client.js 头为收敛裁决的权威记录。
 //
 // ── 同步面与状态归属（调研定稿，勿重走弯路）──
 // 会话数据（列表/增删/重命名/workspace 范围/running）是 dsh 运行时的事实源：两端都订阅
 // SessionController 事件，天然一致，不桥。只有「选中态」是纯客户端本地态（ClientSessions
 // selection store → localStorage 'dsh.sessions.current'，per-iframe 独立；服务端无选中
 // 广播），所以桥只同步选中态（view-layouts「状态归属原则」）。「新建会话」= 数据面 host
-// 建会话 + 创建方本地 sessions.open(新 id) → 走 select 桥（只建一个，桥不复制创建动作）。
+// 建会话 + 创建方本地 sessions.open(新 id) → 走 select 桥下行（sidebar 新建 → main
+// 跟随打开；只建一个，桥不复制创建动作）。
 //
 // ── 挂载点选型（记录）──
 // 候选 A：包装 ClientSessions.open/clear（cordis 服务反射包装）。弃用：①需要拿到并改写
@@ -23,43 +46,73 @@
 // SnapshotStore 投影，current 是事实源——useSessions 标准 hook 同一数据源；open()/clear()/
 // 启动 restore/reconnect resurface 全部经 manager → projectList → list.set 落到同一条
 // 变化流）。桥从 ctx.sessions.list 订阅（createSnapshotStore：subscribe(fn) 无参回调，
-// 侦听器自读 getSnapshot() 比对 current），本地 current 变化即广播；远端消息到来调本地
-// sessions.open(id)/sessions.clear() 应用到同一条流。状态变化单点、无服务改写。
+// 侦听器自读 getSnapshot() 比对 current）。状态变化单点、无服务改写。单向收敛后此挂载
+// 点不变：emitter 从订阅流取「本地变化 → 广播」，receiver 的订阅流只用于 pending 补开
+// 观察 + 簿记（远端应用在收到消息时直接调 open/clear，见下）。
 //
 // ── 通道与消息 ──
 // BroadcastChannel（同源 3080，零依赖）：官方 web 前端不用 BroadcastChannel，dsh-hanako
 // 现有桥（theme/clipboard）是宿主壳页 postMessage 族，均不占名。storage 事件弃用：写方
-// 不触发（localStorage 同文档不事件）且官方不监听，不如 BroadcastChannel 直接双向。
-// 协议（v:1 自校验，非本协议消息忽略）：
-//   { v: 1, type: 'select', sessionId }        —— 选中某会话
-//   { v: 1, type: 'clear' }                    —— 清空选中（无会话视图）
-//   select 消息可带 boot:true（仅「启动握手」的被动宣告，见下；真实用户动作不带）
+// 不触发（localStorage 同文档不事件）且官方不监听，不如 BroadcastChannel 直接。
+// 协议（v:1 自校验，非本协议消息忽略；**生产消息只有 emitter → receiver 一个方向**）：
+//   { v: 1, type: 'select', sessionId }        —— 选中某会话（emitter 本地 live 变化）
+//   { v: 1, type: 'clear' }                    —— 清空选中（emitter 本地清空/数据面 mask）
+//   select 可带 boot:true（仅 emitter 启动握手的一次性被动宣告，见下；live 不带）
+//   boot 标志在 receiver 端不再参与决策（单向无竞争端，见「启动握手」）——保留字段只为
+//   消息语义自描述/调试。
 //
-// ── 防回环（记录）──
-// 双层：①值去重——本端只在自己 current ≠ 上次已广播值（sentValue）时广播；任何收到的
-// 冗余回声在两端都命中去重而终止。②远端应用静默化——把「远端消息引发的 open/clear」包进
-// suppressToken（isRemote 调用链标志），期间列表变化只采纳（adopt sentValue）不广播。
-// open/clear 同步路径经 manager.notifyNow 同步 flush → projectList → list.set → 本订阅
-// 回调**同步重入**（sessions/notifier.ts 已证实；list 订阅在 set 内同步回调），故 token 在
-// 动作返回时**同步清掉**即可覆盖整个回环链；异步尾（refreshSubagents 等后续同值 list.set）
-// 由值去重兜底。token 不拖到微任务——同步窗口外不应抑制独立本地动作。
+// ── 模式拆分（createSyncCore / createSessionSyncBridge 的 mode 参数）──
+// 方向用 opts.mode: 'emit' | 'receive' 表达（常量 BRIDGE_MODE_EMIT/BRIDGE_MODE_RECEIVE；
+// 缺省/非法即抛错——防接线漏传方向静默成错角色）。未拆 createEmitterCore/
+// createReceiverCore 双工厂：两角色共享消息校验、去重簿记与 pending/超时骨架
+// （applyRemote 为 receive 专有——emit 永不应用远端），单核心 + 角色分支（列表订阅
+// 按角色注册对应 handler、receive() 在 emit 端为 no-op）比两份平行实现重复更少、逐
+// 分支可读。角色专有面：
+//   emit：list 订阅 → 本地变化 post（首 ready 投影值 boot:true 宣告一次）；不 open/
+//   clear（本端永不应用远端——若误触发说明接线错角色）。
+//   receive：远端消息 → applyRemote open/clear 应用到本地流；list 订阅只做 pending
+//   补开观察 + 簿记刷新；无 post 面（本地变化——数据面 mask/恢复、未来 main 本地 UI
+//   动作——一律不外发：receiver 是跟随方，其本地变化不回同步 emitter，导航源唯一 =
+//   emitter，该边界如实记录）。
 //
-// ── 启动握手（时序，记录）──
-// 两端加载时各自 localStorage 恢复各自选中（互不知晓对方）。桥激活后等待 list phase
-// 'ready'（首个 host baseline 投影），之后：
-//   · 本端有选中 → 广播一次 boot:true 的 select（被动宣告，不算 live 用户动作）；
-//   · 本端无选中 → 不广播（空态不强加给对端 clear）。
-// 握手竞态（双方同时被动宣告不同选中）：boot:true 消息在接收端仍处于被动期（本端从未
-// 做过 live 用户动作）时按「id 字典序 max-wins」采纳（两独立实例无全局时钟，字典序给一个
-// 确定性收敛；空态端直接采纳对方宣告）；一旦任一端发生过真实用户动作（live=true），此后
-// boot 宣告一律忽略（真实动作优先），一切真实消息无条件采纳——顺序真实动作 last-writer。
-// 对端已被采纳的 boot 值引发的自身变化在 suppressToken 内静默，不回弹。收敛后两端一致。
+// ── 防回环/值去重（单向收敛后的简化分析，记录）──
+// 协议层回环面已结构性归零：emitter 不收远端（不订阅频道 + receive() no-op）、receiver
+// 不发消息（无 post 调用面）——「远端 open 引发的自身 list.set」无处可回声。残余的
+// 噪声/重复面与对策：
+//   ① emitter 同值去重：只在自己 current ≠ 上次已广播值（sentValue）时广播。本地 open/
+//      clear 同步路径经 manager.notifyNow 同步 flush → list.set → 本订阅回调同步重入；
+//      异步尾（refreshSubagents 等后续同值 list.set）与用户同 id 重放都命中 sentValue
+//      去重终止——不重复广播（降官方竞态触发频）。
+//   ② receiver 同值短路：远端 select 目标 === 本地 current 时不 open（不制造冗余
+//      list.set，直接落簿记）；远端 clear 在已空态时同样短路。pending 补开前若恢复/数据
+//      面已把目标落为 current → 清 pending 不重复 open。
+//   ③ isRemote 静默（V4 的 suppressToken）**结构性退役**：原语义是「远端 open/clear 应用
+//      链（同步重入 list.set）不被当作本地 live 变化而回声广播」——该回声面只在「本地
+//      变化会广播」的端上存在，receiver 无 post 面后无处可回声（协议层回环归零），token
+//      已无分支可驱动，故删除（不再保留写而不读的占位）。语义保留处：远端应用一律走
+//      applyRemote（try/catch 兜底 open 抛错），receive 端簿记只随快照对齐；receiver 端
+//      本地用户动作不广播本身即无回环（main 里未来新建会话 open 也只改本端 current）。
+//
+// ── 启动握手（单向收敛后，时序记录）──
+// 两端加载时各自从 localStorage 恢复各自选中（互不知晓对方）。桥激活后等 list phase
+// 'ready'（首个 host baseline 投影）：
+//   · emitter 有选中 → 广播一次 boot:true 的 select（被动宣告，不算 live 用户动作）；
+//     无选中 → 不广播（空态不强加给对端 clear——emitter 空态时 receiver 保留自身恢复，
+//     首次 sidebar live 动作后自然收敛，如实记录）。
+//   · receiver 无宣告，被动跟随：收到 boot/live select 即 open（无条件——单向下没有
+//     竞争宣告面，故去掉 V4 双端「被动期字典序 max-wins + live 优先」整套裁决：本端
+//     持久化选中与 emitter 宣告不同 → 被 emitter 覆盖属预期，导航源在 emitter）。
+//   时序边界（如实记录）：BroadcastChannel 无持久队列，若 receiver 晚于 emitter 的 boot
+//   广播才激活（页面后加载），会错过宣告并保持自身恢复，直到 emitter 下一次 live 变化
+//   才收敛。fp 宿主流中 sidebar（fp 面板嵌）晚于 main 加载，主路径安全；对立时序的
+//   首次分歧可自愈，不做重问机制（协议无 request/response，设计定稿）。
 //
 // ── 数据面瞬时态（masked gap / 删除）──
 // 列表 current 变化也可能来自数据面（当前会话被删/重连重拉瞬断）：projectList 把缺失
-// current mask 为 undefined → 本端会广播 clear，对端 applyRemote(clear)。幂等无害
-// （对端同源数据面同样走向空/回弹），后续 select 再次收敛。远端 select 目标在本端列表
-// 暂缺（如新建会话广播先于本端列表增量到达）→ pending 暂存，列表就绪且 byId 出现后补开，
+// current mask 为 undefined。emitter 侧此变化照常广播 clear（live 语义，幂等无害——
+// receiver 同源数据面同样走向空则同值短路，先到则清空），后续 select 再次收敛。远端
+// select 目标在 receiver 本端列表暂缺（如新建会话广播先于本端列表增量到达）→ pending
+// 暂存，列表就绪且 byId 出现后补开（仅 receive 端需要；emitter 不收远端无此路径），
 // 超时丢弃（防止为永不落地的 id 悬挂）。
 //
 // ── 已知边界（如实记录）──
@@ -67,22 +120,21 @@
 //   态，对端无保留地址则无法 open（ClientSessions.open → manager.select 对未知 id 抛错，
 //   本桥以 byId 成员检查 + try/catch 兜底并记录），该导航面不桥（延续 view-layouts：
 //   catalog/树浏览属各端浏览态）。需要时扩展 select 消息带地址 + 对端 catalog 加载。
-// · 同值短路（降噪）：远端 select 目标与本地 current 一致时不 open（handleRemoteSelect
-//   非 boot 分支 ours===id → adopt 返回；boot 分支字典序 !(id>ours) 同值也短路）——
-//   避免冗余 list.set 风暴（见下官方竞态放大因子）。
 // · 【官方竞态，待上游】AgentPresetSeatController（ui-agent-preset，seat-store/apply）在
 //   会话 scope（ctx.inject ['conversation','sessions',…]）上订阅 sessions.list，任何
 //   list.set（含非 current 变化的投影）都触发 seat.apply() → currentSession() 读
 //   scope.sessions。会话切换时旧 scope 的 dropScope（fiber.dispose）异步，若 list.set
 //   通知落在 scope 销毁窗口内 → apply 在 inactive context 读 sessions 抛
 //   「cannot get required service in inactive context」（uncaught in promise，功能不阻断，
-//   console 噪音）。V4 跨实例联动放大触发频率（多实例都 open → list.set 风暴）。桥侧
-//   同值短路已尽量降噪；必要切换（值真不同）无法避免。上游修法建议：seat.apply 前 guard
-//   scope active（ctx.scope.active/等效），或 effect cleanup 先退订再 dispose。本仓库不
-//   patch 官方 bundle。
+//   console 噪音）。V4 双向桥交叉 open → list.set 风暴放大触发频率；单向收敛砍掉
+//   main 广播源与 sidebar 接收路径后，list.set 触发源减半（同一切换只剩 sidebar 一次
+//   open 落点），该噪音**预期降频但未根除**——官方窗口仍在（任何本端 list.set 都可能
+//   撞上 scope 销毁窗口），如实记录。上游修法建议：seat.apply 前 guard scope active
+//   （ctx.scope.active/等效），或 effect cleanup 先退订再 dispose。本仓库不 patch 官方
+//   bundle。
 // · 无参 full 实例不参与桥（client.js readView 结果判定）；full 与 main/sidebar 并存时：
-//   main/sidebar 之间照常联动，full 的选中不向外发也不接受（full = 官方等价形态，
-//   官方语义即 per-window 独立选中，行为如实记录）。
+//   sidebar → main 照常联动，full 的选中不向外发也不接受（full = 官方等价形态，官方
+//   语义即 per-window 独立选中，行为如实记录）。
 // · BroadcastChannel 按 origin+name 广播：127.0.0.1:3080 单 dsh 运行时内安全；同端口
 //   不可并存第二运行时（绑定冲突），跨 profile/跨端口不同源不串扰。
 //
@@ -99,6 +151,17 @@
 
 const PENDING_TIMEOUT_MS = 10000;
 
+/** 桥方向模式（createSyncCore / createSessionSyncBridge 的 opts.mode 取值）。 */
+export const BRIDGE_MODE_EMIT = "emit"; // sidebar：发射端（本地变化 → 广播）
+export const BRIDGE_MODE_RECEIVE = "receive"; // main：接收端（远端 → 本地 open/clear 应用）
+
+/** 校验方向模式：缺省/非法一律抛错——防止接线漏传方向静默成错角色（方向即角色）。 */
+function assertBridgeMode(mode) {
+  if (mode !== BRIDGE_MODE_EMIT && mode !== BRIDGE_MODE_RECEIVE) {
+    throw new Error('[dshana.sync] opts.mode must be "emit" or "receive", got: ' + String(mode));
+  }
+}
+
 /**
  * 校验并规范化当前列表快照的选中值：current 有效（在 byId 中）才有选中。
  * @param {object} snap - sessions.list.getSnapshot() 的返回。
@@ -111,29 +174,31 @@ function currentOf(snap) {
 }
 
 /**
- * 选中态桥核心：与传输/存储解耦的状态机（挂载点选型 B，见文件头）。
- * 行为：本地 list.current 变化广播；远端 select/clear 应用到本地并静默；
- * 启动握手（boot:true 被动宣告 + 被动期字典序 max-wins）；pending 补开。
+ * 选中态桥核心（单向模式状态机，与传输/存储解耦；模式拆分说明见文件头）。
+ * 行为：
+ *   · emit（sidebar）：本地 list.current 变化 → post select/clear（首 ready 投影值
+ *     boot:true 宣告一次）；不应用远端（open/clear 回调不会被动用）。
+ *   · receive（main）：远端 select/clear → applyRemote open/clear 应用并静默落簿记；
+ *     不 post（本地变化不外发）；pending 补开仅此端需要。
  * @param {object} opts
  * @param {object} opts.list - SnapshotStore 面：{ subscribe(fn), getSnapshot() }。
- * @param {(id: string) => void} opts.open - 本地选中（ClientSessions.open）。
- * @param {() => void} opts.clear - 本地清空（ClientSessions.clear）。
- * @param {(msg: object) => void} opts.post - 发送一条协议消息。
- * @returns {{ dispose: () => void }} 销毁句柄。
+ * @param {'emit'|'receive'} opts.mode - 方向/角色（见 assertBridgeMode）。
+ * @param {(id: string) => void} [opts.open] - 本地选中（ClientSessions.open；仅 receive）。
+ * @param {() => void} [opts.clear] - 本地清空（ClientSessions.clear；仅 receive）。
+ * @param {(msg: object) => void} [opts.post] - 发送一条协议消息（仅 emit）。
+ * @returns {{ dispose: () => void, receive: (msg: object) => void }} 销毁句柄 + 远端入口。
  */
 export function createSyncCore(opts) {
-  const { list, open, clear, post } = opts;
+  const { list, open, clear, post, mode } = opts;
+  assertBridgeMode(mode);
+  const RECEIVE = mode === BRIDGE_MODE_RECEIVE;
   /** list 就绪（首个 host baseline 投影）标志。 */
   let booted = false;
-  /** 是否发生过真实本地用户动作（此后 boot 宣告作废、真实消息无条件采纳）。 */
-  let live = false;
   /** 是否已同步过任何值（区分「从未同步」与「同步为空」）。 */
   let sentAnything = false;
-  /** 本端已广播/已采纳的值（undefined 也是合法值；配合 sentAnything 判「从未同步」）。 */
+  /** 已广播/已采纳的值（undefined 也是合法值；配合 sentAnything 判「从未同步」）。 */
   let sentValue = undefined;
-  /** isRemote 防回环 token：远端 open/clear 应用链上非空，期间列表变化只采纳不广播。 */
-  let suppressToken = null;
-  /** 远端 select 目标在本端暂缺 → pending 补开（id + 超时）。 */
+  /** 远端 select 目标在 receive 端暂缺 → pending 补开（id + 超时；仅 receive 端）。 */
   let pendingId = undefined;
   let pendingTimer = undefined;
   let disposed = false;
@@ -146,130 +211,138 @@ export function createSyncCore(opts) {
     pendingId = undefined;
   }
 
-  /** 记下本端当前事实（同步完成值），供去重与后续变化比较。 */
+  /** 记下本端当前事实（簿记值），供去重与簿记对齐。 */
   function adopt(value) {
     sentAnything = true;
     sentValue = value;
   }
 
   function postValue(value, extra) {
-    if (value === undefined) post({ v: 1, type: 'clear', ...extra });
-    else post({ v: 1, type: 'select', sessionId: value, ...extra });
+    if (value === undefined) post({ v: 1, type: "clear", ...extra });
+    else post({ v: 1, type: "select", sessionId: value, ...extra });
   }
 
   /**
-   * 应用一个远端动作（isRemote 调用链）。open/clear 同步路径触发 manager
-   * notifyNow → projectList → list.set → 本订阅回调**同步重入**，在 token 下静默采纳。
-   * token 在动作返回时**同步清掉**（链是同步的；异步尾由值去重兜底——远端 open 触发的
-   * refreshSubagents 等后续 list.set 携带同一 current，命中 sentValue 去重不再广播）。
-   * 不能拖到微任务再清：会把抑制窗口延伸到同 tick 的独立本地动作（实机跨任务天然隔开，
-   * 但同步窗口内应精确限定在本次远端应用）。
+   * 应用一个远端动作（receive 端；isRemote 调用链）。open/clear 同步路径触发 manager
+   * notifyNow → projectList → list.set → 本订阅回调**同步重入**——V4 的 isRemote 静默
+   * token 在此已结构性退役（receive 无 post 面，回声无处可发，见文件头「防回环」③），
+   * 本函数保留 try/catch 兜底（open 对未知/未保留地址抛错时不打断联动主链）并负责在
+   * 动作后对齐簿记。异常由调用方以动作后快照 adopt 兜底。
    * @param {() => void} action
    */
   function applyRemote(action) {
-    suppressToken = {};
     try {
       action();
     } catch (error) {
       // ClientSessions.open 对未知/未保留地址会话抛错（manager.select 校验）；桥已按
       // byId 预检，仍可能撞 catalog 保留地址边界——忽略并如实留痕（不打断联动主链）。
-      if (typeof console !== 'undefined') {
-        console.warn('[dshana.sync] remote apply failed:', error && error.message ? error.message : error);
+      if (typeof console !== "undefined") {
+        console.warn("[dshana.sync] remote apply failed:", error && error.message ? error.message : error);
       }
-    } finally {
-      suppressToken = null;
     }
   }
 
-  /** pending 补开：目标 id 已就绪（ready + byId 命中）才真正 open。 */
+  /** pending 补开（receive 端）：目标 id 已就绪（ready + byId 命中）才真正 open。 */
   function maybeApplyPending() {
     if (pendingId === undefined || disposed) return;
     const snap = list.getSnapshot();
-    if (snap.phase !== 'ready') return;
+    if (snap.phase !== "ready") return;
     if (snap.byId === undefined || snap.byId[pendingId] === undefined) return;
     const id = pendingId;
+    // 同值短路：pending 目标已被恢复/数据面先行落为 current（list.set 到达顺序竞态）→
+    // 只清 pending 落簿记，不重复 open（降噪——见文件头官方竞态降频面）。
+    if (currentOf(snap) === id) {
+      clearPending();
+      adopt(id);
+      return;
+    }
     clearPending();
     applyRemote(() => open(id));
     adopt(currentOf(list.getSnapshot())); // 以实际落定为准（open 抛错/mask 时保持真值）
   }
 
-  /** 列表订阅回调（createSnapshotStore subscribe 无参回调，侦听器自读快照）。 */
-  function onListChanged() {
+  /** 列表订阅回调——emit 端：本地变化 → 广播（含启动握手 boot 宣告）。 */
+  function onListChangedEmit() {
     if (disposed) return;
-    // 先 gate booted（phase 判定不依赖后续快照），再 maybeApplyPending——pending 补开
-    // （远端 select 目标本端暂缺 → open）会改变 current/sentValue，之后必须重读快照，
-    // 否则 value 取自补开前的旧快照，sentValue 与真实 current 脱节（后续误标 live
-    // 广播 + 忽略 boot 致对端无法收敛）。
-    const firstReady = !booted;
     if (!booted) {
-      if (list.getSnapshot().phase !== 'ready') return;
+      if (list.getSnapshot().phase !== "ready") return;
       booted = true;
+      // 首个 ready 投影上的值 = 持久化恢复（非用户动作）：有值 → boot:true 宣告一次；
+      // 空态 → 不强加 clear（对端保留自身恢复，见文件头「启动握手」时序边界）。
+      const restored = currentOf(list.getSnapshot());
+      if (restored === undefined) {
+        adopt(undefined);
+        return;
+      }
+      postValue(restored, { boot: true });
+      adopt(restored);
+      return;
     }
-    maybeApplyPending();
     const snap = list.getSnapshot();
     const value = currentOf(snap);
-    // 值去重：与上次已同步值一致 → 不广播（含对端冗余回声终止点）。
+    // 值去重：与上次已广播值一致 → 不广播（本地同值尾通知/用户同 id 重放终止点）。
     if (sentAnything && value === sentValue) return;
-    if (suppressToken !== null) {
-      // isRemote 链上变化：静默采纳（对端会自行广播，本端不回弹）。
-      adopt(value);
-      return;
-    }
-    if (firstReady) {
-      // 首个 ready 投影上的值 = 持久化恢复（非用户动作），分类看 tick 而非 sentAnything：
-      // 即便此前 adopt(undefined)/pending 已置 sentAnything，也不把恢复误标成真实动作。
-      if (pendingId !== undefined) { adopt(value); return; } // 有远端 pending 待补开：不宣告
-      if (value === undefined) { adopt(value); return; } // 空态：不强加 clear
-      postValue(value, { boot: true }); // 启动握手：boot:true 被动宣告一次
-      adopt(value);
-      return;
-    }
-    // 真实本地变化（用户点击/新建进入/清空）→ live + 无条件广播。
-    live = true;
+    // 本地变化（live 用户动作/新建进入/数据面 mask/清空）→ 无条件广播。
     postValue(value);
     adopt(value);
   }
 
-  /** 远端消息入口（BroadcastChannel message 载荷已过 v 校验）。 */
-  function onRemoteMessage(msg) {
-    if (disposed || msg === null || typeof msg !== 'object' || msg.v !== 1) return;
-    if (msg.type === 'select') {
-      if (typeof msg.sessionId !== 'string' || msg.sessionId === '') return;
-      handleRemoteSelect(msg.sessionId, msg.boot === true);
-      return;
+  /** 列表订阅回调——receive 端：pending 补开观察 + 簿记刷新（不外发，见文件头）。 */
+  function onListChangedReceive() {
+    if (disposed) return;
+    if (!booted) {
+      if (list.getSnapshot().phase !== "ready") return;
+      booted = true;
     }
-    if (msg.type === 'clear') handleRemoteClear(msg.boot === true);
+    maybeApplyPending();
+    // receive 端本地列表变化（远端应用链的同步重入、数据面 mask/恢复、未来本地 UI
+    // 动作）一律不外发——无 post 面，回环结构性归零（V4 isRemote 静默 token 因无处
+    // 回声而退役，见文件头「防回环」③）。这里只刷新簿记（远端决策均读 live 快照，
+    // 簿记不参与判断，仅 _debug/对齐）。
+    adopt(currentOf(list.getSnapshot()));
   }
 
-  function handleRemoteSelect(id, boot) {
+  /**
+   * 远端消息入口（BroadcastChannel message 载荷已过 v 校验）。emit 端为无操作
+   * （设计：发射端不订阅频道；核心层收到也忽略——双保险，见文件头）。
+   */
+  function onRemoteMessage(msg) {
+    if (mode === BRIDGE_MODE_EMIT) return;
+    if (disposed || msg === null || typeof msg !== "object" || msg.v !== 1) return;
+    if (msg.type === "select") {
+      if (typeof msg.sessionId !== "string" || msg.sessionId === "") return;
+      handleRemoteSelect(msg.sessionId);
+      return;
+    }
+    if (msg.type === "clear") handleRemoteClear();
+  }
+
+  function handleRemoteSelect(id) {
     const snap = list.getSnapshot();
     const ours = currentOf(snap);
-    if (boot) {
-      // 启动握手宣告：真实动作优先——本端已 live 则旧宣告作废；
-      // 被动期双宣告 → id 字典序 max-wins 确定性收敛。
-      if (live) return;
-      if (ours !== undefined && !(id > ours)) return;
-    } else if (ours === id) {
+    // 单向接收：emitter 是唯一导航源，boot/live 一视同仁采纳（无 V4 双端的字典序
+    // max-wins / live 优先裁决——本端没有竞争宣告面；本端持久化选中被 emitter 覆盖属
+    // 预期，见文件头「启动握手」）。同值短路防冗余 open（降噪）。
+    if (ours === id) {
       adopt(ours);
       return;
     }
-    if (snap.phase !== 'ready' || snap.byId === undefined || snap.byId[id] === undefined) {
-      // 目标暂缺（新建会话广播先于本端列表增量）：pending 补开。
+    if (snap.phase !== "ready" || snap.byId === undefined || snap.byId[id] === undefined) {
+      // 目标暂缺（新建会话广播先于本端列表增量/phase 未 ready）：pending 补开。
       clearPending();
       pendingId = id;
       pendingTimer = setTimeout(() => { clearPending(); }, PENDING_TIMEOUT_MS);
-      if (boot && ours !== undefined) adopt(ours); // 未采纳，保留本端事实
-      else if (!sentAnything) adopt(undefined); // 无既有值：pending 落定前按空态对齐
+      adopt(currentOf(snap)); // current 未变：簿记随快照（pending 落定前的对齐值）
       return;
     }
     applyRemote(() => open(id));
     adopt(currentOf(list.getSnapshot())); // open 成功 = id；抛错/mask = 真值
   }
 
-  function handleRemoteClear(boot) {
-    if (boot) return; // 握手从不发 clear（空态不强加）；防御性忽略。
+  function handleRemoteClear() {
     const snap = list.getSnapshot();
     if (currentOf(snap) === undefined) {
+      // 已空态同值短路（对端数据面 mask 下行幂等无害）。
       adopt(undefined);
       return;
     }
@@ -277,9 +350,11 @@ export function createSyncCore(opts) {
     adopt(currentOf(list.getSnapshot()));
   }
 
-  const off = list.subscribe(onListChanged);
-  // 启动立即评估一次：list 已 ready（本插件晚激活/热载）时不等下一次通知即握手。
-  onListChanged();
+  // 列表订阅按角色注册对应 handler；创建后立即评估一次（list 已 ready/本插件晚激活/
+  // 热载时不等下一次通知即走启动逻辑）。
+  const onChange = RECEIVE ? onListChangedReceive : onListChangedEmit;
+  const off = list.subscribe(onChange);
+  onChange();
 
   return {
     dispose() {
@@ -287,13 +362,12 @@ export function createSyncCore(opts) {
       disposed = true;
       off();
       clearPending();
-      suppressToken = null;
     },
-    /** 远端消息入口（浏览器载体/测试邮袋共用）。 */
+    /** 远端消息入口（浏览器载体/测试邮袋共用；emit 端 no-op）。 */
     receive: onRemoteMessage,
     // 测试/诊断内省面（非公开 API；生产不依赖）。
     _debug() {
-      return { booted, live, sentAnything, sentValue, pendingId };
+      return { mode, booted, sentAnything, sentValue, pendingId };
     },
   };
 }
@@ -301,15 +375,19 @@ export function createSyncCore(opts) {
 // ================== 浏览器接线（@dsh-hanako/view client.js 调用）==================
 
 /** BroadcastChannel 频道名（v:1 协议内）；单 dsh 运行时同源 3080 内广播。 */
-export const SYNC_CHANNEL = 'dshana.sync';
+export const SYNC_CHANNEL = "dshana.sync";
 
 /**
  * 实例化跨边联动桥（浏览器面接线）：订阅 ctx.sessions.list + BroadcastChannel 载体。
- * 仅 main/sidebar 视图激活（client.js 按 readView 结果调用）；full 不建桥。
+ * 按视图角色传 mode：sidebar=BRIDGE_MODE_EMIT、main=BRIDGE_MODE_RECEIVE（client.js
+ * effect 3 按 readView 结果分派）；full 不建桥。emit 端只发不收（不注册频道监听）；
+ * receive 端只收不发（频道消息 → 核心应用）。
  * @param {object} ctx - 客户端 root context（已 inject 'sessions'）。
+ * @param {'emit'|'receive'} mode - 方向/角色（见 assertBridgeMode）。
  * @returns {() => void} disposer。
  */
-export function createSessionSyncBridge(ctx) {
+export function createSessionSyncBridge(ctx, mode) {
+  assertBridgeMode(mode);
   const sessions = ctx.sessions;
   if (sessions === undefined || sessions.list === undefined) {
     // sessions 服务未就绪理论上不发生（inject 'sessions' 已等 provider）；
@@ -322,12 +400,16 @@ export function createSessionSyncBridge(ctx) {
     return () => {};
   }
   const core = createSyncCore({
+    mode,
     list: sessions.list,
     open: (id) => sessions.open(id),
     clear: () => sessions.clear(),
     post: (msg) => channel.post(msg),
   });
-  channel.onMessage((msg) => core.receive(msg));
+  if (mode === BRIDGE_MODE_RECEIVE) {
+    // receive：频道消息 → 核心应用。emit：不订阅（发射端不收远端，见文件头）。
+    channel.onMessage((msg) => core.receive(msg));
+  }
   return () => {
     channel.close();
     core.dispose();
@@ -336,7 +418,7 @@ export function createSessionSyncBridge(ctx) {
 
 /** BroadcastChannel 载体封装（channel 缺失/null 时静默降级）。 */
 function createChannel() {
-  if (typeof BroadcastChannel === 'undefined') return null;
+  if (typeof BroadcastChannel === "undefined") return null;
   let channel;
   try {
     channel = new BroadcastChannel(SYNC_CHANNEL);
@@ -350,14 +432,14 @@ function createChannel() {
         listener(event && event.data);
       } catch (error) {
         // 单个侦听器失败不影响其余（官方 notifySubscribers 同款纪律）。
-        if (typeof console !== 'undefined') {
-          console.error('[dshana.sync] message listener failed:', error);
+        if (typeof console !== "undefined") {
+          console.error("[dshana.sync] message listener failed:", error);
         }
       }
     }
   };
   try {
-    channel.addEventListener('message', onMessage);
+    channel.addEventListener("message", onMessage);
   } catch (error) {
     try { channel.onmessage = onMessage; } catch { /* 双保险失败则降级 */ }
   }
@@ -367,8 +449,8 @@ function createChannel() {
         channel.postMessage(msg);
       } catch (error) {
         // 发送失败（极端环境）只记录——联动退化为单端本地语义。
-        if (typeof console !== 'undefined') {
-          console.warn('[dshana.sync] post failed:', error && error.message ? error.message : error);
+        if (typeof console !== "undefined") {
+          console.warn("[dshana.sync] post failed:", error && error.message ? error.message : error);
         }
       }
     },
@@ -378,7 +460,7 @@ function createChannel() {
     close() {
       listeners.clear();
       try {
-        channel.removeEventListener('message', onMessage);
+        channel.removeEventListener("message", onMessage);
       } catch { /* ignore */ }
       try { channel.close(); } catch { /* ignore */ }
     },
@@ -388,4 +470,4 @@ function createChannel() {
 // ---- settings 跨边协议预留（V4 交付 2 结论：上游不可行，见模块头）----
 // 待官方提供 root 可挂 settings shell 槽位或可编程 open/close 服务后，sidebar 视图经
 // 本频道发 { v:1, type:'open-settings' }，main 视图据此打开官方 settings modal。
-export const OPEN_SETTINGS_MESSAGE = { v: 1, type: 'open-settings' };
+export const OPEN_SETTINGS_MESSAGE = { v: 1, type: "open-settings" };

--- a/tests/sync-bridge.test.mjs
+++ b/tests/sync-bridge.test.mjs
@@ -1,22 +1,28 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2026 Nyasers
 //
-// tests/sync-bridge.test.mjs —— fpFullPanel V4 跨边联动选中态桥（sync-bridge.js）核心
+// tests/sync-bridge.test.mjs —— fpFullPanel V4 单向收敛后选中态桥（sync-bridge.js）核心
 // 态机单测。零依赖：Node 内置 node:test + node:assert（同 errclass.test.mjs 纪律——
 // 验收命令 node --test tests/ 自动发现）。
 //
-// 被测面 = createSyncCore（纯状态机，传输/存储解耦注入）：
-//   · 双向实时 select/clear 传播 + 防回环（值去重 + isRemote 静默）不震荡；
-//   · 启动握手：单端恢复宣告 / 双端分歧恢复字典序收敛（boot:true max-wins）；
-//   · live 端忽略迟到 boot 宣告（真实动作优先）；
-//   · 远端 select 目标本端暂缺 → pending 补开（列表就绪且 byId 出现后 open）；
-//   · open 抛错（catalog 未知地址兜底）不炸桥；非协议消息忽略；
-//   · 数据面删除当前会话（mask）两端一致回空后再次收敛；
-//   · dispose 停摆；无 BroadcastChannel 环境（node）接线层静默降级 noop。
+// 被测面 = createSyncCore（纯状态机，传输/存储解耦注入；mode: 'emit' | 'receive'）：
+//   · 单向角色边界：sidebar(emit) 本地变化 → 广播 → main(receive) 应用 open/clear；
+//     receiver 本地变化/数据面变化零外发；emitter 不接收远端（receive() no-op）；
+//   · 启动握手（单源收敛）：emitter 恢复选中 boot:true 宣告 → receiver 空态采纳 /
+//     持久化不同选中被覆盖（导航源在 emitter）；空态 emitter 不强加 clear；
+//   · 值去重：emitter 同值尾通知/同 id 重放不重复广播；receiver 同值远端（live/boot）
+//     不重复 open；
+//   · pending 补开（仅 receive）：远端 select 目标本端暂缺 → ready + byId 出现后补开；
+//     恢复先行落定（同值）→ 不重复 open；
+//   · clear 下行与再收敛；数据面删除 current（mask）幂等回空；
+//   · open 抛错（catalog 未知地址兜底）不炸桥；非协议消息忽略；dispose 停摆；
+//   · mode 校验（缺省/非法抛错——防接线漏传角色）；接线层降级/真 channel（emit/receive）。
 // 浏览器接线（BroadcastChannel 载体/ctx.sessions 注入）属宿主实机验证面，此处不 mock。
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
+  BRIDGE_MODE_EMIT,
+  BRIDGE_MODE_RECEIVE,
   createSyncCore,
   createSessionSyncBridge,
   SYNC_CHANNEL,
@@ -72,226 +78,312 @@ function makeSessions(initialIds = []) {
   };
 }
 
-/** 两参与者直连邮袋（同步排空 + bounded——防回环失败的震荡会被 max 拦下并断言失败）。 */
-function makePair() {
-  const bus = { a2b: [], b2a: [], posted: 0 };
-  const aS = makeSessions();
-  const bS = makeSessions();
-  const sides = {};
-  sides.a = {
-    sessions: aS,
-    posts: [],
-    remoteOpens: [],
-    remoteClears: [],
+/**
+ * sidebar(emit) → main(receive) 单向直连邮袋。角色边界用 throw stub 硬断言：
+ *   · emit 核心的 open/clear 若被调用（= emit 误应用远端）→ 抛错；
+ *   · receive 核心的 post 若被调用（= receive 误广播本地变化）→ 抛错。
+ * 用户级动作直达 sessions store（真实 ui 路径，桥只旁听 list），不经核心回调。
+ */
+function makeOneWay() {
+  const bus = { posts: [], queued: [] };
+  const eS = makeSessions(); // sidebar（发射端）sessions
+  const rS = makeSessions(); // main（接收端）sessions
+  const remoteOpens = [];
+  const remoteClears = [];
+  const emit = {
+    sessions: eS,
+    core: createSyncCore({
+      mode: BRIDGE_MODE_EMIT,
+      list: eS.list,
+      open: () => { throw new Error("emit core must not apply remote open"); },
+      clear: () => { throw new Error("emit core must not apply remote clear"); },
+      post: (msg) => { bus.posts.push(msg); bus.queued.push(msg); },
+    }),
+    _receive: (msg) => { /* 经核心 receive()（no-op 断言面） */ },
   };
-  sides.b = {
-    sessions: bS,
-    posts: [],
-    remoteOpens: [],
-    remoteClears: [],
+  const receive = {
+    sessions: rS,
+    core: createSyncCore({
+      mode: BRIDGE_MODE_RECEIVE,
+      list: rS.list,
+      open: (id) => { remoteOpens.push(id); rS.open(id); },
+      clear: () => { remoteClears.push(1); rS.clear(); },
+      post: () => { throw new Error("receive core must not broadcast local changes"); },
+    }),
+    _receive: (msg) => receive.core.receive(msg),
   };
-  for (const name of ["a", "b"]) {
-    const side = sides[name];
-    const peer = name === "a" ? "b" : "a";
-    side.core = createSyncCore({
-      list: side.sessions.list,
-      open: (id) => { side.remoteOpens.push(id); side.sessions.open(id); },
-      clear: () => { side.remoteClears.push(1); side.sessions.clear(); },
-      post: (msg) => {
-        side.posts.push(msg);
-        bus.posted += 1;
-        bus[name + "2" + peer].push(msg);
-      },
-    });
-    side._receive = (msg) => side.core.receive(msg);
-    side.current = () => side.sessions.current();
-  }
-  /** 投递到邮袋清空（消息可级联；同步推演 + 轮次上限防震荡）。 */
+  emit._receive = (msg) => emit.core.receive(msg);
   function deliver(max = 40) {
     let rounds = 0;
-    while ((bus.a2b.length > 0 || bus.b2a.length > 0) && rounds < max) {
+    while (bus.queued.length > 0 && rounds < max) {
       rounds += 1;
-      while (bus.a2b.length > 0) sides.b._receive(bus.a2b.shift());
-      while (bus.b2a.length > 0) sides.a._receive(bus.b2a.shift());
+      while (bus.queued.length > 0) receive._receive(bus.queued.shift());
     }
-    assert.ok(bus.a2b.length === 0 && bus.b2a.length === 0,
-      "bus did not quiesce within " + max + " rounds (echo loop?)");
+    assert.ok(bus.queued.length === 0, "bus did not quiesce within " + max + " rounds (echo loop?)");
   }
-  return { aS, bS, a: sides.a, b: sides.b, deliver };
+  return {
+    eS, rS, emit, receive, remoteOpens, remoteClears,
+    posts: bus.posts,
+    currentE: () => eS.current(),
+    currentR: () => rS.current(),
+    deliver,
+  };
 }
 
 const flush = () => new Promise((resolve) => { queueMicrotask(resolve); });
 const bootFlags = (posts) => posts.filter((m) => m.type === "select")
   .map((m) => ({ id: m.sessionId, boot: m.boot === true }));
 
-test("实时双向：A 点会话 → B 跟随；B 切会话 → A 跟随；远端应用静默不回发", async () => {
-  const { aS, bS, a, b, deliver } = makePair();
-  aS.ready(["s1", "s2", "s3"]);
-  bS.ready(["s1", "s2", "s3"]);
-  deliver(); // 双端空态：无握手宣告
+test("单向角色：sidebar(emit) 本地选会话 → main(receive) open 跟随；receiver 本地变化不外发", async () => {
+  const h = makeOneWay();
+  h.eS.ready(["s1", "s2", "s3"]);
+  h.rS.ready(["s1", "s2", "s3"]);
+  h.deliver();
+  assert.equal(h.posts.length, 0, "双端空态：emitter 无 boot 宣告");
+  assert.deepEqual(h.remoteOpens, []);
 
-  aS.open("s1"); // 用户级动作直达 sessions（真实 ui 路径）
-  deliver();
-  assert.equal(b.current(), "s1", "B 跟随 A 的选中");
-  assert.equal(a.current(), "s1", "A 保持自身选中");
+  h.eS.open("s1"); // sidebar 用户点击（真实 ui 路径直达 sessions）
+  h.deliver();
+  assert.equal(h.currentR(), "s1", "main 跟随 sidebar 选中");
+  assert.equal(h.currentE(), "s1");
+  assert.deepEqual(h.remoteOpens, ["s1"], "main 恰好应用一次 open");
+  assert.equal(h.posts.length, 1, "emitter 广播一次 select s1（boot:false live）");
+  assert.deepEqual(bootFlags(h.posts), [{ id: "s1", boot: false }]);
   await flush();
 
-  // B 反向切 s2：A 跟随。
-  assert.equal(a.posts.length, 1, "前段 A 只发过 select s1");
-  assert.equal(b.posts.length, 0, "前段 B 无广播（纯接收方）");
-  bS.open("s2");
-  deliver();
-  assert.equal(a.current(), "s2");
-  assert.equal(b.current(), "s2");
-  // 只有广播方（B）多发一条 select s2；接收方（A）的远端应用链静默 → 不回发（isRemote + 值去重）。
-  assert.equal(b.posts.length, 1, "B 恰好多发一条 select s2");
-  assert.equal(a.posts.length, 1, "接收方远端应用链不回发消息");
+  // main 本地选中变化（如未来 main 本地 UI 动作）：自身生效、不外发、不影响 sidebar。
+  h.rS.open("s2");
+  h.deliver();
+  assert.equal(h.currentR(), "s2", "main 本地变化自身生效（跟随方本地态）");
+  assert.equal(h.currentE(), "s1", "sidebar 不受 main 本地变化影响");
+  assert.equal(h.posts.length, 1, "receive 零外发：sidebar 侧无新消息");
 });
 
-test("清空双向：一端 clear → 另一端清空", () => {
-  const { aS, bS, a, b, deliver } = makePair();
-  aS.ready(["s1"], "s1");
-  bS.ready(["s1"], "s1");
-  deliver(); // 同值宣告收敛
-  assert.equal(a.current(), "s1");
-  assert.equal(b.current(), "s1");
-  aS.clear();
-  deliver();
-  assert.equal(b.current(), undefined, "B 跟随 A 的 clear");
-  assert.equal(a.current(), undefined);
+test("main(receive) 零外发边界：本地 open/clear/mask 均不触发 post（throw stub 断言）", () => {
+  const h = makeOneWay();
+  h.eS.ready(["s1", "s2"], "s1"); // boot select s1 已入邮袋
+  h.rS.ready(["s1", "s2"], "s1");
+  h.deliver(); // main 恢复同值 → boot select 同值短路，不重复 open
+  assert.equal(h.currentR(), "s1");
+  assert.deepEqual(h.remoteOpens, []);
+  // receive 端本地路径：open/clear/mask——任何一次误 post 都会让核心抛错。
+  h.rS.clear();
+  h.rS.open("s2");
+  h.rS.remove("s2");
+  h.deliver();
+  assert.equal(h.currentR(), undefined, "main 本地数据面 mask 落空");
+  assert.equal(h.currentE(), "s1");
+  assert.equal(h.posts.length, 1, "sidebar 侧只有自己的 boot 宣告，无任何回声");
 });
 
-test("启动握手：单端恢复选中 → 空态端采纳；空态端不宣告 clear", () => {
-  const { aS, bS, a, b, deliver } = makePair();
-  aS.ready(["restored"], "restored");
-  assert.deepEqual(bootFlags(a.posts), [{ id: "restored", boot: true }], "A 发 boot:true 宣告");
-  bS.ready(["restored"]); // 同一运行时：两端列表同（B 只是空态无恢复）
-  assert.equal(b.posts.length, 0, "空态端不广播 clear");
-  deliver();
-  assert.equal(b.current(), "restored", "B 采纳 A 的恢复宣告");
-  a.core.dispose(); b.core.dispose();
+test("sidebar(emit) 不接收远端：live/boot select/clear/脏消息一律忽略且不回显", () => {
+  const h = makeOneWay();
+  // 本测试不投递 boot 到 receiver（其未 ready，投递只会给对端 arm 一个永不落定的
+  // pending 计时器）；只验 emitter 端 ignore 语义——boot 留在邮袋里不影响断言。
+  h.eS.ready(["s1", "s2"], "s1"); // boot select s1
+  const postsBefore = h.posts.length;
+  h.emit._receive({ v: 1, type: "select", sessionId: "s2" });
+  h.emit._receive({ v: 1, type: "select", sessionId: "s2", boot: true });
+  h.emit._receive({ v: 1, type: "clear" });
+  h.emit._receive({ v: 1, type: "mystery" });
+  h.emit._receive("garbage");
+  assert.equal(h.currentE(), "s1", "emitter 选中不受远端消息影响");
+  assert.equal(h.posts.length, postsBefore, "emitter 不因远端消息回显广播");
 });
 
-test("启动握手竞态：双端不同恢复 → id 字典序 max-wins 收敛一致", () => {
-  const { aS, bS, a, b, deliver } = makePair();
-  // 同一运行时：两端列表同（都含两会话），仅持久化恢复 current 不同（交叉握手）。
-  aS.ready(["restored-a", "restored-b"], "restored-a");
-  bS.ready(["restored-a", "restored-b"], "restored-b"); // 'restored-b' > 'restored-a'
-  deliver();
-  assert.equal(a.current(), "restored-b", "双方收敛到较大 id");
-  assert.equal(b.current(), "restored-b");
-  a.core.dispose(); b.core.dispose();
-});
-
-test("真实动作优先：A live 广播覆盖被动收敛；A 忽略迟到 boot 宣告不回退", () => {
-  const { aS, bS, a, b, deliver } = makePair();
-  // 字典序 zeta > alpha：双 passive 恢复 → 收敛 zeta。
-  aS.ready(["alpha", "zeta"], "alpha");
-  bS.ready(["alpha", "zeta"], "zeta");
-  deliver();
-  assert.equal(a.current(), "zeta");
-  assert.equal(b.current(), "zeta");
-  // A 用户真实点 alpha（小于 zeta）→ 无条件传播到 B。
-  aS.open("alpha");
-  deliver();
-  assert.equal(b.current(), "alpha", "live 动作覆盖被动收敛值");
-  // A 此后忽略任何迟到 boot（含旧宣告 zeta 的回放）。
-  a._receive({ v: 1, type: "select", sessionId: "zeta", boot: true });
-  assert.equal(a.current(), "alpha", "live 端忽略迟到 boot 宣告");
-  assert.equal(b.current(), "alpha");
-  a.core.dispose(); b.core.dispose();
-});
-
-test("pending 补开：远端 select 先于本端 baseline 到达 → baseline 后补 open", async () => {
-  const { aS, bS, a, b, deliver } = makePair();
-  aS.ready(["late"], "late"); // A ready + 选中 late（宣告 boot:true 已入邮袋）
-  bS.arrive("late");          // B 数据面已有 late 行，但 phase 仍 pending
-  deliver();                  // A 的 boot 宣告到 B → B 走 pending（phase 非 ready）
-  assert.equal(b.current(), undefined, "pending 未落定前不选中");
-  bS.ready(["late"]);         // B baseline 落库
-  deliver();
+test("启动握手：sidebar 恢复选中 boot 宣告 → main 空态采纳并 open", async () => {
+  const h = makeOneWay();
+  h.eS.ready(["restored"], "restored");
+  assert.deepEqual(bootFlags(h.posts), [{ id: "restored", boot: true }], "emitter 发 boot:true 宣告");
+  h.rS.ready(["restored"]); // 同一运行时两端列表同；main 空态
+  assert.equal(h.posts.length, 1, "receiver 无宣告（被动跟随）");
+  h.deliver();
   await flush();
-  assert.equal(b.current(), "late", "B 在 baseline 后补开 A 宣告的会话");
-  // 补开落定后 sentValue 必须与真实 current 对齐（CodeRabbit #70）：snap 若取自
-  // maybeApplyPending 之前会脱节——后续无关 list 通知误标 live 广播 + 忽略 boot 致
-  // 对端无法收敛。
-  assert.equal(b.core._debug().sentValue, "late", "pending 补开后 sentValue 与 current 对齐");
-  a.core.dispose(); b.core.dispose();
+  assert.equal(h.currentR(), "restored", "main 采纳 emitter 恢复宣告");
+  assert.deepEqual(h.remoteOpens, ["restored"]);
 });
 
-test("远端 open 抛错（未知/未保留 catalog 地址兜底）不炸桥、不影响后续", () => {
-  const { aS, bS, a, b, deliver } = makePair();
-  aS.ready(["ok", "weird"], "ok");
-  bS.ready(["ok", "weird"], "ok");
-  deliver();
-  const realOpen = bS.open.bind(bS);
-  bS.open = (id) => {
+test("握手收敛：receiver 持久化选中被 emitter 宣告覆盖（导航源唯一）；空态 emitter 不强加 clear", () => {
+  // main 自身恢复 beta ≠ sidebar 恢复 alpha → 收敛到 emitter(导航源) 的 alpha。
+  const h1 = makeOneWay();
+  h1.eS.ready(["alpha", "beta"], "alpha");
+  h1.rS.ready(["alpha", "beta"], "beta");
+  h1.deliver();
+  assert.equal(h1.currentR(), "alpha", "receiver 持久化选中被 emitter 宣告覆盖（预期）");
+  assert.equal(h1.currentE(), "alpha");
+  assert.deepEqual(h1.remoteOpens, ["alpha"]);
+  h1.emit.core.dispose(); h1.receive.core.dispose();
+
+  // 反向 edge：emitter 空态启动 → 不宣告（空态不强加 clear），main 保留自身恢复。
+  const h2 = makeOneWay();
+  h2.eS.ready(["s1"]);
+  h2.rS.ready(["s1"], "s1");
+  h2.deliver();
+  assert.equal(h2.currentR(), "s1", "emitter 空态不强加 clear，main 保留自身选中");
+  assert.equal(h2.posts.length, 0);
+});
+
+test("clear 下行与再收敛；数据面删除 current（mask）幂等回空", () => {
+  const h = makeOneWay();
+  h.eS.ready(["gone", "alive"], "gone");
+  h.rS.ready(["gone", "alive"], "gone");
+  h.deliver(); // boot select gone；main 恢复同值 → 同值短路不重复 open
+  assert.equal(h.currentR(), "gone");
+  assert.deepEqual(h.remoteOpens, [], "main 恢复同值：boot select 同值短路不重复 open");
+
+  // sidebar 清空选中 → clear 下行 → main 清空。
+  h.eS.clear();
+  h.deliver();
+  assert.equal(h.currentR(), undefined, "main 跟随 clear");
+  assert.equal(h.currentE(), undefined);
+
+  // 再选 → 再收敛。
+  h.eS.open("alive");
+  h.deliver();
+  assert.equal(h.currentR(), "alive");
+  assert.deepEqual(h.remoteOpens, ["alive"]);
+
+  // host 删除当前会话：两端数据面同步 remove → current mask undefined。
+  // emitter 侧下行 clear（live），receiver 侧同源 mask 已空 → 远端 clear 同值短路幂等。
+  h.eS.remove("alive");
+  h.rS.remove("alive");
+  h.deliver();
+  assert.equal(h.currentE(), undefined);
+  assert.equal(h.currentR(), undefined);
+
+  // mask 后重新选择继续收敛（不悬挂）。
+  h.eS.open("gone");
+  h.deliver();
+  assert.equal(h.currentR(), "gone");
+  assert.deepEqual(h.remoteOpens, ["alive", "gone"]);
+});
+
+test("pending 补开（receive 端）：远端 select 先于本端 baseline → ready 后补 open", async () => {
+  const h = makeOneWay();
+  h.eS.ready(["late"], "late"); // boot select late 已入邮袋
+  h.rS.arrive("late");          // main 数据面已有行但 phase 仍 pending
+  h.deliver();                  // boot → main 走 pending（phase 非 ready）
+  assert.equal(h.currentR(), undefined, "pending 未落定前不选中");
+  assert.equal(h.receive.core._debug().pendingId, "late");
+  h.rS.ready(["late"]);         // main baseline 落库
+  h.deliver();
+  await flush();
+  assert.equal(h.currentR(), "late", "main 在 baseline 后补开 emitter 宣告的会话");
+  // 补开落定后簿记必须与真实 current 对齐（沿用 V4 CodeRabbit #70 纪律：snap 若取自
+  // maybeApplyPending 之前会脱节）。
+  assert.equal(h.receive.core._debug().sentValue, "late", "pending 补开后簿记与 current 对齐");
+  assert.deepEqual(h.remoteOpens, ["late"]);
+});
+
+test("pending 目标被恢复先行落定（同值）→ 不重复 open（降噪）", async () => {
+  const h = makeOneWay();
+  h.eS.ready(["s1"], "s1"); // boot select s1 已入邮袋
+  h.rS.arrive("s1");        // main 数据面行先到（phase 仍 pending）
+  h.deliver();
+  assert.equal(h.receive.core._debug().pendingId, "s1", "未 ready → pending 暂存");
+  assert.deepEqual(h.remoteOpens, [], "pending 未落定不 open");
+  h.rS.ready(["s1"], "s1"); // baseline + main 自身恢复 s1 同 tick 落定
+  h.deliver();
+  await flush();
+  assert.equal(h.currentR(), "s1");
+  assert.deepEqual(h.remoteOpens, [], "恢复先行落定（同值）→ 清 pending 不重复 open");
+  assert.equal(h.receive.core._debug().pendingId, undefined);
+});
+
+test("值去重（emit 端）：同值尾通知/同 id 重放不重复广播", () => {
+  const h = makeOneWay();
+  h.eS.ready(["s1"]); // 空态启动
+  assert.equal(h.posts.length, 0, "空态不广播 clear");
+  h.eS.open("s1");
+  assert.equal(h.posts.length, 1, "首个 live select 广播一次");
+  h.eS.arrive("s2"); // 数据面行增量、current 不变 → 同值去重
+  h.eS.open("s1");   // 同 id 重放（同值 list.set 尾）→ 去重
+  assert.equal(h.posts.length, 1, "同值后续通知不重复广播");
+  h.eS.open("s2");
+  assert.equal(h.posts.length, 2, "真变化才广播下一条");
+});
+
+test("receive 端同值短路：远端重复 select（live/boot）不重复 open（降噪）", () => {
+  const h = makeOneWay();
+  h.eS.ready(["s1", "s2"], "s1");
+  h.rS.ready(["s1", "s2"]);
+  h.deliver(); // boot → main open s1 一次
+  assert.deepEqual(h.remoteOpens, ["s1"]);
+  // 同值远端消息（live/boot 皆然）：同值短路 → 不重复 open、不制造冗余 list.set。
+  h.receive._receive({ v: 1, type: "select", sessionId: "s1" });
+  h.receive._receive({ v: 1, type: "select", sessionId: "s1", boot: true });
+  assert.deepEqual(h.remoteOpens, ["s1"], "同值远端 select（live/boot）不重复 open");
+  assert.equal(h.currentR(), "s1");
+  // 真变化（切到 s2）才 open——同值短路不吞真变化。
+  h.receive._receive({ v: 1, type: "select", sessionId: "s2" });
+  assert.deepEqual(h.remoteOpens, ["s1", "s2"]);
+  assert.equal(h.currentR(), "s2");
+});
+
+test("receive 端远端 open 抛错（未知/未保留地址兜底）不炸桥；脏消息忽略", () => {
+  const h = makeOneWay();
+  h.eS.ready(["ok", "weird"], "ok");
+  h.rS.ready(["ok", "weird"], "ok");
+  h.deliver(); // boot select ok：main 恢复同值 → 同值短路
+  const realOpen = h.rS.open.bind(h.rS);
+  h.rS.open = (id) => {
     if (id === "weird") throw new Error("sessions.select: unknown session weird");
     realOpen(id);
   };
-  b._receive({ v: 1, type: "select", sessionId: "weird" }); // 抛 → 核心 catch
-  b._receive({ v: 1, type: "select", sessionId: "ok" });
-  assert.equal(b.current(), "ok");
-  assert.equal(a.current(), "ok");
+  h.receive._receive({ v: 1, type: "select", sessionId: "weird" }); // open 抛 → 核心 catch
+  assert.equal(h.currentR(), "ok", "抛错不改变 main 选中、桥不炸");
+  h.receive._receive({ v: 1, type: "select", sessionId: "ok" }); // 同值 → 不 open
+  h.receive._receive({ v: 1, type: "select", sessionId: "ok" });
+  assert.equal(h.currentR(), "ok");
+  // 脏消息（非本协议/坏载荷）忽略不抛。
+  h.receive._receive({ v: 2, type: "select", sessionId: "ok" });
+  h.receive._receive({ type: "select", sessionId: "ok" });
+  h.receive._receive(null);
+  h.receive._receive("garbage");
+  h.receive._receive({ v: 1, type: "mystery" });
+  h.receive._receive({ v: 1, type: "select", sessionId: "" });
+  assert.equal(h.currentR(), "ok");
 });
 
-test("非协议/脏消息忽略不抛", () => {
-  const { bS, b } = makePair();
-  bS.ready(["s1"], "s1");
-  b._receive({ v: 2, type: "select", sessionId: "s1" });
-  b._receive({ type: "select", sessionId: "s1" });
-  b._receive(null);
-  b._receive("garbage");
-  b._receive({ v: 1, type: "mystery" });
-  b._receive({ v: 1, type: "select", sessionId: "" });
-  assert.equal(b.current(), "s1");
+test("dispose 停摆：emit 不再广播、receive 不再订阅/应用", () => {
+  const h = makeOneWay();
+  h.eS.ready(["s1"]);
+  h.rS.ready(["s1"]);
+  h.emit.core.dispose();
+  h.receive.core.dispose();
+  h.eS.open("s1"); // dispose 后本地变化不再广播
+  h.deliver();
+  assert.equal(h.posts.length, 0, "dispose 后不再广播");
+  h.receive._receive({ v: 1, type: "select", sessionId: "s1" }); // disposed receive 忽略
+  assert.equal(h.currentR(), undefined, "dispose 后不再应用远端");
 });
 
-test("数据面删除当前会话（mask）→ 两端回空；再选 → 再次收敛", () => {
-  const { aS, bS, a, b, deliver } = makePair();
-  aS.ready(["gone", "alive"], "gone");
-  bS.ready(["gone", "alive"], "gone");
-  deliver();
-  assert.equal(a.current(), "gone");
-  assert.equal(b.current(), "gone");
-  // host 删除当前会话：两端数据面同步 remove → current mask undefined。
-  aS.remove("gone");
-  bS.remove("gone");
-  deliver();
-  assert.equal(a.current(), undefined);
-  assert.equal(b.current(), undefined);
-  aS.open("alive");
-  deliver();
-  assert.equal(b.current(), "alive");
-  assert.equal(a.current(), "alive");
-});
-
-test("dispose 停止订阅与广播", () => {
-  const { aS, bS, a, b, deliver } = makePair();
-  aS.ready(["s1"]);
-  bS.ready(["s1"]);
-  a.core.dispose();
-  const before = a.posts.length + b.posts.length;
-  aS.open("s1");
-  deliver();
-  assert.equal(a.posts.length + b.posts.length, before, "dispose 后不再广播");
-});
-
-test("接线层：ctx.sessions 缺失 → 静默降级 noop；有 sessions → 建桥并可 dispose", () => {
+test("mode 校验（缺省/非法抛错）+ 接线层（降级 noop / 真 channel 可建可 dispose）", () => {
   assert.equal(SYNC_CHANNEL, "dshana.sync");
-  // sessions 服务缺失：不抛、noop。
-  const disposeMissing = createSessionSyncBridge({});
-  assert.equal(typeof disposeMissing, "function");
-  disposeMissing();
-  // 有 sessions（Node 18+ 自带 BroadcastChannel 全局，真开一个 channel 验证闭环）。
-  const stubCtx = {
-    sessions: {
-      list: { subscribe: () => () => {}, getSnapshot: () => ({ phase: "ready", byId: {}, current: undefined }) },
-      open: () => {},
-      clear: () => {},
-    },
+  assert.equal(BRIDGE_MODE_EMIT, "emit");
+  assert.equal(BRIDGE_MODE_RECEIVE, "receive");
+  const stubList = {
+    subscribe: () => () => {},
+    getSnapshot: () => ({ phase: "ready", byId: {}, current: undefined }),
   };
-  const dispose = createSessionSyncBridge(stubCtx);
-  assert.equal(typeof dispose, "function");
-  dispose();
+  // 非法/缺省 mode 一律抛错——防止接线漏传方向静默成错角色（旧双向 API 语义已删）。
+  assert.throws(() => createSyncCore({ mode: "both", list: stubList, open() {}, clear() {}, post() {} }), /mode/);
+  assert.throws(() => createSyncCore({ list: stubList, open() {}, clear() {}, post() {} }), /mode/);
+  assert.throws(() => createSessionSyncBridge({}, undefined), /mode/);
+  // 接线层：sessions 缺失 → 静默降级 noop（不抛）；有 sessions → 建桥（emit/receive）可 dispose。
+  for (const mode of [BRIDGE_MODE_EMIT, BRIDGE_MODE_RECEIVE]) {
+    const disposeMissing = createSessionSyncBridge({}, mode);
+    assert.equal(typeof disposeMissing, "function");
+    disposeMissing();
+    const stubCtx = {
+      sessions: {
+        list: stubList,
+        open: () => {},
+        clear: () => {},
+      },
+    };
+    const dispose = createSessionSyncBridge(stubCtx, mode);
+    assert.equal(typeof dispose, "function");
+    dispose();
+  }
 });


### PR DESCRIPTION
## 概述

fpFullPanel V4 收敛：选中态桥从通用广播（#70）改为**单向下行——sidebar（emit）→ main（receive）**，full 彻底排除。动因：官方竞态噪音（AgentPresetSeatController 会话 scope 销毁窗口被 list.set 触发 inactive context 错误，已记录于 #71）——单向收敛砍掉 main 广播源与 sidebar 接收路径，消除交叉/并发 list.set 放大面（预期降频，官方窗口不根除，如实记录）。

## mode 拆分方案

单 `createSyncCore(opts)` + `opts.mode: 'emit' | 'receive'`（常量 `BRIDGE_MODE_EMIT/BRIDGE_MODE_RECEIVE`），缺省/非法 mode 一律抛错（防接线漏方向静默成错角色）。比拆双工厂重复更少：两角色共享消息校验、去重簿记、pending/超时骨架。

- **emit（sidebar）**：列表变化 → post（首 ready 投影 `boot:true` 宣告一次，空态不宣告）；`receive()` no-op + 接线层不订阅频道（双保险）
- **receive（main）**：远端 select/clear → applyRemote 本地 open/clear；**零 post 面**；pending 补开仅此端；boot/live 一视同仁（去掉 V4 字典序 max-wins + live 优先裁决——单向下无竞争宣告端，receiver 持久化选中被 emitter 覆盖属预期）
- **full**：不建桥（readView 判定）

**防回环简化**：协议层回环结构性归零（emit 不收、receive 不发）→ isRemote suppressToken 结构性退役；保留 emitter 同值去重 + receiver 同值短路 + pending 补开前短路（不制造冗余 list.set，降官方竞态触发频）。

## 改动清单

- `sync-bridge.js`：核心改造 + 文件头收敛记录（模式拆分、防回环简化、已知边界同步：竞态降频未根除 + BroadcastChannel 无队列导致 receiver 晚启动错过 boot 宣告的时序边界）
- `client.js`：effect 3 按视图角色分派（sidebar=emit / main=receive / full 无）
- `tests/sync-bridge.test.mjs`：双向用例改写单向语义 + 角色用例（13 用例）
- `SidebarOnlyFrame.tsx` / `MainFrame.tsx`：头注释角色同步

## 验证记录

- **单测**：`node tests/*.test.mjs` 三文件 40/40 绿；sync-bridge 13 用例覆盖角色边界（receive 本地变化零外发用 throw stub 硬断言）、握手收敛、pending 补开、clear 下行、值去重、mode 校验
- **构建**：`pnpm run build` 全绿（view client 16.89 kB）
- **实机语义**：sidebar 点会话 → main 跟随（单测用例覆盖）；main 无切换 UI 无反向源（断言零外发）；full 不参与
- **已知边界**：竞态噪音降频不根除（官方窗口）；receiver 晚启动错过 boot 宣告可自愈（下次 live select 同步）

## 背景说明

- 与 view-layouts「通用广播」定稿的偏差及理由记录于 sync-bridge.js 头（官方竞态 + 现实切换源只有 sidebar）
- 下一步（独立任务）：manifest 双卡声明（main 卡 route /main + sidebar 子卡 pageOf，宿主 functionPanel route 支持前用父子卡撑着）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated sidebar and main view synchronization to use a one-way flow: sidebar selections are sent to main views.
  * Main views now receive and apply sidebar selections without sending them back.
  * Added more reliable handling for initial synchronization, pending selections, duplicate updates, clearing, and invalid messages.

* **Documentation**
  * Clarified the updated synchronization behavior and responsibilities for sidebar and main views.

* **Tests**
  * Expanded coverage for one-way synchronization, recovery, validation, disposal, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->