### PR TITLE
feat(ui): 父子双卡——manifest 拆 /main + /sidebar 子卡（pageOf），壳页按 view 参数化

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -40,10 +40,13 @@ Hana 宿主进程
 
 ## DSH Web UI（DSHana 标签页）
 
-配置 `webPort`（默认 3080）时插件加载即**进程内 boot**，DSHana 以整页卡片注册（manifest `contributes.cards[]`，id `dshana`，route `/webui`），卡片 iframe 内嵌 `http://127.0.0.1:<webPort>/`（根路径，免鉴权）：
+配置 `webPort`（默认 3080）时插件加载即**进程内 boot**，DSHana 以**父子双卡**注册（manifest
+`contributes.cards[]`：主卡 id `dshana` route `/main`（realization:page + siteNavEntry）；子卡 id
+`dshana-sidebar` route `/sidebar`、`pageOf: "dshana"`——宿主 functionPanel route 参数落地前的
+过渡表达），每卡壳页 iframe 内嵌 `http://127.0.0.1:<webPort>/?dshana-view=<view>`（同源免鉴权）：
 
 - **三态自举页（Bootstrap 壳，T4）**：按总线连接状态判定——已连接直接渲染 iframe；未连接渲染自举页，数据源 = `GET /webui/boot-state`（T3 单一状态出口）+ `GET /webui/events` 事件流（ready/pending/diag-changed/theme-pref）：booting（阶段时间线 + 安装实时日志 + 退避信息）/ action-needed（errorClass 人话 + 操作步骤 + 自动续跑/停等说明）/ ready（iframe 直嵌）。**页面无任何手动按钮**
-- **功能面板（functionPanel）**：仅 status 段（web host 状态：运行中/自举中/需要处理），actions 段已随手动入口退役（T5）
+- **父子双卡视图装配（V5 过渡）**：主卡 dshana 直嵌 main 视图（`?dshana-view=main`，选中态桥 receive）；子卡 dshana-sidebar 直嵌纯侧栏视图（`?dshana-view=sidebar`，emit）——URL 参数驱动装配与桥角色（`@dsh-hanako/view` readView / sync-bridge），单向下行分落两卡；子卡不声明 realization/siteNavEntry/fpFullPanel（宿主 schema：声明 pageOf 的卡 realization 会被删，显式不声明最干净）。旧 manifest 的 fpFullPanel/functionPanel（embedUrl 侧栏）已摘除，fp 集成待宿主 route 参数支持后议
 - **iframe 主题桥**：壳页 postMessage 回传宿主主题 vars → 注入的 theme 插件写 body 层 `!important` 覆盖（`--dsw-alias-*` + `--dsw-specific-*` token 映射，无静态主题表）；DSH 偏好 `system`（默认）跟随宿主明暗 + 配色，`light`/`dark` 用原生；偏好变更经 3s 轻量轮询 `settings/describe` 实时重评（旧 events.host WS 端点已随 DSH 0.1.2 退役）
 
 ### DSHana 设置分页

--- a/src-cordis/plugins/view/SidebarOnlyFrame.tsx
+++ b/src-cordis/plugins/view/SidebarOnlyFrame.tsx
@@ -61,6 +61,25 @@ export function SidebarOnlyFrame(props: {
   // ResizeObserver 首报即校正为容器实测宽；宿主面板宽度可调，观察持续跟随。
   const [width, setWidth] = useState(() => window.innerWidth)
 
+  // sidebar 减法（logoRow）：fp 窄栏顶部品牌 logo 行（SidebarRoot logoRow——wide 态 = brand/
+  // New Session 快捷）在宿主 fp 面板冗余，剪除。官方 class 为 css-modules hash_local 产物
+  // （如 hHd-Xa_logoRow），local 名后缀稳定 → [class$="_logoRow"] 属性后缀匹配不受 hash
+  // 变化影响；作用域限定本帧 data-sidebar-frame，不影响 full 视图的 sidebar 列。
+  // 样式动态注入（style 标签 + !important 压官方 css 注入序），卸载即清。
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+    const tagId = 'dshana-sidebar-subtract-logoRow'
+    if (document.querySelector('style[data-dshana-subtract="' + tagId + '"]') !== null) return
+    const tag = document.createElement('style')
+    tag.dataset.dshanaSubtract = tagId
+    tag.textContent =
+      '[data-sidebar-frame] [class$="_logoRow"] { display: none !important }'
+    document.head.appendChild(tag)
+    return () => {
+      try { if (tag.parentNode) tag.parentNode.removeChild(tag) } catch { /* 已脱离 */ }
+    }
+  }, [])
+
   // 容器框级测量（同 AppFrame frame 自测语义：rAF 节流 + 取边框盒宽）。
   useEffect(() => {
     const el = frameRef.current
@@ -82,7 +101,12 @@ export function SidebarOnlyFrame(props: {
   }, [])
 
   return (
-    <div ref={frameRef} className={css.frame} style={{ gridTemplateColumns: 'minmax(0, 1fr)' }}>
+    <div
+      ref={frameRef}
+      className={css.frame}
+      data-sidebar-frame=""
+      style={{ gridTemplateColumns: 'minmax(0, 1fr)' }}
+    >
       {/* 减法：.frame 内只留官方 .sidebarCol 列（fill/边框/裁剪上下文与 full 视图 sidebar
           列同构），center/details 列从结构上减除；sidebar 槽渲染点 collapsed 恒 false
           （fp 面板唯一内容面，无 rail 语义），width = 容器实测宽直通 SidebarRoot。 */}

--- a/src/assets/webui-shell.jinja2
+++ b/src/assets/webui-shell.jinja2
@@ -636,10 +636,15 @@
         // 事件驱动的就绪（bus ready / 父窗口握手）可能早于快照：异步拉一次对齐面板/状态
         if (!(boot && boot.ready === true)) refreshBoot();
       }
+      // iframe src 按视图参数化（父子双卡过渡方案）：it.viewQuery 由服务端路由决定——
+      // /main → "?dshana-view=main"（main 视图 = 接收端 receive）、/sidebar →
+      // "?dshana-view=sidebar"（纯侧栏视图 = 发射端 emit），两卡各自直嵌同源 3080；
+      // viewQuery 空串（view 缺失/白名单外）＝无参 root = full 整页视图——仅调试兜底
+      // （宿主双卡路由恒带 view，正常不可达；3080 直开仍是无参 full）。
       function attach() {
         var wasPending = document.body.getAttribute("data-view") !== "ready";
         if (wasPending || !frame.getAttribute("src")) {
-          frame.src = "http://127.0.0.1:{{= it.port }}/";
+          frame.src = "http://127.0.0.1:{{= it.port }}/{{= it.viewQuery }}";
         }
         startThemePush();
       }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -74,6 +74,7 @@
         "id": "dshana-sidebar",
         "title": "DSHana Sidebar",
         "route": "/sidebar",
+        "cardForm": "flush",
         "pageOf": "dshana"
       }
     ]

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -64,17 +64,17 @@
       {
         "id": "dshana",
         "title": "DSHana",
-        "route": "/webui",
+        "route": "/main",
         "cardForm": "flush",
         "titlebar": "translucent",
         "realization": "page",
-        "siteNavEntry": true,
-        "fpFullPanel": true,
-        "functionPanel": {
-          "id": "dshana-sidebar",
-          "label": "DSHana",
-          "embedUrl": "http://127.0.0.1:3080/?dshana-view=sidebar"
-        }
+        "siteNavEntry": true
+      },
+      {
+        "id": "dshana-sidebar",
+        "title": "DSHana Sidebar",
+        "route": "/sidebar",
+        "pageOf": "dshana"
       }
     ]
   }

--- a/src/routes/webui.js
+++ b/src/routes/webui.js
@@ -1,11 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2026 Nyasers
 //
-// routes/webui.js — dsh-hanako 插件页：contributes.cards（realization:page）内嵌 dsh Web UI
-//   GET /webui            插件页：ready（总线已连接）直嵌 dsh Web UI iframe；未 ready 渲染
-//                         Bootstrap 三态自举页（booting/action-needed/ready，见 webui-shell 头注释；
-//                         数据源 = GET /webui/boot-state + /webui/events 事件流；
-//                         功能面板 functionPanel 仅 status 常驻，无操作段）
+// routes/webui.js — dsh-hanako 宿主页面：父子双卡（宿主 functionPanel route 参数落地前的
+// 过渡表达——contributes.cards 两张卡各嵌一个同源 3080 iframe，?dshana-view=<view> 驱动视图）
+//   GET /main            主卡（cards[0] dshana，realization:page）：ready（总线已连接）直嵌
+//                         main 视图 iframe（?dshana-view=main，选中态桥接收端 receive）；
+//                         未 ready 渲染 Bootstrap 三态自举页（booting/action-needed/ready，
+//                         见 webui-shell 头注释；数据源 = GET /webui/boot-state + /webui/events
+//                         事件流）
+//   GET /sidebar         侧栏子卡（cards[1] dshana-sidebar，pageOf: "dshana"）：同壳页按 view
+//                         参数化——?dshana-view=sidebar = 纯侧栏视图（发射端 emit）；自举页/
+//                         boot-state/events 与主卡共用（路由只差 iframe 的 view 参数）
 //   GET /webui/boot-state  自举状态快照（T3 spec：dsh-deps-zero-intervention）——单一状态出口：
 //                         g.boot 状态机 + g.deps（含 T1 errorClass/guidance）+ g.web 就绪收敛成
 //                         { phase, ready, deps, boot, web } 三段 JSON，三态可渲染；Bootstrap
@@ -84,7 +89,7 @@ function busReady() {
  *
  * 返回结构（值域与缺省语义）：
  *   phase     状态机阶段 ensure-deps|waiting|booting|ready（g.boot.phase；未跑过 = ensure-deps）
- *   ready     web host 就绪 = g.web.ready（boot 收敛）或总线已连接（busReady，与 /webui
+ *   ready     web host 就绪 = g.web.ready（boot 收敛）或总线已连接（busReady，与页面
  *             渲染同源判定）；停机/重启窗口由 /webui/events pending/ready 事件驱动页面翻转
  *   deps      { status, errorClass, guidance, error, version, logTail }
  *               status     g.deps.status：idle|installing|running|ok|error
@@ -184,13 +189,17 @@ function readBootState() {
   }
 }
 
-/** 插件页 HTML 壳：ready=true 直接内联 iframe；否则渲染自举页（三态 Bootstrap 壳，
- * 见 assets/webui-shell.jinja2 头注释；T4 spec：dsh-deps-zero-intervention）。
+/** 页面壳（主卡 /main 与子卡 /sidebar 共用）：ready=true 直接内联 iframe；否则渲染
+ * 自举页（三态 Bootstrap 壳，见 assets/webui-shell.jinja2 头注释；T4 spec：
+ * dsh-deps-zero-intervention）。
  * colorScheme：按宿主 hana-theme 映射的 color-scheme（dark/light）。dsh 主题为
  * system 时通过 prefers-color-scheme 解析，Chromium 会让跨源 iframe 继承父页面
  * 的 color-scheme，因此 dsh 会跟随宿主主题；dsh 内显式选了 light/dark 则不受影响。
  * boot：未就绪时服务端取一次自举状态快照（readBootState，T3 单一状态出口）作首帧
- * 渲染数据（JSON 对象或 null）；壳页随后以 /webui/events 事件驱动刷新本快照。 */
+ * 渲染数据（JSON 对象或 null）；壳页随后以 /webui/events 事件驱动刷新本快照。
+ * view：视图标识（"main" | "sidebar"，父子双卡由注册路由决定）→ 透传给壳页拼 iframe
+ * URL 查询参数 ?dshana-view=<view>。白名单外/缺失 → viewQuery 空串（iframe 无参 root
+ * = full 整页视图，仅调试兜底——宿主双卡路由恒带 view，正常不可达；3080 直开仍无参）。 */
 function buildShell({
   ready,
   hcLink,
@@ -199,6 +208,7 @@ function buildShell({
   port,
   colorScheme,
   boot,
+  view,
 }) {
   // dsh-frame 保持裸嵌（曾尝试显式声明 sandbox/allow 绕过宿主沙箱，实测跨源继承链
   // 下内层声明无法生效，属无效方案已回滚，见 CHANGELOG）。
@@ -211,6 +221,10 @@ function buildShell({
   const initBoot = boot
     ? JSON.stringify(boot).replace(/<\//g, "<\\/")
     : "null";
+  // 父子双卡视图参数化：view 白名单（main/sidebar）外一律空串 → 壳页 iframe 无参 root
+  // = full 整页视图（调试/兜底；宿主双卡路由恒带 view，正常不可达）
+  const viewQuery =
+    view === "main" || view === "sidebar" ? "?dshana-view=" + view : "";
   // HTML 模板来自 src/assets/webui-shell.jinja2（asset/source 内联，占位符保留）；
   // 渲染函数由 template-loader 在构建期生成（doT），scope 直接作 it 传入。
   return webuiShellHtml({
@@ -223,6 +237,8 @@ function buildShell({
     api,
     initBoot,
     port,
+    view,
+    viewQuery,
   });
 }
 
@@ -233,7 +249,10 @@ export default function registerWebuiRoutes(app, ctx) {
     ctx && typeof ctx.config === "object" && ctx.config ? ctx.config : {};
   const port = Number(cfg.webPort) || 3080;
 
-  // 插件页：按总线连接状态判定就绪——已连接直接渲染 iframe；未连接渲染 Bootstrap
+  // 页面（父子双卡，见文件头）：主卡 /main 与子卡 /sidebar 共用同一壳页与自举逻辑，仅
+  // iframe 的 view 参数不同（/main → main 视图 = 接收端 receive；/sidebar → sidebar 视图
+  // = 发射端 emit；URL ?dshana-view=<view> 驱动视图装配与桥角色，见 src-cordis/plugins/view
+  // readView 与 sync-bridge.js）。就绪判定：已连接直接渲染 iframe；未连接渲染 Bootstrap
   // 自举页（三态：booting/action-needed/ready，壳页订阅 /webui/events 事件流 + 刷新
   // /webui/boot-state 驱动）。不再服务端 probeHost（就绪事件化，probeHost 仅诊断路径
   // 使用）。未就绪时服务端同步取一次自举状态快照（readBootState，首屏即渲染三态）；
@@ -242,7 +261,7 @@ export default function registerWebuiRoutes(app, ctx) {
   // /webui/boot-state（T3 单一状态出口），SPA 全部资源由 @dsh-hanako/app 子插件
   // （dsh 3080）iframe 同源直嵌提供，无浏览器端劫持/改写。
 
-  app.get("/webui", async (c) => {
+  const page = (view) => async (c) => {
     // 壳页：iframe 直嵌 @dsh-hanako/app 子插件（dsh 3080）serve 的 fork SPA——
     // iframe 内同源（资源/API/SSE/WS 全由子插件提供，免鉴权，无劫持无 token/PSS）；
     // 宿主只做页面壳：就绪事件化 / 自举状态 / 主题与剪贴板桥（全部在壳页 JS 里）。
@@ -264,9 +283,12 @@ export default function registerWebuiRoutes(app, ctx) {
         port,
         colorScheme,
         boot,
+        view,
       }),
     );
-  });
+  };
+  app.get("/main", page("main"));
+  app.get("/sidebar", page("sidebar"));
 
   // 就绪事件流（GET /webui/events，SSE 式 chunked）——壳页事件化的宿主推送通道
   // （就绪/停机/自举状态变化/主题偏好，全部事件驱动；壳页收到后刷新 /webui/boot-state

--- a/src/skills/dsh-hanako/SKILL.md
+++ b/src/skills/dsh-hanako/SKILL.md
@@ -36,7 +36,7 @@ config.json 由宿主设置界面生成、**不随包分发**，缺省全部可�
 
 ## DSHana 标签页（Bootstrap 三态自举页，T4）
 
-标签页（`/webui`）按 `boot-state` 渲染三态，**无任何可点的启动/安装/检测按钮**（手动入口已随 T5 退役）：
+标签页（主卡 DSHana route `/main`；子卡 dshana-sidebar route `/sidebar`、`pageOf: dshana`——两卡同壳页按 `?dshana-view=<view>` 装配视图：main 视图 = 接收端 receive、sidebar 视图 = 发射端 emit）按 `boot-state` 渲染三态，**无任何可点的启动/安装/检测按钮**（手动入口已随 T5 退役）：
 
 1. **booting（自举中）**：阶段时间线（依赖就绪 → 启动 Web Host → 就绪）+ 依赖安装实时日志尾滚动 + 重试信息（第 N 次 / 下次自动重试时刻）。自动推进中，等即可。
 2. **action-needed（需要处理）**：自动链暂停。页面给出 **errorClass 人话 + 明确操作步骤**（如配置 nodejsPath、装编译工具链、清理磁盘）+ 「自动续跑中/停等」说明（区分可恢复退避重试中 vs 需重启宿主/等条件）；原始错误折叠「详情」。用户只做页面所述环境动作，**完成后自动续跑**。


### PR DESCRIPTION
## 概述

父子双卡（过渡方案，宿主 functionPanel 支持 route 参数落地前）：manifest 拆两张卡表达 main/sidebar 关系——主卡 `dshana`（route `/main`，主页）+ 子卡 `dshana-sidebar`（route `/sidebar`，`pageOf: "dshana"`）。壳页按视图参数化：`/main` 嵌 `?dshana-view=main`、`/sidebar` 嵌 `?dshana-view=sidebar`，V4 单向下行桥（sidebar emit → main receive）天然落在两卡上。

## 改动清单

- **`src/manifest.json`**：主卡 route `/webui` → `/main`，删 `fpFullPanel` + `functionPanel`（宿主 fp 集成后议，字段不留）；新增子卡 `dshana-sidebar`：route `/sidebar`、`pageOf: "dshana"`、`cardForm: "flush"`、无 realization/siteNavEntry/fpFullPanel（schema：pageOf 卡不带 page 语义）
- **`src/routes/webui.js`**：页面路由拆为共用 `page(view)` 工厂（`/main` + `/sidebar`）；`buildShell` 加 view 白名单（main/sidebar）→ `viewQuery` 透传；内部端点 `/webui/boot-state`、`/webui/events` 路径保持（两卡壳页共享）；文件头注释同步
- **`src/assets/webui-shell.jinja2`**：`attach()` iframe src 拼 `viewQuery`——白名单外/缺失回退无参（full 整页，调试兜底）；脏 view 值服务端白名单挡掉
- **`src-cordis/plugins/view/SidebarOnlyFrame.tsx`**：sidebar 减法剪 logoRow——frame 加 `data-sidebar-frame` 标记 + 动态注 style：官方 SidebarRoot `logoRow`（css-modules `hash_local` 产物，fp 窄栏品牌行冗余）用 `[class$="_logoRow"]` 属性后缀匹配（local 名不受 hash 变化影响）+ `!important`，作用域限 sidebar 帧不影响 full，卸载即清
- **`src/skills/dsh-hanako/SKILL.md` / `DESIGN.md`**：标签页 route 引用同步（/webui → /main + /sidebar 子卡说明；内部端点引用不动）

**未动**：client.js（含 #73 self-heal）、vendor、cordis.patch.yml roster、CHANGELOG。

## 桥角色对齐

main 卡 = main 视图（receive 端）、sidebar 卡 = sidebar 视图（emit 端）——URL view 参数驱动，单向下行正好落在两卡：sidebar 卡操作会话 → main 卡跟随。

## 验证记录

- **构建**：`pnpm run build` 全绿；产物 manifest 两卡核对（子卡 `pageOf: dshana` + `cardForm: flush`、主卡 route /main、无 fpFullPanel/functionPanel/embedUrl——src/dist/bundle 三处 grep 0 残留）
- **产物抽查**：dist/index.js 含 `/main` `/sidebar` 页面路由 + 内部端点；模板编译后 viewQuery 正确拼进 iframe src；view client 含 `_logoRow` 减法规则 + `data-sidebar-frame`
- **实机观察点（声明实验）**：部署重载后宿主打开 DSHana（siteNavEntry）→ /main 主页（无侧栏 main 视图）；子卡 dshana-sidebar 的宿主呈现（pageOf 处理 + flush 形态）待观察


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added separate main and sidebar views for the DSH Web UI.
  - Both views use a shared interface and can be selected with the `dshana-view` URL parameter.
  - Added a dedicated sidebar presentation with streamlined framing.

- **Changes**
  - Updated the DSHana card route to `/main` and added `/sidebar`.
  - The previous `/webui` route and integrated function-panel sidebar configuration are no longer available.
  - Existing three-state bootstrap behavior remains unchanged.

- **Documentation**
  - Updated DSHana tab documentation with the new routes and view-selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->