### PR TITLE
feat: ACP 进程内通讯通道——任务通讯零端口（指令/事件/审批全链）

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2799,6 +2799,7 @@ packages:
   '@smithy/node-http-handler@4.12.0':
     resolution: {integrity: sha512-0mq1pHadfyXCYCqm2cNpbjNIT+fbaUpNxewZb/YNr2L0IrEVMOb8gM/Fl4K6XvHCW3uSNDFwPl/+iKm0bx9jYg==}
     engines: {node: '>=18.0.0'}
+    deprecated: Depreacted due to a memory leak issue https://github.com/smithy-lang/smithy-typescript/issues/2258
 
   '@smithy/node-http-handler@4.7.3':
     resolution: {integrity: sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==}

--- a/src-cordis/cordis.patch.yml
+++ b/src-cordis/cordis.patch.yml
@@ -225,6 +225,12 @@
     - id: '@dsh-hanako/provider'
       name: '@dsh-hanako/provider'
 
+    # ACP 插件的插件：agent 工厂 setup 后置段——补 dsh-acp 缺的 preset 组合/effort
+    # 校准（探测版：只 patch + 日志）。须在 dsh-acp 同树激活（依赖 agents 工厂，
+    # 行序不敏感——patch 在首个 session 请求前完成即可）。
+    - id: '@dsh-hanako/acp-assist'
+      name: '@dsh-hanako/acp-assist'
+
     - id: '@dsh-hanako/settings'
       name: '@dsh-hanako/settings'
 

--- a/src-cordis/plugins/acp-assist/cordis.config.mjs
+++ b/src-cordis/plugins/acp-assist/cordis.config.mjs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2026 Nyasers
+//
+// @dsh-hanako/acp-assist 自持构建描述（学官方 dsh 组织：配置随源码走）。
+// 消费方：src-cordis/build.js（package.json build:cordis）扫描本文件 → src-cordis/build/* preset。
+// 约定：本文件存在 = 该包有 service 半（index.js，rspack 打包，默认开）；本包无 client 半。
+export default {};

--- a/src-cordis/plugins/acp-assist/index.js
+++ b/src-cordis/plugins/acp-assist/index.js
@@ -120,15 +120,24 @@ export function apply(ctx) {
               );
             }
           });
+          let waitTimer = null;
           try {
             // await fiber（装载完成 = ap.mount 完成）；等待上限防缺服务形态挂死 create
             await Promise.race([
               fiber,
-              new Promise((resolve) =>
-                setTimeout(resolve, AGENT_PRESETS_INJECT_WAIT_MS),
-              ),
+              new Promise((resolve) => {
+                waitTimer = setTimeout(resolve, AGENT_PRESETS_INJECT_WAIT_MS);
+              }),
             ]);
           } finally {
+            // 清理等待计时器（CodeRabbit 第五轮：race 先被 fiber settle 时 timer 仍
+            // 挂着——多会话累积 10s 空 timer；clearTimeout 防泄漏）
+            if (waitTimer !== null) {
+              try {
+                clearTimeout(waitTimer);
+              } catch { /* 清理失败忽略 */ }
+              waitTimer = null;
+            }
             // 装载/挂载完成（或超时放弃）后 dispose fiber——不留常驻插件实例
             if (fiber && typeof fiber.dispose === "function") {
               try {

--- a/src-cordis/plugins/acp-assist/index.js
+++ b/src-cordis/plugins/acp-assist/index.js
@@ -130,8 +130,12 @@ export function apply(ctx) {
         };
         return await origCreate.call(this, opt);
       } catch (e) {
-        log("create wrap 失败（透传原行为）：" + ((e && e.message) || e));
-        return origCreate.call(this, options);
+        // CodeRabbit 第二轮 #5：不再二次调 origCreate 重试。首试失败时原装配可能已部分
+        // 生效/agent 已创建（重试会双创建/重复装配），且重试掩盖 setup 抛出的真因
+        //（assist 自带 try/catch 不抛，能走到这里是原 setup/工厂装配失败）。log + rethrow，
+        // 保留原工厂的错误语义。
+        log("create wrap 失败（透传原错误）：" + ((e && e.message) || e));
+        throw e;
       }
     };
 
@@ -148,8 +152,10 @@ export function apply(ctx) {
           };
           return await origResume.call(this, opt);
         } catch (e) {
-          log("resume wrap 失败（透传原行为）：" + ((e && e.message) || e));
-          return origResume.call(this, options);
+          // CodeRabbit 第二轮 #5（与 create 同款）：不再二次调 origResume 重试——恢复
+          // 会话的装配同样可能已部分生效（重试双创建/双装配），log + rethrow 透传真因。
+          log("resume wrap 失败（透传原错误）：" + ((e && e.message) || e));
+          throw e;
         }
       };
     }

--- a/src-cordis/plugins/acp-assist/index.js
+++ b/src-cordis/plugins/acp-assist/index.js
@@ -27,6 +27,11 @@
 export const name = "@dsh-hanako/acp-assist";
 export const inject = ["agents", "hanaLogger"];
 
+// agentPresets 注入等待上限（CodeRabbit 第二轮 #6）：ctx.inject 的 fiber 在极端缺服务
+// 形态可能迟迟不就绪，而 assist 已改为 await（见 assist 内实现）——设上限防 create/
+// resume 被挂死；超时记日志继续（preset 缺省不阻断会话，与插件降级语义一致）。
+const AGENT_PRESETS_INJECT_WAIT_MS = 10000;
+
 export function apply(ctx) {
   try {
     let loggerSvc = null;
@@ -75,8 +80,14 @@ export function apply(ctx) {
         );
         // agentPresets 默认 preset 挂载（settings agent-presets.default——ACP 会话
         // 接回 DSH 默认 preset 系统——mount id 缺省用 config.default）
+        // CodeRabbit 第二轮 #6：ctx.inject 是回调式——本 cordis 分支的 inject 返回
+        // Fiber & PromiseLike（await 它 = 等依赖就绪 + 回调完成）。原实现不 await：
+        // ap.mount() 在 setup 返回后才异步完成，create/resume 不等 preset 就绪就对
+        // 首 turn 开放（竞态——首 turn 可能先于 preset 挂载到达）。这里 await fiber，
+        // 保证 ap.mount() 在 assist 返回（= setup 链完成 → 会话可接首 turn）前完成；
+        // 完成后 dispose fiber（不留常驻插件实例）。等待设上限防极端缺服务形态挂死。
         try {
-          ctx.inject(["agentPresets"], async (apCtx) => {
+          const fiber = ctx.inject(["agentPresets"], async (apCtx) => {
             try {
               const ap = apCtx && apCtx.agentPresets;
               if (!ap || typeof ap.mount !== "function") {
@@ -101,12 +112,30 @@ export function apply(ctx) {
                   " preset=" + String(presetDefault ?? "default"),
               );
             } catch (e) {
+              // 挂载失败不阻断会话（降级语义保留）；回调自身不抛 → fiber await 只反映
+              // 依赖就绪/完成，不因 preset 失败 reject
               hostLog(
                 "[dsh acp-assist] preset 挂载失败（session 继续，无 preset 组合）：" +
                   ((e && e.message) || e),
               );
             }
           });
+          try {
+            // await fiber（装载完成 = ap.mount 完成）；等待上限防缺服务形态挂死 create
+            await Promise.race([
+              fiber,
+              new Promise((resolve) =>
+                setTimeout(resolve, AGENT_PRESETS_INJECT_WAIT_MS),
+              ),
+            ]);
+          } finally {
+            // 装载/挂载完成（或超时放弃）后 dispose fiber——不留常驻插件实例
+            if (fiber && typeof fiber.dispose === "function") {
+              try {
+                await fiber.dispose();
+              } catch { /* dispose 失败忽略 */ }
+            }
+          }
         } catch (e) {
           hostLog(
             "[dsh acp-assist] agentPresets 注入失败：" +

--- a/src-cordis/plugins/acp-assist/index.js
+++ b/src-cordis/plugins/acp-assist/index.js
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2026 Nyasers
+//
+// @dsh-hanako/acp-assist — dsh-acp 插件的插件（DSH 进程内 cordis 插件）。
+//
+// 目标（规格见 specs/current/dshana-host-task-registry/spec.md 关联记录）：
+// dsh-acp（@deepseek-ai/dsh-acp）的 AcpSession.create 在 agent 工厂 setup 里只装
+// modelControl + MCP，不做 preset 组合（"No preset composition——reads from global
+// layer"）——ACP 会话因此拿不到 agentPresets 默认 preset（用户配的
+// settings.yaml agent-presets.default: ptc 只服务 Web 会话）。本插件在 agent 工厂层
+// wrap agents.create/resume 的 setup 链，给 ACP 会话补装配后置段：
+//   ① preset：mountPreset(agentCtx, agentPresets.config.default)——把 ACP 会话接回
+//      DSH 自己的默认 preset 系统（DSH 配置直读，零宿主通讯）
+//   ② effort 校准：经 installModelSelection 挂的 selection 补默认 reasoningEffort
+//      （宿主 set model 后保持用户配的 effort——时序在宿主侧 acpSelect 处理，
+//       setup 期补会被随后的 selectModel 冲掉——见 protocol.js）
+// 边界：超时宿主面（run.js timer），本插件不管；工具显式覆盖（宿主传 preset/effort）
+// 是宿主→DSH 透传面（ACP 协议无 preset 字段，暂不实现——需要时经 set_config 扩展）。
+//
+// 本文件 = 探测版（patch 面验证）：只 wrap setup 后置 + 日志（agentCtx 特征 /
+// agentPresets.default 可达性 / create·resume 双路），不真 mountPreset。验证通过后
+// 第二步填 assist 的 preset 挂载与 effort 校准。
+//
+// 纪律：apply 全程 try/catch 不抛（插件降级为空操作，不阻断 dsh 启动）——cordis
+// 装配失败/服务缺失时静默跳过，宿主日志留痕。
+
+export const name = "@dsh-hanako/acp-assist";
+export const inject = ["agents", "hanaLogger"];
+
+export function apply(ctx) {
+  try {
+    let loggerSvc = null;
+    try {
+      ctx.inject(["hanaLogger"], (logCtx) => {
+        loggerSvc = logCtx && logCtx.hanaLogger;
+      });
+    } catch {
+      /* 日志服务缺失：静默 */
+    }
+    const log = (msg) => {
+      try {
+        loggerSvc?.log("acp-assist", msg);
+      } catch {
+        /* 日志失败不阻断 */
+      }
+    };
+
+    // patch 目标：agent 工厂（dsh-acp 经 ctx.agents.create/resume 建 ACP 会话；
+    // web 会话同走此工厂——assist 需区分/查重防双挂）
+    const factory = ctx && ctx.agents;
+    if (!factory || typeof factory.create !== "function") {
+      log("agents 工厂不可用（无 create）——跳过 patch");
+      return;
+    }
+    const origCreate = factory.create;
+    const origResume =
+      typeof factory.resume === "function" ? factory.resume : null;
+
+    /** setup 后置段：原装配（modelControl+MCP）跑完后追加 assist。 */
+    const hostLog = (msg) => {
+      // 同进程宿主单例直写（loggerSvc 经 dshanaBus 总线——总线已退役（ACP 时代），
+      // 日志到不了宿主；globalThis.__dshHanako 同进程可达——直写宿主日志文件）
+      try {
+        const g = globalThis && globalThis.__dshHanako;
+        g && typeof g.appendLog === "function" && g.appendLog("hana", msg);
+      } catch { /* 日志失败不阻断 */ }
+    };
+    const assist = async (agentCtx, options, mode) => {
+      try {
+        const sid =
+          (options && (options.sessionId || options.resumeSessionId)) || "?";
+        hostLog(
+          "[dsh acp-assist] " + mode + " setup 后置触发 session=" +
+            String(sid).slice(0, 16),
+        );
+        // agentPresets 默认 preset 挂载（settings agent-presets.default——ACP 会话
+        // 接回 DSH 默认 preset 系统——mount id 缺省用 config.default）
+        try {
+          ctx.inject(["agentPresets"], async (apCtx) => {
+            try {
+              const ap = apCtx && apCtx.agentPresets;
+              if (!ap || typeof ap.mount !== "function") {
+                hostLog("[dsh acp-assist] agentPresets 服务不可用（无 mount）——跳过 preset");
+                return;
+              }
+              const presetDefault =
+                typeof ap.defaultId === "string" && ap.defaultId
+                  ? ap.defaultId
+                  : ap.config && ap.config.default
+                    ? ap.config.default
+                    : undefined;
+              hostLog(
+                "[dsh acp-assist] 挂载默认 preset：" +
+                  String(presetDefault ?? "（config.default 缺省）") +
+                  " 到 session=" + String(sid).slice(0, 12),
+              );
+              await ap.mount(agentCtx, presetDefault);
+              hostLog(
+                "[dsh acp-assist] preset 已挂载完成 session=" +
+                  String(sid).slice(0, 12) +
+                  " preset=" + String(presetDefault ?? "default"),
+              );
+            } catch (e) {
+              hostLog(
+                "[dsh acp-assist] preset 挂载失败（session 继续，无 preset 组合）：" +
+                  ((e && e.message) || e),
+              );
+            }
+          });
+        } catch (e) {
+          hostLog(
+            "[dsh acp-assist] agentPresets 注入失败：" +
+              ((e && e.message) || e),
+          );
+        }
+      } catch (e) {
+        hostLog("[dsh acp-assist] assist 失败：" + ((e && e.message) || e));
+      }
+    };
+
+    // wrap create：原 setup（ACP 的 modelControl+MCP 装配）后追加 assist
+    factory.create = async function createPatched(options) {
+      try {
+        const opt = options || {};
+        const origSetup =
+          typeof opt.setup === "function" ? opt.setup : null;
+        opt.setup = async (agentCtx) => {
+          if (origSetup) await origSetup(agentCtx);
+          await assist(agentCtx, opt, "create");
+        };
+        return await origCreate.call(this, opt);
+      } catch (e) {
+        log("create wrap 失败（透传原行为）：" + ((e && e.message) || e));
+        return origCreate.call(this, options);
+      }
+    };
+
+    // wrap resume（同款：恢复会话的装配也走 setup——preset 同样要补）
+    if (origResume) {
+      factory.resume = async function resumePatched(options) {
+        try {
+          const opt = options || {};
+          const origSetup =
+            typeof opt.setup === "function" ? opt.setup : null;
+          opt.setup = async (agentCtx) => {
+            if (origSetup) await origSetup(agentCtx);
+            await assist(agentCtx, opt, "resume");
+          };
+          return await origResume.call(this, opt);
+        } catch (e) {
+          log("resume wrap 失败（透传原行为）：" + ((e && e.message) || e));
+          return origResume.call(this, options);
+        }
+      };
+    }
+
+    log("agent 工厂已 patch（create" + (origResume ? "/resume" : "") + " setup 后置）");
+    hostLog(
+      "[dsh acp-assist] agent 工厂已 patch（create" +
+        (origResume ? "/resume" : "") + " setup 后置）——默认 preset 挂载就位",
+    );
+  } catch (e) {
+    try {
+      console.warn("[@dsh-hanako/acp-assist] " + ((e && e.message) || e));
+    } catch {
+      /* 无日志通道静默 */
+    }
+  }
+}

--- a/src-cordis/plugins/acp-assist/package.json
+++ b/src-cordis/plugins/acp-assist/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@dsh-hanako/acp-assist",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "index.js",
+  "cordis": {
+    "name": "@dsh-hanako/acp-assist"
+  }
+}

--- a/src-cordis/plugins/bridge/index.js
+++ b/src-cordis/plugins/bridge/index.js
@@ -310,6 +310,44 @@ const connection = {
   },
 }
 
+/**
+ * 进程内一元 RPC 分发服务（总线内置化第二刀 refactor/bus-inproc）：bus 翻译器/宿主直调
+ * 时绕过 /api HTTP 载体（fetch 自环依赖端口 + cookie 换发），直接经 interceptor 分发
+ * （同 dispatchApiRpc 的 handler 调用 + 错误翻译语义）。payload 为信封 payload（bus 翻译
+ * 器已包装 { args } / { request } 等 Remote 信封）；endpoint 为斜杠格式（/api 路径段）。
+ */
+const rpcDispatcher = {
+  async call(endpoint, payload, signal) {
+    const interceptor = interceptors.get(API_PATH)
+    if (interceptor === undefined || !interceptor.matches(endpoint)) {
+      return {
+        ok: false,
+        error: {
+          code: 'api-bridge/not-found',
+          message: 'no interceptor for endpoint ' + String(endpoint),
+          details: {},
+        },
+      }
+    }
+    try {
+      const value = await interceptor.handler(
+        endpoint,
+        payload ?? {},
+        signal || new AbortController().signal,
+      )
+      return { ok: true, value }
+    } catch (e) {
+      return {
+        ok: false,
+        error: {
+          code: 'api-bridge/dispatch',
+          message: String((e && e.message) || e),
+          details: {},
+        },
+      }
+    }
+  },
+}
 /** 独立 channel 路由分发（非 /api channel，防御实现：信封语义同 /api）。 */
 async function handleChannelReq(req, res, channel) {
   const handler = handleRoutes.get(channel)
@@ -353,6 +391,9 @@ export function apply(ctx, config) {
     // connection 服务在 apply 同步段 provide（与官方 Service 基类构造即注册同语义，
     // 保证 gateway 的 inject(['connection']) 回调不落空）。
     const provideDisposer = ctx.provide('connection', connection)
+    // 进程内一元 RPC 分发服务（总线内置化第二刀）：同同步段 provide——bus 翻译器 ctx
+    // 收口直调（不再 fetch 自环依赖端口），宿主 callUnaryBus 进程内通道的 DSH 侧终点。
+    const provideRpcDisposer = ctx.provide('apiRpcDispatcher', rpcDispatcher)
     ctx.inject(['webServer'], (webCtx) => {
       webCtx.effect(() => {
         const disposers = []
@@ -388,6 +429,11 @@ export function apply(ctx, config) {
             } catch {
               /* 注销失败忽略 */
             }
+          }
+          try {
+            provideRpcDisposer()
+          } catch {
+            /* 注销失败忽略 */
           }
           try {
             provideDisposer()

--- a/src-cordis/plugins/bus/index.js
+++ b/src-cordis/plugins/bus/index.js
@@ -355,6 +355,10 @@ export function apply(ctx, config) {
         const emitter = new EventEmitter()
         let conn = null // 当前已握手连接（单连接语义）
         let upgradeDisposer = null
+        // 进程内 RPC 收口订阅的退订函数（rootCtx.on('dshana/inproc-request') 返回）。
+        // effect 重执行/卸载时必须退订——不保留则重载累积 stale handler，一次请求被
+        // 多次翻译/回投（CodeRabbit Major #1）。见下方 inprocDisposer 赋值与 cleanup 调用。
+        let inprocDisposer = null
         // 宿主下发的配置（hello 后经 config 帧到达；提供 getConfig() 供 settings/provider 取路径）
         let busConfig = null
 
@@ -631,6 +635,8 @@ export function apply(ctx, config) {
         // 宿主在根 emit **不下行**到插件子 ctx——收口必须挂根层（ctx.root，cordis 插件 ctx
         // 的根引用；无 root（即根自身）兑底 ctx）才能收到宿主 ctx.emit。回投 emit 在子 ctx
         // 发 → 冒泡到根 → 宿主 ctx.on（根层）收 ✓（与 DSH 内部 emit 同向）。
+        // 订阅返回退订函数存入 inprocDisposer：effect 清理（模块重载/unload）时退订，
+        // 防重注册导致 stale handler 累积（一次请求被多次翻译/回投/结果帧）。
         const rootCtx = ctx.root || ctx
         try {
           ctx.inject(['apiRpcDispatcher'], (dispCtx) => {
@@ -640,9 +646,10 @@ export function apply(ctx, config) {
               rpcDispatcherRef = null
             }
           })
-          rootCtx.on('dshana/inproc-request', onInprocRequest)
+          inprocDisposer = rootCtx.on('dshana/inproc-request', onInprocRequest)
         } catch (e) {
           bridgeLog('进程内 RPC 收口接线失败：' + ((e && e.message) || e))
+          inprocDisposer = null
         }
 
         // ---- 事件流订阅（remote.mux + $events）：bridge 在 dsh 进程内代宿主订阅，
@@ -828,6 +835,17 @@ export function apply(ctx, config) {
               /* 忽略 */
             }
             conn = null
+          }
+          // 进程内 RPC 收口退订（rootCtx.on disposer）：effect 清理/卸载时移除——
+          // 否则 bridge 插件 reload 时 rootCtx.on 重复注册，stale handler 累积导致一次
+          // 请求被多次翻译/回投（CodeRabbit Major #1）。退订失败忽略（已宕/已退订 no-op）。
+          if (inprocDisposer && typeof inprocDisposer === 'function') {
+            try {
+              inprocDisposer()
+            } catch {
+              /* 退订失败忽略 */
+            }
+            inprocDisposer = null
           }
           emitter.removeAllListeners()
         }

--- a/src-cordis/plugins/bus/index.js
+++ b/src-cordis/plugins/bus/index.js
@@ -110,6 +110,13 @@ let authCookieInflight = null
 // （$events/result）需要它定位事件流——宿主侧无 launchToken 源无从得知，由
 // 本总线事件流持有（apply 的 evtConnect ready 回调赋值）。
 let evtClientId = ''
+// 进程内 RPC 分发服务引用（总线内置化第二刀 refactor/bus-inproc）：bridge provide
+// 'apiRpcDispatcher'（apply 同步段），bus 经 ctx.inject 动态注入（不阻塞激活）。
+// 注入成功 → 翻译器 Unary/respond 直调 dispatcher（免自环 fetch 依赖端口 + cookie）；
+// 未注入（bridge 未激活/旧版）→ 降级原自环 fetch 路径，行为不变。
+let rpcDispatcherRef = null
+// 模块级 logger（apply 注入 ctx.logger；翻译器模块级函数日志用——bridgeLog 是 apply 闭包）
+let moduleLogger = null
 
 /** 自环 RPC 鉴权 cookie（dsh 0.1.2+ /api/* 需浏览器 cookie，无则 401）。
  * launchToken 经 GET /?token= 换发 signed cookie（authorizeIndex 流程，本机回环）；
@@ -205,6 +212,13 @@ export async function translateRpcRequest(req, port, reply) {
         eventId: p.eventId,
         outcome: p.outcome,
       }
+      // 进程内优先（总线内置化第二刀）：dispatcher 直调 $events/result interceptor
+      // （免自环 fetch 依赖端口）；未注入降级原 fetch 路径
+      if (rpcDispatcherRef && typeof rpcDispatcherRef.call === 'function') {
+        const rr = await rpcDispatcherRef.call('$events/result', { args })
+        reply({ reqId, ok: true, value: { accepted: rr.ok === true } })
+        return
+      }
       const res = await fetch(base + '/api/$events/result', {
         method: 'POST',
         headers,
@@ -246,6 +260,34 @@ export async function translateRpcRequest(req, port, reply) {
     const args = isSession
       ? { [isSessionList ? '_request' : 'request']: { ...(req.payload || {}), requestId: reqId } }
       : req.payload
+    // 进程内优先（总线内置化第二刀）：dispatcher 直调 interceptor（免自环 fetch 依赖
+    // 端口 + cookie 换发）；未注入（bridge 未激活/旧版）降级原 fetch 路径
+    if (rpcDispatcherRef && typeof rpcDispatcherRef.call === 'function') {
+      const r = await rpcDispatcherRef.call(endpoint, { args })
+      if (r.ok) {
+        reply({ reqId, ok: true, value: r.value })
+        return
+      }
+      const e = r.error || {}
+      try {
+        moduleLogger?.info?.(
+          '[@dsh-hanako/bus] RPC dispatcher 失败：method=' +
+            method +
+            ' code=' +
+            (e.code || 'unknown') +
+            ' msg=' +
+            ((e.message || '') + '').slice(0, 300),
+        )
+      } catch {
+        /* 日志失败不阻断 */
+      }
+      reply({
+        reqId,
+        ok: false,
+        error: { code: e.code || 'unknown', message: e.message || '' },
+      })
+      return
+    }
     const res = await fetch(base + '/api/' + endpoint, {
       method: 'POST',
       headers,
@@ -536,6 +578,72 @@ export function apply(ctx, config) {
             },
           )
         })
+
+        // ---- 进程内 RPC 收口（总线内置化第二刀 refactor/bus-inproc）：宿主经 ctx
+        // 直发指令（免 WS/端口）——宿主与 DSH 同进程同 ctx，宿主 ctx.emit(
+        // 'dshana/inproc-request', { reqId, method, payload }) → 这里 ctx.on 收 →
+        // translateRpcRequest（dispatcher 直调 bridge interceptor，免自环 fetch）→
+        // ctx.emit('dshana/inproc-result') 回投。WS 总线路径保留（兜底/外部连接）。
+        // apiRpcDispatcher 动态 inject（不阻塞激活：bridge 未激活时 ref 为空，翻译器
+        // 降级自环 fetch，行为不变）。
+        const onInprocRequest = (frame) => {
+          try {
+            const req =
+              frame && typeof frame === 'object' && frame.req ? frame.req : frame
+            try {
+              bridgeLog(
+                'inproc-request 收到：reqId=' +
+                  ((req && req.reqId) || '?') +
+                  ' method=' +
+                  ((req && req.method) || '?'),
+              )
+            } catch {
+              /* 诊断日志失败不阻断 */
+            }
+            if (
+              !req ||
+              typeof req.reqId !== 'string' ||
+              !req.reqId ||
+              typeof req.method !== 'string'
+            ) {
+              return
+            }
+            translateRpcRequest(
+              req,
+              httpCtx.webServer && typeof httpCtx.webServer.port === 'number'
+                ? httpCtx.webServer.port
+                : undefined,
+              (out) => {
+                try {
+                  ctx.emit('dshana/inproc-result', out)
+                } catch {
+                  bridgeLog('inproc-result 回投失败（reqId=' + ((out && out.reqId) || '?') + '）')
+                }
+              },
+            ).catch(() => {
+              bridgeLog('inproc-request 翻译失败（reqId=' + ((req && req.reqId) || '?') + '）')
+            })
+          } catch {
+            bridgeLog('inproc-request 收帧异常（已忽略）')
+          }
+        }
+        // cordis 事件冒泡方向：插件子 ctx emit 冒泡到根，宿主（持 g.web.ctx = 根）收得到；
+        // 宿主在根 emit **不下行**到插件子 ctx——收口必须挂根层（ctx.root，cordis 插件 ctx
+        // 的根引用；无 root（即根自身）兑底 ctx）才能收到宿主 ctx.emit。回投 emit 在子 ctx
+        // 发 → 冒泡到根 → 宿主 ctx.on（根层）收 ✓（与 DSH 内部 emit 同向）。
+        const rootCtx = ctx.root || ctx
+        try {
+          ctx.inject(['apiRpcDispatcher'], (dispCtx) => {
+            try {
+              rpcDispatcherRef = dispCtx.get?.('apiRpcDispatcher') || null
+            } catch {
+              rpcDispatcherRef = null
+            }
+          })
+          rootCtx.on('dshana/inproc-request', onInprocRequest)
+        } catch (e) {
+          bridgeLog('进程内 RPC 收口接线失败：' + ((e && e.message) || e))
+        }
 
         // ---- 事件流订阅（remote.mux + $events）：bridge 在 dsh 进程内代宿主订阅，
         // 经总线 events 频道转发——宿主无需 WS 连接/鉴权（launchToken 在进程内

--- a/src-cordis/plugins/bus/index.js
+++ b/src-cordis/plugins/bus/index.js
@@ -284,6 +284,12 @@ export async function translateRpcRequest(req, port, reply) {
 // ---- 插件 apply：注册 upgrade 路由 + 提供 dshanaBus 服务（全程容错，降级不阻断）----
 export function apply(ctx, config) {
   try {
+    // 模块级 logger（翻译器等模块级函数诊断用）
+    try {
+      moduleLogger = ctx.logger || null
+    } catch {
+      moduleLogger = null
+    }
     // launchToken：从 connection 服务（HostConnectionService）的 BrowserAuth 读
     // （dsh 0.1.2+ 浏览器鉴权进程令牌），自环 RPC 用它换 cookie。旧版 dsh 无此
     // 服务 → 保持空，自环免鉴权兼容（改造前行为）。
@@ -492,8 +498,25 @@ export function apply(ctx, config) {
             ready: !!conn && conn.readyState === 1,
             path: BUS_PATH,
           }),
-          // 宿主下发的配置（未下发返回 null——settings/provider 据此报「总线配置未就绪」）
-          getConfig: () => (busConfig ? { ...busConfig } : null),
+          // 宿主下发的配置（总线形态：握手后 config 帧下发）。总线退役（refactor/
+          // bus-inproc）后宿主不再连 dshana.bus——同进程形态兑底：读 process.env
+          //（宿主 boot 前注入 DSHANA_ROOT = DSH 包与依赖根（插件根）/ DSHANA_HOME =
+          // 宿主数据目录；DSH_HOME 官方名 = DSHANA_HOME/dsh-home），settings/
+          // provider/app 的 dshPkgDir/dataDir 消费不再依赖总线 config。env 也缺
+          //（极端情况）返回 null（调用方原有「未就绪」语义保留）。
+          getConfig: () => {
+            if (busConfig) return { ...busConfig };
+            const envDshPkgDir = process.env.DSHANA_ROOT;
+            const envDataDir = process.env.DSHANA_HOME;
+            if (typeof envDshPkgDir === 'string' && envDshPkgDir) {
+              return {
+                dshPkgDir: envDshPkgDir,
+                dataDir:
+                  typeof envDataDir === 'string' && envDataDir ? envDataDir : null,
+              };
+            }
+            return null;
+          },
         }
         // ---- 总线 RPC 接线：订阅宿主 rpc.request → 翻译器执行 → 回投 rpc.result ----
         // service.on 的监听器异常隔离是每回调包装（新订阅沿用该模式）；翻译器内部

--- a/src-cordis/plugins/provider/index.js
+++ b/src-cordis/plugins/provider/index.js
@@ -460,54 +460,38 @@ export async function apply(ctx, config) {
       }
     };
 
-    // ---- 宿主 push 通知（dshana.bus 消息总线）----
-    ctx.inject(["dshanaBus"], (busCtx) => {
-      busCtx.effect(() => {
-        const disposers = [];
+    // ---- 宿主 push 通知（总线退役后 ctx 事件：cordis ctx.on 直收，宿主经
+    // g.web.ctx.emit('dshana/provider-push') 广播——见 src/lib/lifecycle.js
+    // pushProviderRoutes）----
+    ctx.on("dshana/provider-push", (payload) => {
+      try {
+        const p = payload && typeof payload === "object" ? payload : {};
+        const routes = Array.isArray(p.routes) ? p.routes : null;
+        refresh("宿主 push（ctx）", { routes });
+        providerLog(
+          "收到 provider-push 事件（宿主 push（ctx）" +
+            (Array.isArray(p.routes)
+              ? "，" + p.routes.length + " 条 routes"
+              : "，路由缺失") +
+            "）",
+        );
+      } catch (e) {
         try {
-          if (busCtx.dshanaBus && typeof busCtx.dshanaBus.on === "function") {
-            disposers.push(
-              busCtx.dshanaBus.on("provider.refresh", (payload) => {
-                const p = payload && typeof payload === "object" ? payload : {};
-                const routes = Array.isArray(p.routes) ? p.routes : null;
-                refresh("宿主 push（总线）", { routes });
-                providerLog(
-                  "收到 provider.refresh 事件（宿主 push" +
-                  (Array.isArray(p.routes)
-                    ? "，" + p.routes.length + " 条 routes"
-                    : "，路由缺失") +
-                  "）",
-                );
-              }),
-            );
-            try {
-              if (typeof busCtx.dshanaBus.emit === "function") {
-                busCtx.dshanaBus.emit("provider.refresh.request", {});
-              }
-            } catch {
-              /* 请求失败不阻断（宿主补推兜底） */
-            }
-          }
-        } catch (e) {
-          try {
-            ctx.logger?.warn?.(
-              "[@dsh-hanako/provider] provider.refresh 订阅失败：" + (e?.message || e),
-            );
-          } catch {
-            /* 日志失败不阻断 */
-          }
+          ctx.logger?.warn?.(
+            "[@dsh-hanako/provider] provider-push 处理失败：" + (e?.message || e),
+          );
+        } catch {
+          /* 日志失败不阻断 */
         }
-        return () => {
-          for (const dispose of disposers) {
-            try {
-              dispose();
-            } catch {
-              /* 清理失败不阻断 */
-            }
-          }
-        };
-      });
+      }
     });
+    // 订阅建立后请求重放（覆盖宿主首批 push 早于本订阅的窗口）：ctx.emit 请求，宿主
+    // ctx.on('dshana/provider-refresh-request') 收后重推
+    try {
+      ctx.emit("dshana/provider-refresh-request", {});
+    } catch {
+      /* 请求失败不阻断（宿主就绪点已主动推） */
+    }
 
     // 启动 snapshot 置空：首个 provider 由宿主 web host 就绪后主动 push 填上。
     // 兼容旧版 config.routesJSON（旧 patch 注入残留）仍可作初始 snapshot。

--- a/src-cordis/plugins/provider/index.js
+++ b/src-cordis/plugins/provider/index.js
@@ -485,26 +485,33 @@ export async function apply(ctx, config) {
         }
       }
     });
-    // 订阅建立后请求重放（覆盖宿主首批 push 早于本订阅的窗口）：ctx.emit 请求，宿主
-    // ctx.on('dshana/provider-refresh-request') 收后重推
-    try {
-      ctx.emit("dshana/provider-refresh-request", {});
-    } catch {
-      /* 请求失败不阻断（宿主就绪点已主动推） */
-    }
-
-    // 启动 snapshot 置空：首个 provider 由宿主 web host 就绪后主动 push 填上。
-    // 兼容旧版 config.routesJSON（旧 patch 注入残留）仍可作初始 snapshot。
+    // 启动 snapshot（旧版 config.routesJSON 兼容）先于 replay 请求执行（CodeRabbit：
+    // Data Integrity）。理由：provider 插件在宿主 ctx 传输已就绪时重载（bus/插件 effect
+    // reload），下方 ctx.emit('dshana/provider-refresh-request') 的重放是**同步**回推宿主已
+    // 组装的最新 routes（宿主 ctx.on 收后立即 provider-push 再同步 feed 回本插件的
+    // ctx.on('dshana/provider-push') → refresh）。若 legacy routesJSON 刷新排在 replay 之后，
+    // 会用 stale 快照覆盖刚重放的最新 routes。故先落旧版初始快照，再发 replay——宿主最新
+    // routes 后到胜出。
     if (config && Array.isArray(config.routesJSON)) {
       ctx.logger.info(
         `[@dsh-hanako/provider] 检测到旧版 config.routesJSON（${config.routesJSON.length} 条），用作初始 route 目录`,
       );
+      // 首次激活（宿主 ctx 订阅未就绪，emit 无响应）时此处即最终初始值；重载场景退让给
+      // 下方 replay（若 ctx 传输可用，后续最新 push 覆盖此旧快照）。
       refresh("旧版 routesJSON", { routes: config.routesJSON });
     } else {
       ctx.logger.info(
         "[@dsh-hanako/provider] 启动 snapshot 为空，等待宿主 push 首批 route 目录",
       );
       providerLog("启动 snapshot 为空，等待宿主 push 首批 route 目录");
+    }
+    // 订阅建立后请求重放（覆盖宿主首批 push 早于本订阅的窗口）：ctx.emit 请求，宿主
+    // ctx.on('dshana/provider-refresh-request') 收后重推。调用点排在 legacy 初始快照之后——
+    // replay 加载的是宿主最新组装（ctx 传输可用时同步生效），不会被下方 stale snapshot 覆盖。
+    try {
+      ctx.emit("dshana/provider-refresh-request", {});
+    } catch {
+      /* 请求失败不阻断（宿主就绪点已主动推） */
     }
   } catch (e) {
     // 顶层兜底：apply 永不抛出（边界要求——不阻断 dsh 启动）

--- a/src/assets/webui-shell.jinja2
+++ b/src/assets/webui-shell.jinja2
@@ -589,7 +589,14 @@
         if (view === "ready") {
           clearClocks();
           clearReadyTimer();
-          if (!readyReceived) { mountReady(); }
+          if (!readyReceived) {
+            mountReady();
+          } else {
+            // 已 ready 后的快照刷新（端口读回/变化）：重跑 attach——attach 内按当前
+            // boot.web.port 判 src（端口一致不重设、变化则重载到真实端口），否则随机
+            // 端口场景 iframe 会停在服务端固化的兑底端口（见 attach 注释）
+            attach();
+          }
           return;
         }
         readyReceived = false; // 非 ready 快照：撤销就绪标志，使后续 ready 恢复时能完整走 mountReady（data-view 恢复 + attach）
@@ -638,13 +645,21 @@
       }
       // iframe src 按视图参数化（父子双卡过渡方案）：it.viewQuery 由服务端路由决定——
       // /main → "?dshana-view=main"（main 视图 = 接收端 receive）、/sidebar →
-      // "?dshana-view=sidebar"（纯侧栏视图 = 发射端 emit），两卡各自直嵌同源 3080；
-      // viewQuery 空串（view 缺失/白名单外）＝无参 root = full 整页视图——仅调试兜底
-      // （宿主双卡路由恒带 view，正常不可达；3080 直开仍是无参 full）。
+      // "?dshana-view=sidebar"（纯侧栏视图 = 发射端 emit），两卡各自直嵌 DSH server
+      // （随机端口形态：实际端口 boot 后写 g.web.port → boot-state web.port，attach 时
+      // 优先取快照端口；服务端模板 port 仅为兜底——自举页渲染时端口可能未定，固化即错）；
+      // viewQuery 空串（view 缺失/白名单外）＝无参 root = full 整页视图——仅调试兜底。
       function attach() {
         var wasPending = document.body.getAttribute("data-view") !== "ready";
-        if (wasPending || !frame.getAttribute("src")) {
-          frame.src = "http://127.0.0.1:{{= it.port }}/{{= it.viewQuery }}";
+        var viewQuery = {{= JSON.stringify(it.viewQuery) }};
+        var port =
+          (boot && boot.web && boot.web.port) || {{= JSON.stringify(it.port) }};
+        var target = "http://127.0.0.1:" + port + "/" + viewQuery;
+        var cur = frame.getAttribute("src");
+        // 已有 src 且端口一致：不重设（防 applyBoot/事件反复重载 iframe）；端口变化
+        // （自举页固化兑底 → 快照真实端口）重设 src，iframe 重载到正确端口。
+        if (wasPending || !cur || cur.indexOf("127.0.0.1:" + port) === -1) {
+          frame.src = target;
         }
         startThemePush();
       }

--- a/src/lib/acp-mount.js
+++ b/src/lib/acp-mount.js
@@ -20,6 +20,9 @@ import { readFileSync, realpathSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { createRequire } from "node:module";
 import { pathToFileURL } from "node:url";
+import { getSingleton } from "./state.js";
+import { notifyApprovalWake } from "./wake.js";
+import { resolveApprovalTimeoutSec } from "./config.js";
 
 // ACP 运行时依赖定位：@deepseek-ai/dsh-acp（插件本体）与 @agentclientprotocol/sdk
 // 随 DSH 依赖树存在（@deepseek-ai/dsh → @deepseek-ai/dsh-acp-app → dsh-acp，SDK 是
@@ -59,6 +62,86 @@ export async function mountAcp(ctx, { dshHome, emitLog }) {
   const log = (msg) => {
     try { emitLog?.("hana", "[dsh acp] " + msg); } catch { /* noop */ }
   };
+  // ---- L4：审批反向应答（request_permission）----
+  // DSH agent 越界/敏感工具调用 → ctx approval/request → dsh-acp 插件转
+  // session/request_permission 请求发 client（options: allow-once / reject-once，映射
+  // 见 dsh-acp index.ts requestPermission）。宿主应答 = onRequest handler 返回
+  // { outcome }——本 handler 挂起等宿主决策：审批上下文存 g.ops.activeApprovals
+  //（approve.js dsh_approve 工具查同一表——ap._respond resolve 本 pending）；超时
+  // 自动拒绝（approvalTimeoutSec）；无活动任务（op 缺失/终态）默认拒绝（安全）。
+  async function handleRequestPermission({ params, requestId }) {
+    const g = getSingleton();
+    const sessionId = params && params.sessionId;
+    const callId = params && params.toolCall && params.toolCall.toolCallId;
+    const cached = callId ? toolCache.get(callId) : null;
+    const approvalId = String(
+      requestId ?? callId ?? "req-" + Date.now(),
+    );
+    const op =
+      g && typeof g.ops?.get === "function" ? g.ops.get(sessionId) : null;
+    if (!op || !Array.isArray(op.activeApprovals)) {
+      // 无活动任务/协调条目缺失（任务已终态/未知会话）：默认拒绝（安全）
+      return { outcome: { outcome: "selected", optionId: "reject-once" } };
+    }
+    let settle = null;
+    const pending = new Promise((resolve) => {
+      settle = resolve;
+    });
+    const approval = {
+      approvalId,
+      eventId: approvalId,
+      sessionId,
+      toolName: (cached && cached.name) || "tool",
+      callId: callId ?? null,
+      reason: null,
+      args: cached ? cached.args : null,
+      status: "pending",
+      requestedAt: new Date().toISOString(),
+      _respond: (outcomeStr) => {
+        if (!settle) return;
+        const s = settle;
+        settle = null;
+        try {
+          s({
+            outcome: {
+              outcome: "selected",
+              optionId:
+                outcomeStr === "allowed-once" ? "allow-once" : "reject-once",
+            },
+          });
+        } catch { /* 已 settle 忽略 */ }
+      },
+    };
+    op.activeApprovals.push(approval);
+    // 超时自动拒绝（approvalTimeoutSec 秒无人应答；0/不可读 = 禁用）
+    try {
+      const ats = resolveApprovalTimeoutSec({ dataDir: g?.dataDir });
+      if (ats > 0) {
+        const timer = setTimeout(() => {
+          try {
+            approval._respond("rejected");
+            approval.status = "answered";
+            approval.outcome = "rejected";
+            approval.answeredAt = new Date().toISOString();
+          } catch { /* 忽略 */ }
+        }, ats * 1000);
+        approval._cancelTimer = () => clearTimeout(timer);
+      }
+    } catch { /* 超时表不可用禁用（等待 approve.js/会话终局兑底） */ }
+    // 宿主 Agent 审批通知（interlude 插话——bus/sessionPath/rpcId/task 经 op 条目
+    // 由 run.js createOpEntry 提交上下文补齐；通知失败不阻断——审批仍可经 dsh_approve）
+    try {
+      await notifyApprovalWake({
+        bus: g && g.bus,
+        sessionPath: op.sessionPath,
+        rpcId: op.rpcId || "",
+        approval,
+        task: op.task || "",
+      });
+    } catch { /* 通知失败不阻断 */ }
+    return pending;
+  }
+
   // 依赖沿 DSH 树解析（dsh realpath → dsh-acp-app → dsh-acp + SDK——见文件头注释），
   // 与 DSH 运行时同物理包实例（非 bundle 内联）；动态加载不阻塞模块加载（闭环）。
   const dshReal = realpathSync(
@@ -99,15 +182,43 @@ export async function mountAcp(ctx, { dshHome, emitLog }) {
     apply: (inner) => acp.apply(inner, { ...acpConfig, stream: agentStream }),
   });
   log("插件已挂载（provider=" + (acpConfig.provider || "?") + " model=" + (acpConfig.model || "?") + "）");
-  // 宿主侧 client：注册 session/update 通知缓冲（指令进展事件；L2 指令通道接入后消费）
+  // 宿主侧 client：注册 session/update 通知缓冲（指令进展事件）与审批反向应答
+  //（L4：request_permission——DSH agent 越界/敏感工具审批，见 handleRequestPermission）。
+  // update 同时缓存 tool_call 的 title/rawInput（审批决策信息源——request_permission
+  // 请求只带 toolCallId，name/args 从 tool_call update 补）。
   const updateQueue = [];
   const updateWaiters = [];
+  const toolCache = new Map(); // toolCallId → { name, args }
   const clientApp = createAcpClientApp({ name: "dsh-hanako-host" })
     .onNotification(methods.client.session.update, ({ params }) => {
+      const update = params && params.update;
+      if (update && typeof update === "object" && update.sessionUpdate === "tool_call") {
+        if (update.toolCallId) {
+          let args = null;
+          if (update.rawInput !== undefined) {
+            try {
+              args =
+                typeof update.rawInput === "string"
+                  ? update.rawInput
+                  : JSON.stringify(update.rawInput);
+            } catch {
+              args = String(update.rawInput ?? "");
+            }
+          }
+          toolCache.set(update.toolCallId, {
+            name: typeof update.title === "string" ? update.title : "tool",
+            args,
+          });
+        }
+      }
       if (updateWaiters.length) updateWaiters.shift()(params);
       else updateQueue.push(params);
       return Promise.resolve();
-    });
+    })
+    .onRequest(
+      methods.client.session.requestPermission,
+      handleRequestPermission,
+    );
   const connection = clientApp.connect(clientStream);
   const client = connection.agent;
   // initialize 握手验证（协议面通 = 挂载成功门槛；失败抛错由调用方降级）。

--- a/src/lib/acp-mount.js
+++ b/src/lib/acp-mount.js
@@ -62,26 +62,41 @@ export async function mountAcp(ctx, { dshHome, emitLog }) {
   const log = (msg) => {
     try { emitLog?.("hana", "[dsh acp] " + msg); } catch { /* noop */ }
   };
-  // ---- L4：审批反向应答（request_permission）----
-  // DSH agent 越界/敏感工具调用 → ctx approval/request → dsh-acp 插件转
-  // session/request_permission 请求发 client（options: allow-once / reject-once，映射
-  // 见 dsh-acp index.ts requestPermission）。宿主应答 = onRequest handler 返回
-  // { outcome }——本 handler 挂起等宿主决策：审批上下文存 g.ops.activeApprovals
-  //（approve.js dsh_approve 工具查同一表——ap._respond resolve 本 pending）；超时
-  // 自动拒绝（approvalTimeoutSec）；无活动任务（op 缺失/终态）默认拒绝（安全）。
-  async function handleRequestPermission({ params, requestId }) {
+  // ---- L4：审批应答（approval/request ctx global waterfall）----
+  // DSH agent 越界/敏感工具 → ApprovalService.decide → ctx.waterfall(scopeTarget(agent),
+  // 'approval/request', req, ...)——agent-scope 过滤，普通 ctx.on（无 global）因 context
+  // filter 收不到（实证：宿主与 dsh-acp 的无 scope ctx.on 均静默；dsh-acp 的
+  // request_permission 转发也因此从不触发）。EventOptions.global: true = 无视 context
+  // filter 收所有 agent 的 scope 事件。listener 返回 ApprovalOutcome（allowed-once /
+  // rejected / cancelled / unavailable）= 认领请求（不调 next）——宿主决策即审批结果，
+  // 零端口（不经 ACP request_permission / HTTP respond）。
+  // req: { agent, toolName, callId?, reason?, signal? }（ApprovalRequestEvent）。
+  async function approvalAnswerer(req, next) {
     const g = getSingleton();
-    const sessionId = params && params.sessionId;
-    const callId = params && params.toolCall && params.toolCall.toolCallId;
+    const sessionId =
+      req && req.agent && req.agent.session ? req.agent.session.id : null;
+    const callId = (req && req.callId) || null;
     const cached = callId ? toolCache.get(callId) : null;
-    const approvalId = String(
-      requestId ?? callId ?? "req-" + Date.now(),
-    );
+    const toolName =
+      (req && req.toolName) || (cached && cached.name) || "tool";
+    const approvalId = String(callId || "req-" + Date.now());
+    try {
+      g?.appendLog?.(
+        "hana",
+        `[dsh acp] 审批请求收到（session=${String(sessionId || "?").slice(0, 12)} tool=${toolName} id=${approvalId.slice(0, 24)}）`,
+      );
+    } catch { /* 日志失败不阻断 */ }
     const op =
       g && typeof g.ops?.get === "function" ? g.ops.get(sessionId) : null;
     if (!op || !Array.isArray(op.activeApprovals)) {
-      // 无活动任务/协调条目缺失（任务已终态/未知会话）：默认拒绝（安全）
-      return { outcome: { outcome: "selected", optionId: "reject-once" } };
+      // 无活动任务/协调条目缺失（任务已终态/未知会话）：认领并默认拒绝（安全）
+      try {
+        g?.appendLog?.(
+          "hana",
+          `[dsh acp] 审批无活动任务（op=${op ? "有但无表" : "无"}）——默认拒绝`,
+        );
+      } catch { /* 日志失败不阻断 */ }
+      return "rejected";
     }
     let settle = null;
     const pending = new Promise((resolve) => {
@@ -91,9 +106,9 @@ export async function mountAcp(ctx, { dshHome, emitLog }) {
       approvalId,
       eventId: approvalId,
       sessionId,
-      toolName: (cached && cached.name) || "tool",
-      callId: callId ?? null,
-      reason: null,
+      toolName,
+      callId,
+      reason: (req && req.reason) || null,
       args: cached ? cached.args : null,
       status: "pending",
       requestedAt: new Date().toISOString(),
@@ -102,17 +117,31 @@ export async function mountAcp(ctx, { dshHome, emitLog }) {
         const s = settle;
         settle = null;
         try {
-          s({
-            outcome: {
-              outcome: "selected",
-              optionId:
-                outcomeStr === "allowed-once" ? "allow-once" : "reject-once",
-            },
-          });
+          s(outcomeStr === "rejected" ? "rejected" : "allowed-once");
         } catch { /* 已 settle 忽略 */ }
       },
     };
     op.activeApprovals.push(approval);
+    try {
+      g?.appendLog?.(
+        "hana",
+        `[dsh acp] 审批已挂起（id=${approvalId.slice(0, 24)}）——等宿主应答`,
+      );
+    } catch { /* 日志失败不阻断 */ }
+    // 审批请求取消（会话 abort/cancel）→ 返回 cancelled（waterfall 认领）
+    const signal = req && req.signal;
+    const onAbort = () => {
+      try {
+        approval._respond("cancelled");
+        approval.status = "answered";
+        approval.outcome = "cancelled";
+        approval.answeredAt = new Date().toISOString();
+      } catch { /* 忽略 */ }
+    };
+    if (signal) {
+      if (signal.aborted) onAbort();
+      else signal.addEventListener("abort", onAbort, { once: true });
+    }
     // 超时自动拒绝（approvalTimeoutSec 秒无人应答；0/不可读 = 禁用）
     try {
       const ats = resolveApprovalTimeoutSec({ dataDir: g?.dataDir });
@@ -127,7 +156,7 @@ export async function mountAcp(ctx, { dshHome, emitLog }) {
         }, ats * 1000);
         approval._cancelTimer = () => clearTimeout(timer);
       }
-    } catch { /* 超时表不可用禁用（等待 approve.js/会话终局兑底） */ }
+    } catch { /* 超时表不可用禁用 */ }
     // 宿主 Agent 审批通知（interlude 插话——bus/sessionPath/rpcId/task 经 op 条目
     // 由 run.js createOpEntry 提交上下文补齐；通知失败不阻断——审批仍可经 dsh_approve）
     try {
@@ -140,6 +169,14 @@ export async function mountAcp(ctx, { dshHome, emitLog }) {
       });
     } catch { /* 通知失败不阻断 */ }
     return pending;
+  }
+  // 注册 global waterfall listener（无视 agent-scope filter——收所有审批）；返回 outcome
+  // = 认领（不调 next——审批服务 decide 拿宿主决策）。
+  try {
+    ctx.on("approval/request", approvalAnswerer, { global: true });
+    log("审批应答已挂（approval/request global listener）");
+  } catch (e) {
+    log("审批应答挂载失败：" + ((e && e.message) || e));
   }
 
   // 依赖沿 DSH 树解析（dsh realpath → dsh-acp-app → dsh-acp + SDK——见文件头注释），
@@ -183,7 +220,7 @@ export async function mountAcp(ctx, { dshHome, emitLog }) {
   });
   log("插件已挂载（provider=" + (acpConfig.provider || "?") + " model=" + (acpConfig.model || "?") + "）");
   // 宿主侧 client：注册 session/update 通知缓冲（指令进展事件）与审批反向应答
-  //（L4：request_permission——DSH agent 越界/敏感工具审批，见 handleRequestPermission）。
+  //（L4：审批应答——ctx approval/request global waterfall，见 approvalAnswerer）。
   // update 同时缓存 tool_call 的 title/rawInput（审批决策信息源——request_permission
   // 请求只带 toolCallId，name/args 从 tool_call update 补）。
   const updateQueue = [];
@@ -192,6 +229,14 @@ export async function mountAcp(ctx, { dshHome, emitLog }) {
   const clientApp = createAcpClientApp({ name: "dsh-hanako-host" })
     .onNotification(methods.client.session.update, ({ params }) => {
       const update = params && params.update;
+      try {
+        const sid = (params && params.sessionId) || "?";
+        const ut = (update && update.sessionUpdate) || "?";
+        getSingleton()?.appendLog?.(
+          "hana",
+          `[dsh acp] session/update 收到（session=${String(sid).slice(0, 12)} type=${ut}）`,
+        );
+      } catch { /* 日志失败不阻断 */ }
       if (update && typeof update === "object" && update.sessionUpdate === "tool_call") {
         if (update.toolCallId) {
           let args = null;
@@ -214,11 +259,7 @@ export async function mountAcp(ctx, { dshHome, emitLog }) {
       if (updateWaiters.length) updateWaiters.shift()(params);
       else updateQueue.push(params);
       return Promise.resolve();
-    })
-    .onRequest(
-      methods.client.session.requestPermission,
-      handleRequestPermission,
-    );
+    });
   const connection = clientApp.connect(clientStream);
   const client = connection.agent;
   // initialize 握手验证（协议面通 = 挂载成功门槛；失败抛错由调用方降级）。

--- a/src/lib/acp-mount.js
+++ b/src/lib/acp-mount.js
@@ -58,6 +58,9 @@ function readDefaultModel(dshHome) {
     // readDshDefaultModel 同源（settings.yaml 结构简单，不需引 YAML 解析器）。
     const lines = String(readFileSync(p, "utf8")).split(/\r?\n/);
     let inBlock = false;
+    let directIndent = null; // agent-default-model 直接子键的缩进（CodeRabbit 第五轮：
+    // 嵌套 mapping（缩进更深）的键不得冒充直接字段——如某子块里同名 provider/model
+    // 会覆盖 out——只收缩进 == 直接子级的键）
     const out = {};
     for (const line of lines) {
       if (/^agent-default-model\s*:/.test(line)) {
@@ -72,6 +75,9 @@ function readDefaultModel(dshHome) {
       }
       const m = line.match(/^(\s+)([A-Za-z]+)\s*:\s*(.*)$/);
       if (!m) continue; // 块内嵌套（列表项等）跳过，继续找键
+      const indent = m[1].length;
+      if (directIndent === null) directIndent = indent;
+      if (indent !== directIndent) continue; // 嵌套 mapping（缩进更深）跳过
       const k = m[2];
       const v = m[3].trim();
       if (v) out[k] = v.replace(/^['"]|['"]$/g, "");

--- a/src/lib/acp-mount.js
+++ b/src/lib/acp-mount.js
@@ -62,6 +62,15 @@ export async function mountAcp(ctx, { dshHome, emitLog }) {
   const log = (msg) => {
     try { emitLog?.("hana", "[dsh acp] " + msg); } catch { /* noop */ }
   };
+  // 共享状态持有（审批应答 + client session/update 通知缓冲共用）：必须在
+  // approvalAnswerer 注册/可能被调用**之前**初始化——approvalAnswerer 在审批到达时读
+  // toolCache。若其声明在注册之后，ctx.on("approval/request", approvalAnswerer) 同步注册
+  // 后本函数还有很多 await（动态 import、ctx.plugin、握手），事件循环可在 toolCache 声明
+  //（TDZ）之前 dispatch 审批 → approvalAnswerer 读 toolCache 抛 ReferenceError。
+  // 故在此前置声明（CodeRabbit Minor #3）。
+  const updateQueue = []; // session/update 通知缓冲（takeUpdate 取号者为空时暂存）
+  const updateWaiters = []; // 等待 update 的解析器队列（takeUpdate 无缓冲时等投递）
+  const toolCache = new Map(); // toolCallId → { name, args }（审批决策的 tool 上下文）
   // ---- L4：审批应答（approval/request ctx global waterfall）----
   // DSH agent 越界/敏感工具 → ApprovalService.decide → ctx.waterfall(scopeTarget(agent),
   // 'approval/request', req, ...)——agent-scope 过滤，普通 ctx.on（无 global）因 context
@@ -232,12 +241,10 @@ export async function mountAcp(ctx, { dshHome, emitLog }) {
   });
   log("插件已挂载（provider=" + (acpConfig.provider || "?") + " model=" + (acpConfig.model || "?") + "）");
   // 宿主侧 client：注册 session/update 通知缓冲（指令进展事件）与审批反向应答
-  //（L4：审批应答——ctx approval/request global waterfall，见 approvalAnswerer）。
+  //（审批应答 = ctx approval/request global waterfall，见 approvalAnswerer）。
   // update 同时缓存 tool_call 的 title/rawInput（审批决策信息源——request_permission
-  // 请求只带 toolCallId，name/args 从 tool_call update 补）。
-  const updateQueue = [];
-  const updateWaiters = [];
-  const toolCache = new Map(); // toolCallId → { name, args }
+  // 请求只带 toolCallId，name/args 从 tool_call update 补）。updateQueue/updateWaiters/
+  // toolCache 已在上方前置声明（防审批在 TDZ 期读 toolCache，见 CodeRabbit Minor #3）。
   const clientApp = createAcpClientApp({ name: "dsh-hanako-host" })
     .onNotification(methods.client.session.update, ({ params }) => {
       const update = params && params.update;

--- a/src/lib/acp-mount.js
+++ b/src/lib/acp-mount.js
@@ -111,6 +111,10 @@ export async function mountAcp(ctx, { dshHome, emitLog }) {
   const updateQueue = []; // session/update 通知缓冲（takeUpdate 取号者为空时暂存）
   const updateWaiters = []; // 等待 update 的解析器队列（takeUpdate 无缓冲时等投递）
   const toolCache = new Map(); // toolCallId → { name, args }（审批决策的 tool 上下文）
+  // 通道关闭标记（CodeRabbit 第二轮 #3）：close() 先置 closed 再关连接——closed 期间
+  // takeUpdate 立即 resolve null（不再新增 waiter，防新取号者挂死在已停用通道）；迟到的
+  // session/update 通知直接丢弃（不重入缓冲/toolCache）；close() 幂等（重复调用安全）。
+  let closed = false;
   // ---- L4：审批应答（approval/request ctx global waterfall）----
   // DSH agent 越界/敏感工具 → ApprovalService.decide → ctx.waterfall(scopeTarget(agent),
   // 'approval/request', req, ...)——agent-scope 过滤，普通 ctx.on（无 global）因 context
@@ -324,6 +328,8 @@ export async function mountAcp(ctx, { dshHome, emitLog }) {
   // toolCache 已在上方前置声明（防审批在 TDZ 期读 toolCache，见 CodeRabbit Minor #3）。
   const clientApp = createAcpClientApp({ name: "dsh-hanako-host" })
     .onNotification(methods.client.session.update, ({ params }) => {
+      // 通道已关闭（close 后迟到的通知）：直接丢弃，不写 toolCache/updateQueue
+      if (closed) return Promise.resolve();
       const update = params && params.update;
       if (update && typeof update === "object" && update.sessionUpdate === "tool_call") {
         if (update.toolCallId) {
@@ -377,11 +383,19 @@ export async function mountAcp(ctx, { dshHome, emitLog }) {
     client,
     sdk,
     methods,
-    takeUpdate: () =>
-      updateQueue.length
+    takeUpdate: () => {
+      // 已关闭：立即 resolve null——不新增 waiter（防 close 后新取号者挂死）；遗留
+      // waiter 由 close() 唤醒置空（既有 waiter-draining 行为保留）。
+      if (closed) return Promise.resolve(null);
+      return updateQueue.length
         ? Promise.resolve(updateQueue.shift())
-        : new Promise((r) => updateWaiters.push(r)),
+        : new Promise((r) => updateWaiters.push(r));
+    },
     close: () => {
+      // 幂等：closed 已置位直接返回（重复 close 安全，不再重复关连接/清空/唤醒）。
+      // 先置 closed 再关连接：closed 先行使新 takeUpdate / 迟到通知立即短路。
+      if (closed) return;
+      closed = true;
       try { connection.close?.(); } catch { /* noop */ }
       // 卸载/关闭：废弃累积 update 缓冲与等待者（防 close 后残留无界暂存/挂死 waiter）。
       // close 语义 = 通道停用不再取用——遗留缓冲可被 GC（CodeRabbit Major #5）。

--- a/src/lib/acp-mount.js
+++ b/src/lib/acp-mount.js
@@ -45,19 +45,41 @@ const hostRequire = createRequire(import.meta.url);
 function readDefaultModel(dshHome) {
   try {
     const p = join(dshHome, "settings.yaml");
-    const txt = String(readFileSync(p, "utf8"));
-    const mm = txt.match(
-      /agent-default-model:[\s\S]*?\n\s+model:\s*["']?([^"'\n]+)/,
-    );
-    const mp = txt.match(/agent-default-model:\s*\n\s+provider:\s*["']?([^"'\n]+)/);
-    const me = txt.match(
-      /agent-default-model:[\s\S]*?\n\s+reasoningEffort:\s*["']?([^"'\n]+)/,
-    );
-    if (!mm || !mp) return null;
+    // 行级解析（CodeRabbit 第二轮 #7）：原实现三条跨块正则
+    // `agent-default-model:[\s\S]*?\n\s+(model|reasoningEffort):` 在 agent-default-model
+    // 块内没有对应键时，懒匹配会跨越到下一个顶层 mapping（llm-pi-ai / agent-presets 等）
+    // 误取同名字段（settings.yaml 顶层键嵌套子块同名键时）。先截 agent-default-model 块
+    //（到下一个顶层键/出块）再在块内提取键——零依赖行级策略，与 lib/config.js 的
+    // readDshDefaultModel 同源（settings.yaml 结构简单，不需引 YAML 解析器）。
+    const lines = String(readFileSync(p, "utf8")).split(/\r?\n/);
+    let inBlock = false;
+    const out = {};
+    for (const line of lines) {
+      if (/^agent-default-model\s*:/.test(line)) {
+        inBlock = true;
+        continue;
+      }
+      if (!inBlock) continue;
+      // 无缩进行 = 出块（下一个顶层键）；空行/注释行跳过（块内允许，不算出块）
+      if (!/^\s/.test(line)) {
+        if (line.trim() === "" || /^\s*#/.test(line)) continue;
+        break;
+      }
+      const m = line.match(/^(\s+)([A-Za-z]+)\s*:\s*(.*)$/);
+      if (!m) continue; // 块内嵌套（列表项等）跳过，继续找键
+      const k = m[2];
+      const v = m[3].trim();
+      if (v) out[k] = v.replace(/^['"]|['"]$/g, "");
+    }
+    // 选择行为与旧实现一致：provider+model 必需（缺任一回退 null，调用方走 undefined）；
+    // reasoningEffort 可选。值在块内截取，不会跨块误配。
+    if (!out.provider || !out.model) return null;
     return {
-      provider: mp[1].trim(),
-      model: mm[1].trim(),
-      reasoningEffort: me ? me[1].trim() : undefined,
+      provider: String(out.provider).trim(),
+      model: String(out.model).trim(),
+      reasoningEffort: out.reasoningEffort
+        ? String(out.reasoningEffort).trim()
+        : undefined,
     };
   } catch {
     return null;

--- a/src/lib/acp-mount.js
+++ b/src/lib/acp-mount.js
@@ -111,6 +111,32 @@ export async function mountAcp(ctx, { dshHome, emitLog }) {
     const pending = new Promise((resolve) => {
       settle = resolve;
     });
+    // ---- 单飞收尾守卫（CodeRabbit Minor #4）----
+    // onAbort 与超时（及宿主应答 _respond）是三条独立 settle 路径。原实现无共享 guard：
+    // onAbort 标记 cancelled 后，超时回调仍会写 status="answered"/outcome="rejected"/
+    // answeredAt（_respond 空操作但状态字段被后到者污染），且 onAbort 不清超时计时器。
+    // settled 标志 = 首个 settle 写终态 + resolve 挂起 Promise + 清除超时计时器；后续
+    // 路径只 no-op——保留先到者设的状态/时间戳（onAbort 的 cancelled 不会被覆盖）。
+    let settled = false;
+    let timeoutTimer = null; // 超时拒绝计时器（settle/onAbort 时 clearTimeout，防再触发污染）
+    const commitSettle = (statusOutcome, resolvedValue) => {
+      if (settled) return;
+      settled = true;
+      approval.status = "answered";
+      approval.outcome = statusOutcome;
+      approval.answeredAt = new Date().toISOString();
+      if (timeoutTimer) {
+        clearTimeout(timeoutTimer);
+        timeoutTimer = null;
+      }
+      const s = settle;
+      settle = null;
+      if (s) {
+        try {
+          s(resolvedValue);
+        } catch { /* 已 settle 忽略 */ }
+      }
+    };
     const approval = {
       approvalId,
       eventId: approvalId,
@@ -122,12 +148,11 @@ export async function mountAcp(ctx, { dshHome, emitLog }) {
       status: "pending",
       requestedAt: new Date().toISOString(),
       _respond: (outcomeStr) => {
-        if (!settle) return;
-        const s = settle;
-        settle = null;
-        try {
-          s(outcomeStr === "rejected" ? "rejected" : "allowed-once");
-        } catch { /* 已 settle 忽略 */ }
+        // 宿主应答（dsh_approve / interlude 转发）：rejected → rejected，其余 → allowed-once
+        //（与旧 mapping 一致）。经 commitSettle：已 settle（abort/超时先到）则 no-op。
+        const mapped =
+          outcomeStr === "rejected" ? "rejected" : "allowed-once";
+        commitSettle(mapped, mapped);
       },
     };
     op.activeApprovals.push(approval);
@@ -137,33 +162,33 @@ export async function mountAcp(ctx, { dshHome, emitLog }) {
         `[dsh acp] 审批已挂起（id=${approvalId.slice(0, 24)}）——等宿主应答`,
       );
     } catch { /* 日志失败不阻断 */ }
-    // 审批请求取消（会话 abort/cancel）→ 返回 cancelled（waterfall 认领）
+    // 审批请求取消（会话 abort/cancel）→ 返回 cancelled。
+    // onAbort 写 cancelled 终态并清超时计时器（commitSettle 内部）：后到的超时/应答
+    // 只 no-op，不再覆盖 cancelled 状态与时间戳。
     const signal = req && req.signal;
     const onAbort = () => {
-      try {
-        approval._respond("cancelled");
-        approval.status = "answered";
-        approval.outcome = "cancelled";
-        approval.answeredAt = new Date().toISOString();
-      } catch { /* 忽略 */ }
+      // 先到分支写入 cancelled；resolve 仍沿用旧的 allowed-once（waterfall outcome）。
+      commitSettle("cancelled", "allowed-once");
     };
     if (signal) {
-      if (signal.aborted) onAbort();
+      if (signal.aborted) onAbort(); // signal 已 aborted：立即 settle + 清计时器
       else signal.addEventListener("abort", onAbort, { once: true });
     }
     // 超时自动拒绝（approvalTimeoutSec 秒无人应答；0/不可读 = 禁用）
     try {
       const ats = resolveApprovalTimeoutSec({ dataDir: g?.dataDir });
-      if (ats > 0) {
-        const timer = setTimeout(() => {
-          try {
-            approval._respond("rejected");
-            approval.status = "answered";
-            approval.outcome = "rejected";
-            approval.answeredAt = new Date().toISOString();
-          } catch { /* 忽略 */ }
+      if (ats > 0 && !settled) {
+        // signal 已同步 aborted（上方 onAbort 已 settle）→ 不再起计时器
+        timeoutTimer = setTimeout(() => {
+          // 已 settle（onAbort/应答先到）→ no-op（守卫处理）；仍 pending → rejected
+          commitSettle("rejected", "rejected");
         }, ats * 1000);
-        approval._cancelTimer = () => clearTimeout(timer);
+        approval._cancelTimer = () => {
+          if (timeoutTimer) {
+            clearTimeout(timeoutTimer);
+            timeoutTimer = null;
+          }
+        };
       }
     } catch { /* 超时表不可用禁用 */ }
     // 宿主 Agent 审批通知（interlude 插话——bus/sessionPath/rpcId/task 经 op 条目

--- a/src/lib/acp-mount.js
+++ b/src/lib/acp-mount.js
@@ -202,8 +202,12 @@ export async function mountAcp(ctx, { dshHome, emitLog }) {
     // 只 no-op，不再覆盖 cancelled 状态与时间戳。
     const signal = req && req.signal;
     const onAbort = () => {
-      // 先到分支写入 cancelled；resolve 仍沿用旧的 allowed-once（waterfall outcome）。
-      commitSettle("cancelled", "allowed-once");
+      // 审批请求取消（会话 abort/cancel）→ 返回 cancelled。resolve 值 = 宿主回给
+      // ApprovalService 的 ApprovalOutcome：必须完整透传 cancelled——不得沿用旧的
+      // allowed-once（否则 abort 被当作一次授权放行，工具可能随后续重试被执行）。
+      // outcome→allowed-once/rejected 的收窄映射只发生在宿主决策入口 _respond；
+      // 超时自动拒绝路径已直传 rejected（CodeRabbit 第二轮 #2）。
+      commitSettle("cancelled", "cancelled");
     };
     if (signal) {
       if (signal.aborted) onAbort(); // signal 已 aborted：立即 settle + 清计时器

--- a/src/lib/acp-mount.js
+++ b/src/lib/acp-mount.js
@@ -38,8 +38,10 @@ const MAX_BUFFERED_UPDATES = 128;
 const hostRequire = createRequire(import.meta.url);
 
 /** 读 DSH 默认模型（dsh-home/settings.yaml agent-default-model，与 tools run.js 同源），
- * 供 ACP 插件的 provider/model 配置（ACP 创建的 agent 的 initialSelection）。读失败
- * 返回 null（调用方回退 undefined——Schema 必填失败时抛错由调用方降级）。 */
+ * 供 ACP 插件的 provider/model 配置（ACP 创建的 agent 的 initialSelection）与
+ * selectModel 后的 effort 默认保持（readDefaultModel().effort——宿主 set model 会冲掉
+ * DSH settings 的 reasoningEffort，需在 set model 后补 set；不支持的模型 set 失败静默
+ * 降级）。读失败返回 null（调用方回退 undefined——Schema 必填失败时抛错由调用方降级）。 */
 function readDefaultModel(dshHome) {
   try {
     const p = join(dshHome, "settings.yaml");
@@ -48,8 +50,15 @@ function readDefaultModel(dshHome) {
       /agent-default-model:[\s\S]*?\n\s+model:\s*["']?([^"'\n]+)/,
     );
     const mp = txt.match(/agent-default-model:\s*\n\s+provider:\s*["']?([^"'\n]+)/);
+    const me = txt.match(
+      /agent-default-model:[\s\S]*?\n\s+reasoningEffort:\s*["']?([^"'\n]+)/,
+    );
     if (!mm || !mp) return null;
-    return { provider: mp[1].trim(), model: mm[1].trim() };
+    return {
+      provider: mp[1].trim(),
+      model: mm[1].trim(),
+      reasoningEffort: me ? me[1].trim() : undefined,
+    };
   } catch {
     return null;
   }
@@ -257,6 +266,14 @@ export async function mountAcp(ctx, { dshHome, emitLog }) {
     provider: dm?.provider,
     model: dm?.model,
   };
+  // 默认 effort（settings agent-default-model.reasoningEffort）：宿主 selectModel
+  // set model 会冲掉 DSH settings 的 effort（set model 无 effort → resolveCallConfig
+  // 落 model 默认）——存宿主单例供 protocol acpSelect 在 set model 后补 set effort
+  //（任务显式传优先；不支持的模型 set 失败静默降级——见 acpSelect catch）。
+  try {
+    const g0 = getSingleton();
+    if (g0) g0.acpDefaultEffort = dm?.reasoningEffort || null;
+  } catch { /* 单例不可写忽略 */ }
   // 内存双工对（零端口零 stdio）：server 侧写 a2c / 读 c2a；client 侧相反
   const a2c = new TransformStream();
   const c2a = new TransformStream();

--- a/src/lib/acp-mount.js
+++ b/src/lib/acp-mount.js
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2026 Nyasers
+//
+// lib/acp-mount.js — ACP（Agent Client Protocol）进程内内部通讯通道挂载
+// （feat/acp-channel，2026-09-06 用户裁定方向）
+//
+// 形态：宿主与 DSH 同进程（进程内 boot），在 DSH cordis ctx 上挂 @deepseek-ai/dsh-acp
+// 插件，transport 用内存双工 Web Streams（TransformStream + ndJsonStream）——零端口
+// 零 stdio。宿主侧用 @agentclientprotocol/sdk 的 client 连同一双工对，得到 agent 面
+// 客户端（session.new/prompt/cancel 等）——指令通道内部化，HTTP /api 只服务 WebUI。
+//
+// 事件面不经过 ACP：继续 ctx.on 直订（dsh-events.js）——ACP 只管指令。
+//
+// 依赖定位（安装副本 pnpm 严格布局）：@deepseek-ai/dsh-acp 与 @agentclientprotocol/sdk
+// 都不是 @deepseek-ai/dsh 的直接依赖（dsh 依赖 @deepseek-ai/dsh-acp-app，后者依赖
+// dsh-acp；SDK 是 dsh-acp 的依赖）——从 dsh-acp-app 的 .pnpm 真实位置 createRequire
+// 沿同层 node_modules 解析（不硬编码 hash：枚举 .pnpm/@deepseek-ai+dsh-acp-app@*，
+// 取唯一匹配/首个）。
+import { readFileSync, realpathSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { createRequire } from "node:module";
+import { pathToFileURL } from "node:url";
+
+// ACP 运行时依赖定位：@deepseek-ai/dsh-acp（插件本体）与 @agentclientprotocol/sdk
+// 随 DSH 依赖树存在（@deepseek-ai/dsh → @deepseek-ai/dsh-acp-app → dsh-acp，SDK 是
+// dsh-acp 的依赖）——宿主不新增声明（bootstrap pnpm i -P 只装 cordis/dsh，避免 pnpm
+// 全局解析重排）。从 @deepseek-ai/dsh（宿主 dependencies，顶层链接）realpath 到
+// .pnpm 真实位置后 createRequire 沿依赖链解析（链接路径解析不到间接依赖）。
+// 宿主**不静态 import**（静态 import 在模块加载期解析，依赖未装时崩 → onload 自动装
+// 不跑 = 无法闭环）：解析与动态 import 全在 mountAcp 内（惰性，boot 时执行）。
+const hostRequire = createRequire(import.meta.url);
+
+/** 读 DSH 默认模型（dsh-home/settings.yaml agent-default-model，与 tools run.js 同源），
+ * 供 ACP 插件的 provider/model 配置（ACP 创建的 agent 的 initialSelection）。读失败
+ * 返回 null（调用方回退 undefined——Schema 必填失败时抛错由调用方降级）。 */
+function readDefaultModel(dshHome) {
+  try {
+    const p = join(dshHome, "settings.yaml");
+    const txt = String(readFileSync(p, "utf8"));
+    const mm = txt.match(
+      /agent-default-model:[\s\S]*?\n\s+model:\s*["']?([^"'\n]+)/,
+    );
+    const mp = txt.match(/agent-default-model:\s*\n\s+provider:\s*["']?([^"'\n]+)/);
+    if (!mm || !mp) return null;
+    return { provider: mp[1].trim(), model: mm[1].trim() };
+  } catch {
+    return null;
+  }
+}
+
+/** 挂载 ACP 内部通讯通道。
+ * @param ctx DSH cordis ctx（进程内 boot 的 r.ctx）
+ * @param opts { pkgDir, dshHome, emitLog }
+ * @returns { client, close }——client = ACP agent 面客户端（request/notify）；close =
+ *   卸载（ctx.fiber.dispose 由 lifecycle 统一管，本处仅释放 client 连接）。
+ * 挂载/握手失败抛错（调用方降级——WebUI 主链不依赖 ACP）。
+ */
+export async function mountAcp(ctx, { dshHome, emitLog }) {
+  const log = (msg) => {
+    try { emitLog?.("hana", "[dsh acp] " + msg); } catch { /* noop */ }
+  };
+  // 依赖沿 DSH 树解析（dsh realpath → dsh-acp-app → dsh-acp + SDK——见文件头注释），
+  // 与 DSH 运行时同物理包实例（非 bundle 内联）；动态加载不阻塞模块加载（闭环）。
+  const dshReal = realpathSync(
+    dirname(hostRequire.resolve("@deepseek-ai/dsh/package.json")),
+  );
+  const dshRequire = createRequire(join(dshReal, "package.json"));
+  const acpAppRequire = createRequire(dshRequire.resolve("@deepseek-ai/dsh-acp-app"));
+  const acpPath = acpAppRequire.resolve("@deepseek-ai/dsh-acp");
+  // SDK 是 dsh-acp 的依赖（不在 dsh-acp-app 层）——从 dsh-acp 解析
+  const acpRequire = createRequire(acpPath);
+  const acpMod = await import(/* webpackIgnore: true */ pathToFileURL(acpPath).href);
+  const sdkMod = await import(/* webpackIgnore: true */ pathToFileURL(
+    acpRequire.resolve("@agentclientprotocol/sdk"),
+  ).href);
+  const acp = acpMod.default ?? acpMod;
+  const sdk = sdkMod.default ?? sdkMod;
+  const ndJsonStream = sdk.ndJsonStream;
+  const createAcpClientApp = sdk.client ?? sdk.ClientApp?.create;
+  const methods = sdk.methods;
+  if (typeof ndJsonStream !== "function" || typeof createAcpClientApp !== "function") {
+    throw new Error("ACP SDK 缺 ndJsonStream/client（版本不兼容）");
+  }
+  // 模型配置：优先显式 provider/model 缺省读 dsh 默认（ACP agent initialSelection）
+  const dm = readDefaultModel(dshHome);
+  const acpConfig = {
+    provider: dm?.provider,
+    model: dm?.model,
+  };
+  // 内存双工对（零端口零 stdio）：server 侧写 a2c / 读 c2a；client 侧相反
+  const a2c = new TransformStream();
+  const c2a = new TransformStream();
+  const agentStream = ndJsonStream(a2c.writable, c2a.readable);
+  const clientStream = ndJsonStream(c2a.writable, a2c.readable);
+  // 挂 ACP 插件（注入面与 web bundle 共享 services：agents/llm/sessionPersistence/sessions）
+  await ctx.plugin({
+    name: "dshana-acp",
+    inject: [...(acp.inject || [])],
+    apply: (inner) => acp.apply(inner, { ...acpConfig, stream: agentStream }),
+  });
+  log("插件已挂载（provider=" + (acpConfig.provider || "?") + " model=" + (acpConfig.model || "?") + "）");
+  // 宿主侧 client：注册 session/update 通知缓冲（指令进展事件；L2 指令通道接入后消费）
+  const updateQueue = [];
+  const updateWaiters = [];
+  const clientApp = createAcpClientApp({ name: "dsh-hanako-host" })
+    .onNotification(methods.client.session.update, ({ params }) => {
+      if (updateWaiters.length) updateWaiters.shift()(params);
+      else updateQueue.push(params);
+      return Promise.resolve();
+    });
+  const connection = clientApp.connect(clientStream);
+  const client = connection.agent;
+  // initialize 握手验证（协议面通 = 挂载成功门槛；失败抛错由调用方降级）。
+  // 参数需 protocolVersion + clientCapabilities（SDK 方法校验，缺则 Invalid params）
+  const init = await client.request(methods.agent.initialize, {
+    protocolVersion: sdk.PROTOCOL_VERSION ?? 1,
+    clientCapabilities: {},
+  });
+  log(
+    "握手成功（agent=" + ((init && init.agentInfo && init.agentInfo.name) || "?") +
+    " v" + ((init && init.agentInfo && init.agentInfo.version) || "?") +
+    " proto=" + ((init && init.protocolVersion) || "?") + "）",
+  );
+  return {
+    client,
+    sdk,
+    methods,
+    takeUpdate: () =>
+      updateQueue.length
+        ? Promise.resolve(updateQueue.shift())
+        : new Promise((r) => updateWaiters.push(r)),
+    close: () => {
+      try { connection.close?.(); } catch { /* noop */ }
+    },
+  };
+}

--- a/src/lib/acp-mount.js
+++ b/src/lib/acp-mount.js
@@ -24,6 +24,10 @@ import { getSingleton } from "./state.js";
 import { notifyApprovalWake } from "./wake.js";
 import { resolveApprovalTimeoutSec } from "./config.js";
 
+// ACP client session/update 通知缓冲上限（CodeRabbit Major #5）：takeUpdate 无候取者时
+// updateQueue 的暂存上限——超限丢最旧（进展遥测非关键，防无界累积内存增长）。
+const MAX_BUFFERED_UPDATES = 128;
+
 // ACP 运行时依赖定位：@deepseek-ai/dsh-acp（插件本体）与 @agentclientprotocol/sdk
 // 随 DSH 依赖树存在（@deepseek-ai/dsh → @deepseek-ai/dsh-acp-app → dsh-acp，SDK 是
 // dsh-acp 的依赖）——宿主不新增声明（bootstrap pnpm i -P 只装 cordis/dsh，避免 pnpm
@@ -293,7 +297,14 @@ export async function mountAcp(ctx, { dshHome, emitLog }) {
         }
       }
       if (updateWaiters.length) updateWaiters.shift()(params);
-      else updateQueue.push(params);
+      else {
+        // 无候取者时的无界暂存防护（CodeRabbit Major #5）：takeUpdate 长期无人调用时
+        // updateQueue 原会无限累积（session/update 每次进展/工具/checkpoint 都触发）。
+        // 有限上限 MAX_BUFFERED_UPDATES：超限丢最旧一条（保留近期进展取号方向，也让
+        // 队列有界）。updateWaiters.shift() 的即时投递路径不走此缓存、不受限。
+        if (updateQueue.length >= MAX_BUFFERED_UPDATES) updateQueue.shift();
+        updateQueue.push(params);
+      }
       return Promise.resolve();
     });
   const connection = clientApp.connect(clientStream);
@@ -319,6 +330,13 @@ export async function mountAcp(ctx, { dshHome, emitLog }) {
         : new Promise((r) => updateWaiters.push(r)),
     close: () => {
       try { connection.close?.(); } catch { /* noop */ }
+      // 卸载/关闭：废弃累积 update 缓冲与等待者（防 close 后残留无界暂存/挂死 waiter）。
+      // close 语义 = 通道停用不再取用——遗留缓冲可被 GC（CodeRabbit Major #5）。
+      updateQueue.length = 0;
+      const ws = updateWaiters.splice(0);
+      for (const r of ws) {
+        try { r(null); } catch { /* 忽略 */ }
+      }
     },
   };
 }

--- a/src/lib/acp-mount.js
+++ b/src/lib/acp-mount.js
@@ -28,6 +28,11 @@ import { resolveApprovalTimeoutSec } from "./config.js";
 // updateQueue 的暂存上限——超限丢最旧（进展遥测非关键，防无界累积内存增长）。
 const MAX_BUFFERED_UPDATES = 128;
 
+// toolCache 上限（CodeRabbit 第二轮 #1）：toolCallId → { name, args }（审批决策的 tool
+// 上下文）——每次 tool_call 通知都存一条序列化 rawInput，web host 长活 + 工具反复调用
+// 时可无界累积参数数据。设上限，超限淘汰最旧；close() 时清空（见下方 close）。
+const MAX_TOOL_CACHE = 200;
+
 // ACP 运行时依赖定位：@deepseek-ai/dsh-acp（插件本体）与 @agentclientprotocol/sdk
 // 随 DSH 依赖树存在（@deepseek-ai/dsh → @deepseek-ai/dsh-acp-app → dsh-acp，SDK 是
 // dsh-acp 的依赖）——宿主不新增声明（bootstrap pnpm i -P 只装 cordis/dsh，避免 pnpm
@@ -337,6 +342,11 @@ export async function mountAcp(ctx, { dshHome, emitLog }) {
             name: typeof update.title === "string" ? update.title : "tool",
             args,
           });
+          // 有界缓存（CodeRabbit 第二轮 #1）：超上限淘汰最旧（Map 插入序最早 = 最旧）
+          if (toolCache.size > MAX_TOOL_CACHE) {
+            const oldestKey = toolCache.keys().next().value;
+            if (oldestKey !== undefined) toolCache.delete(oldestKey);
+          }
         }
       }
       if (updateWaiters.length) updateWaiters.shift()(params);
@@ -375,6 +385,9 @@ export async function mountAcp(ctx, { dshHome, emitLog }) {
       try { connection.close?.(); } catch { /* noop */ }
       // 卸载/关闭：废弃累积 update 缓冲与等待者（防 close 后残留无界暂存/挂死 waiter）。
       // close 语义 = 通道停用不再取用——遗留缓冲可被 GC（CodeRabbit Major #5）。
+      // toolCache 同步清空（CodeRabbit 第二轮 #1）：审批决策上下文随通道停用失效，
+      // 释放序列化 rawInput 引用（不再挂起长活 web host 的审批上下文）。
+      toolCache.clear();
       updateQueue.length = 0;
       const ws = updateWaiters.splice(0);
       for (const r of ws) {

--- a/src/lib/acp-mount.js
+++ b/src/lib/acp-mount.js
@@ -173,11 +173,23 @@ export async function mountAcp(ctx, { dshHome, emitLog }) {
   // 注册 global waterfall listener（无视 agent-scope filter——收所有审批）；返回 outcome
   // = 认领（不调 next——审批服务 decide 拿宿主决策）。
   try {
-    ctx.on("approval/request", approvalAnswerer, { global: true });
-    log("审批应答已挂（approval/request global listener）");
+    ctx.on("approval/request", approvalAnswerer, { global: true, prepend: true });
+    log("审批应答已挂（approval/request global+prepend listener）");
   } catch (e) {
     log("审批应答挂载失败：" + ((e && e.message) || e));
   }
+  // 诊断（审批链路定位）：internal/dispatch 探测——waterfall 分发面实证。events.ts
+  // dispatch 时 emit('internal/dispatch', mode, name, args, thisArg)——收 log 确认
+  // approval/request 的 waterfall 是否真的 dispatch（policy 短路则完全不进）。
+  // 注：已验证完成（12:58 审批全链通）——此探测仅保留供未来链路回归参考。
+  try {
+    ctx.on("internal/dispatch", (mode, name) => {
+      if (name !== "approval/request") return;
+      try {
+        log("internal/dispatch 探测：approval/request 已分发（mode=" + mode + "）");
+      } catch { /* 日志失败不阻断 */ }
+    });
+  } catch { /* 探测订阅失败忽略 */ }
 
   // 依赖沿 DSH 树解析（dsh realpath → dsh-acp-app → dsh-acp + SDK——见文件头注释），
   // 与 DSH 运行时同物理包实例（非 bundle 内联）；动态加载不阻塞模块加载（闭环）。
@@ -229,14 +241,6 @@ export async function mountAcp(ctx, { dshHome, emitLog }) {
   const clientApp = createAcpClientApp({ name: "dsh-hanako-host" })
     .onNotification(methods.client.session.update, ({ params }) => {
       const update = params && params.update;
-      try {
-        const sid = (params && params.sessionId) || "?";
-        const ut = (update && update.sessionUpdate) || "?";
-        getSingleton()?.appendLog?.(
-          "hana",
-          `[dsh acp] session/update 收到（session=${String(sid).slice(0, 12)} type=${ut}）`,
-        );
-      } catch { /* 日志失败不阻断 */ }
       if (update && typeof update === "object" && update.sessionUpdate === "tool_call") {
         if (update.toolCallId) {
           let args = null;

--- a/src/lib/dsh-events.js
+++ b/src/lib/dsh-events.js
@@ -21,6 +21,9 @@
 import { getSingleton } from "./state.js";
 
 // emit 模式白名单（与官方 remote-events 的 mode:"emit" 项对齐；waterfall 项不在此）
+// session/event = DSH 会话事件通用广播（turn/start、step/start、assistant/message、
+// turn/end 等，jsonl 同源）：api-session/* 是 HTTP 网关（session-controller）转发面，
+// ACP 会话不经 session-controller——宿主直订 session/event 才能收 ACP 会话的活动/终态。
 const CTX_EMIT_EVENTS = [
   "agent-preset/selected",
   "api-session/activity",
@@ -37,6 +40,7 @@ const CTX_EMIT_EVENTS = [
   "cordis/inspect-query",
   "cordis/inspect-query-resolved",
   "llm/adapters-updated",
+  "session/event",
   "settings/document-updated",
 ];
 

--- a/src/lib/dsh-events.js
+++ b/src/lib/dsh-events.js
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2026 Nyasers
+//
+// lib/dsh-events.js — 宿主侧 DSH 事件进程内订阅（refactor/bus-inproc：总线内置化第一刀）
+//
+// 背景：DSH 0.1.2 的 Host 事件（api-session/*、settings/document-updated 等）源头是 cordis
+// ctx 事件总线（官方 dsh-api-remotes 的 remoteEventSource 即 ctx.on 直订，再桥到 gateway 的
+// remote.mux WS）。旧架构宿主经「remote.mux WS → @dsh-hanako/bus 插件 → dshana.bus WS → 宿主」
+// 绕两圈收事件——那是跨进程假设的产物。进程内 boot（DSH 与宿主同进程，DSH ctx = g.web.ctx）
+// 下宿主可直接 ctx.on 订阅同一事件源，零 WS、零总线、零延迟。端口形态（3080/随机端口直嵌）
+// 同样成立：ctx 在手即可直订，总线只是载波不是事件源。
+//
+// 本模块 = 宿主侧事件订阅层（emit 模式）：web.ctx 可用时 ctx.on 直订白名单事件，帧格式与
+// 总线 events 频道兼容（{ type:"emit", event, args }——run.js consume / webui.js 消费不变）。
+// waterfall 模式（approval/request 等）需应答语义，见 lib/dsh-approval.js（瀑布适配未做时
+// 回退：审批请求仍走总线/官方 approvalTimeoutSec 超时自动拒绝兜底）。
+//
+// 事件白名单（emit 模式，抄官方 dsh-api-remotes API_REMOTE_FORWARDED_EVENTS 的 emit 项）：
+// api-session/*（任务状态/终态/错误）、settings/document-updated（主题偏好）、commands/change
+// 等。订阅返回退订函数；ctx 未就绪返回 null（调用方回退总线 events，行为不变）。
+import { getSingleton } from "./state.js";
+
+// emit 模式白名单（与官方 remote-events 的 mode:"emit" 项对齐；waterfall 项不在此）
+const CTX_EMIT_EVENTS = [
+  "agent-preset/selected",
+  "api-session/activity",
+  "api-session/added",
+  "api-session/error",
+  "api-session/removed",
+  "api-session/status",
+  "commands/change",
+  "credentials/reference-updated",
+  "cordis/request-run",
+  "cordis/request-run-resolved",
+  "cordis/dynamic-package",
+  "cordis/dynamic-retract",
+  "cordis/inspect-query",
+  "cordis/inspect-query-resolved",
+  "llm/adapters-updated",
+  "settings/document-updated",
+];
+
+/**
+ * 无端口形态判定 + 取 DSH cordis ctx（进程内 boot 的 runProfile ctx，挂在 g.web.ctx）。
+ * ctx 的 on/emit 是 cordis 事件 API（与官方 remoteEventSource 同一订阅面）。
+ */
+export function inprocDshCtx() {
+  try {
+    const g = getSingleton();
+    const ctx = g?.web?.ctx;
+    return ctx && typeof ctx.on === "function" && typeof ctx.emit === "function" ? ctx : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 进程内订阅 DSH emit 事件（ctx.on 直订，帧格式与总线 events 兼容）。
+ * @param {(frame: {type:"emit", event:string, args:any[]}) => void} cb
+ * @returns 退订函数；ctx 未就绪（端口形态 / boot 未完成）返回 null——调用方回退总线 events。
+ */
+export function subscribeDshCtxEmitEvents(cb) {
+  const ctx = inprocDshCtx();
+  if (!ctx) return null;
+  const disposers = [];
+  for (const event of CTX_EMIT_EVENTS) {
+    try {
+      const off = ctx.on(event, (...args) => {
+        try {
+          cb({ type: "emit", event, args });
+        } catch {
+          /* 消费者异常不阻断事件分发 */
+        }
+      });
+      if (typeof off === "function") disposers.push(off);
+    } catch {
+      /* 单事件订阅失败（事件不存在/未注册）跳过——白名单保守覆盖 */
+    }
+  }
+  return () => {
+    for (const off of disposers) {
+      try {
+        off();
+      } catch {
+        /* 退订失败忽略 */
+      }
+    }
+    disposers.length = 0;
+  };
+}

--- a/src/lib/dsh-events.js
+++ b/src/lib/dsh-events.js
@@ -81,6 +81,10 @@ export function subscribeDshCtxEmitEvents(cb) {
       /* 单事件订阅失败（事件不存在/未注册）跳过——白名单保守覆盖 */
     }
   }
+  // 全白名单 ctx.on 都失败（disposers 为空）时返回 null（CodeRabbit #8）：否则调用方
+  // 拿到一个 truthy 空退订函数会误判「ctx 订阅成功」→ openMux 等地跳过总线兜底，结果
+  // 收不到任何事件帧挂起。null 语义 = ctx 订阅不可用，调用方回退总线 events。
+  if (disposers.length === 0) return null;
   return () => {
     for (const off of disposers) {
       try {

--- a/src/lib/dsh-events.js
+++ b/src/lib/dsh-events.js
@@ -62,6 +62,11 @@ export function inprocDshCtx() {
  * 进程内订阅 DSH emit 事件（ctx.on 直订，帧格式与总线 events 兼容）。
  * @param {(frame: {type:"emit", event:string, args:any[]}) => void} cb
  * @returns 退订函数；ctx 未就绪（端口形态 / boot 未完成）返回 null——调用方回退总线 events。
+ *
+ * 注意返回值契约（CodeRabbit 第二轮 #4）：truthy 退订函数只代表「ctx.on 订阅注册成功
+ *（白名单 ≥1 事件挂上）」——不等于「DSH producer 可用」（事件真正从 ctx 广播要到 host
+ * boot 收敛才保证）。调用方不得仅凭 truthy 判定事件源就绪；producer 可用性不足时仍应
+ * 保留总线 events 兜底（见 protocol.js openMux / routes/webui.js 的双订模式）。
  */
 export function subscribeDshCtxEmitEvents(cb) {
   const ctx = inprocDshCtx();

--- a/src/lib/lifecycle.js
+++ b/src/lib/lifecycle.js
@@ -544,23 +544,31 @@ async function loadInprocDsh(pkgDir) {
 }
 
 // ---- T7b 进程内 boot：进程级 env 管理 ----
-// 进程内形态 dsh 与宿主同进程：boot 前把 DSH_HOME / DSHANA_BUS_SECRET 写入
-// process.env（dsh 侧 loadProfile / resolveDshHome / bridge 凭据读同一 env，
-// 与 spawn 注入子进程 env 语义等价），dispose 后恢复原值（不留污染）。
-let inprocEnv = null; // { DSH_HOME?, DSHANA_BUS_SECRET? } 原值快照（undefined = 未设置）
-function setInprocEnv(dshHome, busSecret) {
+// 进程内形态 dsh 与宿主同进程：boot 前把 DSH_HOME（官方契约，dsh 运行时
+// resolveDshHome/loadProfile 读）/ DSHANA_ROOT（DSH 包与依赖根 = 插件根，
+// loadDeps 基座与版本/资源路径）/ DSHANA_HOME（数据家目录 = 宿主 dataDir，
+// settings 的 update-status/dataDir 消费）/ DSHANA_BUS_SECRET 写入 process.env
+//（与 spawn 注入子进程 env 语义等价），dispose 后恢复原值（不留污染）。
+// 总线 config 下发退役后，DSH 侧 dshanaBus.getConfig() 的兑底即读这三个 env
+//（同进程直给，不再依赖总线握手）。
+let inprocEnv = null; // { DSH_HOME?, DSHANA_ROOT?, DSHANA_HOME?, DSHANA_BUS_SECRET? } 原值快照
+function setInprocEnv(dshHome, dataDir, dshPkgDir, busSecret) {
   inprocEnv = {
     DSH_HOME: process.env.DSH_HOME,
+    DSHANA_ROOT: process.env.DSHANA_ROOT,
+    DSHANA_HOME: process.env.DSHANA_HOME,
     DSHANA_BUS_SECRET: process.env.DSHANA_BUS_SECRET,
   };
   process.env.DSH_HOME = dshHome;
+  process.env.DSHANA_ROOT = dshPkgDir;
+  process.env.DSHANA_HOME = dataDir;
   process.env.DSHANA_BUS_SECRET = busSecret;
 }
 function restoreInprocEnv() {
   if (!inprocEnv) return;
   const prev = inprocEnv;
   inprocEnv = null;
-  for (const k of ["DSH_HOME", "DSHANA_BUS_SECRET"]) {
+  for (const k of ["DSH_HOME", "DSHANA_ROOT", "DSHANA_HOME", "DSHANA_BUS_SECRET"]) {
     if (prev[k] === undefined) delete process.env[k];
     else process.env[k] = prev[k];
   }
@@ -706,10 +714,14 @@ async function bootInproc(cfg, { pkgDir, dshHome, port, logPath }) {
     disposed: false,
     bootError: null,
   };
-  // 进程内形态：dsh 与宿主同进程——boot 前把 DSH_HOME / DSHANA_BUS_SECRET 写入
-  // process.env（dsh 侧 loadProfile / resolveDshHome / bridge 凭据读同一 env，
-  // 与 spawn 注入子进程 env 语义等价），dispose 后恢复（见 closeProcess / restoreInprocEnv）。
-  setInprocEnv(dshHome, g.busSecret);
+  // 进程内形态：dsh 与宿主同进程——boot 前把 DSH_HOME / DSHANA_ROOT /
+  // DSHANA_HOME / DSHANA_BUS_SECRET 写入 process.env（dsh 侧 loadProfile /
+  // resolveDshHome / settings-provider 的 config 兑底（dshanaBus.getConfig 无总线
+  // 时读 env）/ bridge 凭据读同一 env，与 spawn 注入子进程 env 语义等价），dispose
+  // 后恢复（见 closeProcess / restoreInprocEnv）。DSHANA_ROOT = DSH 包与依赖根
+  //（插件根，loadDeps 基座），DSHANA_HOME = 宿主 dataDir——同进程直给，不再依赖
+  // 总线 config 下发（总线已退役）。
+  setInprocEnv(dshHome, cfg.dataDir, cfg.dshPkgDir || pkgDir, g.busSecret);
   const readyPromise = (async () => {
     try {
       const { profileBoot, bootEntry, appBoot, appBootEntry } = await loadInprocDsh(pkgDir);

--- a/src/lib/lifecycle.js
+++ b/src/lib/lifecycle.js
@@ -66,7 +66,7 @@ import {
 // 种子模板为独立文件 src-cordis/seed（构建期复制 dist/cordis/seed）；设计
 // specs/current/dshana-profile-bundle/spec.md）：
 import { ensureProfileSeeded } from "./profile-seed.js";
-import { connectBus, closeBus, setBusConfigProvider } from "./bus.js";
+import { closeBus } from "./bus.js";
 
 const STDERR_CAP = 8192;
 const PORT_READY_TIMEOUT_MS = 60000; // web host 端口就绪等待上限
@@ -799,30 +799,14 @@ async function waitWebReady(web, port, emitLog, cfg) {
         web.ready = true;
         // 新进程就绪：清掉上次退出记录（持久字段只反映最近一次退出）
         g.webLastExit = null;
-        // dshana.bus 消息总线：同一就绪点连接（bridge 段随 patch 挂载，子插件注册了
-        // /api/dshana.bus upgrade 路由）。connectBus 幂等 + 内部退避重连（连接失败不阻断
-        // dsh 启动——更新请求信道降级：settings 报「消息总线未连接」，check-version 走 dsh 侧
-        // 直查不受影响）。不 await，页面/任务不阻塞。
-        try {
-          connectBus({ webPort: port });
-          // bus.ready 补推接线（幂等，只挂一次）：总线连接成功后如有待补推 routes
-          // 立即补推（connectBus 是异步建连，pushProviderRoutes 在握手前调用必然
-          // 未送达记 pending——补推监听必须与 connectBus 同一就绪点挂上，否则工具
-          // 路径（ensureWebHost）不经过 startWebHostFromPlugin 时待补推永不到达）。
-          wireProviderPushOnBusReady();
-          // config 下发 provider（替代 patch config 注入）：hello-ok 后自动发 config 帧
-          // （dshPkgDir/dataDir），settings/provider 子插件经 dshanaBus.getConfig() 取路径。
-          // 每次握手重发，覆盖 web host 重启后新 bridge 实例。
-          setBusConfigProvider(() => ({
-            dshPkgDir: cfg.dshPkgDir || resolveDshPkgDir(cfg),
-            dataDir: cfg.dataDir,
-          }));
-        } catch (e) {
-          g.appendLog?.("hana", "[dshana.bus] 连接失败：" + (e?.message || e));
-        }
-        // provider 路由推送走总线（替代 /api/hana-provider.refresh HTTP push，任务 G）：
-        // 唯一新进程就绪点主动推一次最新 routes（任意 spawn 路径都保证有初始 push）；
-        // bus 未连接（hello-ok 未到）时记待补推，bus.ready 后自动补推——覆盖连接窗口期。
+        // 总线退役（refactor/bus-inproc 修正 B，2026-09-06）：宿主不再连 dshana.bus WS——
+        // 指令走 HTTP RPC（callUnary 直连 /api）、事件走 cordis ctx 直订。provider 路由
+        // push 与 config 下发随之 ctx 化（provider-refresh-request ctx 订阅 + ctx.emit
+        // provider-push，见 pushProviderRoutes / wireProviderPushCtx）。connectBus /
+        // setBusConfigProvider 已停调（closeBus 在 closeProcess 防御保留，未连时 no-op）。
+        // provider 路由推送：唯一新进程就绪点主动推一次最新 routes（ctx.emit 广播，
+        // provider 插件 ctx.on 收——纯数据注册无 HTTP 上下文依赖，实测方向可靠）。
+        wireProviderPushCtx();
         pushProviderRoutes();
         return web;
       };
@@ -864,8 +848,12 @@ const PROVIDER_SYNC_DEBOUNCE_MS = 300;
 let providerPushPending = false; // bus 未连接期间待补推标志（模块级单例）
 function pushProviderRoutes() {
   const g = getSingleton();
-  const bus = g.dshanaBus;
-  if (!bus || typeof bus.emit !== "function") {
+  // 总线退役（refactor/bus-inproc 修正 B）：provider push 改 cordis ctx 事件广播
+  // （DSH 侧 provider 插件 ctx.on('dshana/provider-push') 收；cordis 事件全向——
+  // 任意 ctx emit 触发任意 ctx on，实测可靠）。ctx 不可用（boot 未完成/异常）记
+  // providerPushPending，wireProviderPushCtx 的 request 订阅补推时清除。
+  const ctx = g?.web?.ctx;
+  if (!ctx || typeof ctx.emit !== "function") {
     providerPushPending = true;
     return;
   }
@@ -881,46 +869,45 @@ function pushProviderRoutes() {
     }
     return;
   }
-  const delivered = bus.emit("provider.refresh", { routes: host.routes });
-  if (delivered) {
+  try {
+    ctx.emit("dshana/provider-push", { routes: host.routes });
     providerPushPending = false;
     try {
-      g.appendLog?.("hana", "[dsh-run] provider 路由已经总线推送（" + host.routes.length + " 条 routes）");
+      g.appendLog?.("hana", "[dsh-run] provider 路由已 ctx 推送（" + host.routes.length + " 条 routes）");
     } catch {
       /* 日志失败不阻断 */
     }
-    console.log("[dsh-run] provider 路由已经总线推送（" + host.routes.length + " 条 routes）");
-  } else {
-    // 未送达（bus 未连接/未握手）：记待补推，bus.ready 后自动补推
+  } catch (e) {
     providerPushPending = true;
     try {
-      g.appendLog?.("hana", "[dsh-run] provider 路由总线推送未送达（bus 未连接），标记待补推");
+      g.appendLog?.("hana", "[dsh-run] provider 路由 ctx 推送失败：" + (e?.message || e));
     } catch {
       /* 日志失败不阻断 */
     }
   }
 }
 // bus.ready 补推接线（幂等，只挂一次）：总线连接成功后如有待补推 routes 立即补推。
-// 另订阅 dsh 侧 provider 插件的 provider.refresh.request 就绪握手（CodeRabbit 时序意见）：
-// 子插件订阅建立后显式请求重放最新 routes——覆盖「宿主首批 push 早于子插件订阅建立」
-// 的窗口（loadDeps/effect 未完成时首批 provider.refresh 事件丢失，provider 卡
-// empty-snapshot）。收到请求即重推（pushProviderRoutes 内部未送达记 pending，
-// bus.ready 后自动补推，无需在此重复判 pending）。
+// provider.refresh.request 的 ctx 订阅（幂等，只挂一次）：DSH 侧 provider 插件订阅建立后
+// 显式请求重放最新 routes（覆盖「宿主首批 push 早于子插件订阅」窗口）。总线退役后
+// request 经 ctx 事件（provider 插件 ctx.emit('dshana/provider-refresh-request')），宿主
+// ctx.on 收 → 重推（ctx 不可用（boot 边缘）记 providerPushPending，ctx 就绪后首推清除）。
 let providerPushWired = false;
-function wireProviderPushOnBusReady() {
+function wireProviderPushCtx() {
   if (providerPushWired) return;
-  providerPushWired = true;
   const g = getSingleton();
-  if (g.dshanaBus && typeof g.dshanaBus.on === "function") {
-    g.dshanaBus.on("provider.refresh.request", () => {
+  const ctx = g?.web?.ctx;
+  if (!ctx || typeof ctx.on !== "function") return;
+  providerPushWired = true;
+  try {
+    ctx.on("dshana/provider-refresh-request", () => {
       pushProviderRoutes();
     });
-    g.dshanaBus.on("bus.ready", () => {
-      if (providerPushPending) {
-        providerPushPending = false;
-        pushProviderRoutes();
-      }
-    });
+  } catch (e) {
+    try {
+      g.appendLog?.("hana", "[dsh-run] provider-refresh-request ctx 订阅失败：" + (e?.message || e));
+    } catch {
+      /* 日志失败不阻断 */
+    }
   }
 }
 function ensureProviderPushWatch(cfg) {
@@ -1068,8 +1055,8 @@ getSingleton().startWebHost = async function startWebHostFromPlugin(
     await ensureWebHost(cfg);
     // web host 就绪后建立宿主侧 provider 跟随 push watch（幂等：先清理旧 watch 再建）
     ensureProviderPushWatch(cfg);
-    // bus.ready 补推接线（幂等）：总线连接成功后如有待补推 routes 立即补推
-    wireProviderPushOnBusReady();
+    // provider-refresh-request ctx 订阅（幂等）：provider 插件订阅建立后请求重放 routes
+    wireProviderPushCtx();
     // 首批 provider 的初始 push 已收敛进 ensureWebHost（唯一就绪点，bus 就绪后自动
     // 送达或待补推），此处不再重复推；后续每次 resource.changed 经防抖 watch 增量 push。
     // DSH 更新请求 v0.22.1 起由子插件经 dshana.bus 消息总线直投（connectBus 已

--- a/src/lib/lifecycle.js
+++ b/src/lib/lifecycle.js
@@ -654,7 +654,10 @@ export async function ensureWebHost(cfg) {
   // 写 process.env.DSHANA_BUS_SECRET（同进程共享，bridge 读）；重启即换新 secret。
   g.busSecret = randomUUID();
   mkdirSync(cfg.dataDir, { recursive: true });
-  const port = Number(cfg.webPort) || 3080;
+  // 随机端口（listen 0 语义，2026-09-06 refactor/random-port）：webPort 配置项已删，
+  // DSH 以 port 0 boot（系统分配空闲端口），boot 后从 webServer service 读回实际监听端口
+  // （resolveActualPort）写 g.web.port——总线/探测/iframe 全链跟随实际端口。
+  const port = 0;
   // 当前会话日志 = 时间戳会话文件（index.js onload 已初始化单例 g.logPath）。
   // 单例优先；index.js 未初始化（冷启动边缘）时兜底自建。写进 web/logLastExit/错误消息供诊断。
   const logPath = g.logPath || newWebLogPath(cfg.dataDir);
@@ -665,6 +668,24 @@ export async function ensureWebHost(cfg) {
   return bootInproc(cfg, { pkgDir, dshHome, port, logPath });
 }
 // ---- T7b：进程内 boot dsh（动态 import + runProfile，webserver 保留在进程内 bind）----
+/** 读回 webServer service 的实际监听端口（listen 0 语义：系统分配后从此取真实端口）。
+ * 官方 service.port getter = 实际监听端口；防御性 fallback 探 _server.address()。
+ * 读不到返回 0（保持 port 0 → waitWebReady 探测超时显式失败，属异常路径）。 */
+function resolveActualPort(web) {
+  try {
+    const ctx = web && web.ctx;
+    if (!ctx) return 0;
+    const svc = typeof ctx.get === "function" ? ctx.get("webServer") : ctx.webServer;
+    if (!svc) return 0;
+    if (typeof svc.port === "number" && svc.port > 0) return svc.port;
+    const srv = svc._server || (svc.server && svc.server._server);
+    if (srv && typeof srv.address === "function") {
+      const a = srv.address();
+      if (a && typeof a === "object" && a.port) return a.port;
+    }
+  } catch { /* 读端口失败走 0 */ }
+  return 0;
+}
 async function bootInproc(cfg, { pkgDir, dshHome, port, logPath }) {
   const g = getSingleton();
   const emitLog = (src, d) => {
@@ -704,12 +725,20 @@ async function bootInproc(cfg, { pkgDir, dshHome, port, logPath }) {
       });
       web.ctx = r.ctx;
       web.shutdown = r.shutdown;
-      emitLog("hana", `[dsh web] 进程内 boot 完成（ctx=${!!r.ctx} shutdown=${typeof r?.shutdown}，webserver ${port} 存活）`);
+      // port 0（listen 0 语义）：系统分配随机端口，boot 后从官方 webServer service 读回
+      // 实际监听端口（官方 service.port getter = 实际监听端口）。读回失败（服务未暴露）
+      // 保持 0——waitWebReady 探测会超时并给出带 stderr 的诊断，属异常路径显式失败。
+      const actual = resolveActualPort(web);
+      if (actual > 0 && actual !== port) {
+        web.port = actual;
+        emitLog("hana", `[dsh web] 随机端口已分配：${actual}`);
+      }
+      emitLog("hana", `[dsh web] 进程内 boot 完成（ctx=${!!r.ctx} shutdown=${typeof r?.shutdown}，webserver ${web.port} 存活）`);
       // 就绪探测必须与 boot 同 try：就绪失败（超时/握手失败）时 web.ctx 仍持有
       // 进程内 cordis 树 + 占用端口——不回收则 g.web 被 ensureWebHost 清掉后引用
       // 丢失，重试必 EADDRINUSE 直到重启 Hana（CodeRabbit Major：spawn 路径可杀子进程
       // 自愈，进程内路径必须显式 dispose）。
-      return await waitWebReady(web, port, emitLog, cfg);
+      return await waitWebReady(web, web.port, emitLog, cfg);
     } catch (e) {
       web.bootError = e;
       web.stderr = String(e?.stack || e?.message || e).slice(0, STDERR_CAP);

--- a/src/lib/lifecycle.js
+++ b/src/lib/lifecycle.js
@@ -674,6 +674,11 @@ export async function ensureWebHost(cfg) {
   // 目录 → dist/cordis），否则 dsh loadProfile 会抛「profile
   // does not exist」。
   await ensureDshanaProfile(cfg);
+  // g.web 被替换/重建（含 closeProcess 回收后重拉，CodeRabbit #6）：换新实例前重置
+  // providerPushWired——旧 ctx 的 provider-refresh-request 订阅已随旧 ctx dispose 失效，
+  // 若不移除 true 标志，新 ctx 就绪点不会再接线（markReady 里 wire 被短路），新 ctx 的
+  // ctx.on 订阅丢失 → provider 路由补推/home 就绪首推接收不到。此处清位让新实例重接。
+  providerPushWired = false;
   return bootInproc(cfg, { pkgDir, dshHome, port, logPath });
 }
 // ---- T7b：进程内 boot dsh（动态 import + runProfile，webserver 保留在进程内 bind）----
@@ -928,12 +933,17 @@ function wireProviderPushCtx() {
   const g = getSingleton();
   const ctx = g?.web?.ctx;
   if (!ctx || typeof ctx.on !== "function") return;
-  providerPushWired = true;
   try {
     ctx.on("dshana/provider-refresh-request", () => {
       pushProviderRoutes();
     });
+    // ctx.on 成功后才置位（CodeRabbit #6）：订阅建立失败时保持 false，下次就绪点可重试
+    //（否则置位后失败永不重接本实例的订阅）。新 web 实例重建时已在上方 ensureWebHost
+    // 清零 providerPushWired，新 ctx 就绪会重新接线。
+    providerPushWired = true;
   } catch (e) {
+    // 订阅失败：不置位（保持可重试），仅记日志
+    providerPushWired = false;
     try {
       g.appendLog?.("hana", "[dsh-run] provider-refresh-request ctx 订阅失败：" + (e?.message || e));
     } catch {

--- a/src/lib/lifecycle.js
+++ b/src/lib/lifecycle.js
@@ -643,7 +643,13 @@ export async function ensureWebHost(cfg) {
     }
   }
   if (g.web?.ctx) {
-    // 旧实例启动失败过：清掉重建（进程内形态 dispose）
+    // 旧实例启动失败过：清掉重建（进程内形态 dispose）——旧实例若已挂 ACP client
+    //（mountAcp 在 waitWebReady 前完成，之后失败属此路径）先 close 释放连接/清缓冲。
+    try {
+      if (g.web.acp && typeof g.web.acp.close === "function") g.web.acp.close();
+    } catch {
+      /* ACP client 关闭失败不阻断重建 */
+    }
     try {
       await g.web.ctx?.fiber?.dispose();
     } catch {
@@ -782,6 +788,11 @@ async function bootInproc(cfg, { pkgDir, dshHome, port, logPath }) {
       // 回收：就绪失败或 boot 失败都要 dispose 进程内 cordis 树（释放 HTTP server /
       // 端口），并恢复改写过的进程级 env（DSH_HOME / DSHANA_BUS_SECRET）——否则
       // g.web 摘除后 ctx 引用丢失，端口永久占用。
+      // ACP client 连接先关（web.acp.close 幂等）：mountAcp 在 waitWebReady 前已挂载，
+      // 失败回收路径同样要释放 client 连接/清缓冲，不能只依赖 ctx fiber dispose。
+      try {
+        if (web.acp && typeof web.acp.close === "function") web.acp.close();
+      } catch { /* ACP client 关闭失败不阻断回收 */ }
       try {
         await web.ctx?.fiber?.dispose();
       } catch (e2) {
@@ -1169,6 +1180,16 @@ export async function closeProcess() {
   const web = g.web;
   g.web = null;
   if (web?.ctx) {
+    // ACP client 连接先于 ctx 树 dispose 关闭（CodeRabbit 第二轮 #1）：web.acp.close()
+    // 释放宿主侧 client 连接并清空 toolCache/updateQueue 缓冲（mountAcp 的 close，幂等）。
+    // 必须在 ctx.fiber.dispose 之前——同树插件随 dispose 卸载后 client 连接失去收尾入口。
+    try {
+      if (web.acp && typeof web.acp.close === "function") web.acp.close();
+    } catch (e) {
+      try {
+        g.appendLog?.("hana", "[dsh web] ACP client 关闭异常（不影响回收）：" + ((e && e.message) || e));
+      } catch { /* 日志失败不阻断 */ }
+    }
     // T7b 进程内形态：await ctx.fiber.dispose() 释放 dsh cordis 树（HTTP server +
     // loader + 全部插件）。不用 runProfile 返回的 shutdown 控制器：其 shutdown() 会写
     // process.exitCode、interrupt() 会 process.exit 直接杀宿主进程（createProcessShutdown

--- a/src/lib/lifecycle.js
+++ b/src/lib/lifecycle.js
@@ -67,6 +67,7 @@ import {
 // specs/current/dshana-profile-bundle/spec.md）：
 import { ensureProfileSeeded } from "./profile-seed.js";
 import { closeBus } from "./bus.js";
+import { mountAcp } from "./acp-mount.js";
 
 const STDERR_CAP = 8192;
 const PORT_READY_TIMEOUT_MS = 60000; // web host 端口就绪等待上限
@@ -746,6 +747,24 @@ async function bootInproc(cfg, { pkgDir, dshHome, port, logPath }) {
         emitLog("hana", `[dsh web] 随机端口已分配：${actual}`);
       }
       emitLog("hana", `[dsh web] 进程内 boot 完成（ctx=${!!r.ctx} shutdown=${typeof r?.shutdown}，webserver ${web.port} 存活）`);
+      // ACP 内部通讯通道挂载（feat/acp-channel）：DSH ctx 上挂 dsh-acp 插件（内存双工
+      // stream，零端口零 stdio），宿主侧 client 单例挂 web.acp——指令通道内部化的
+      // 载体（HTTP /api 兑底保留至 L2 迁移完成）。挂载/握手失败不阻断 boot（WebUI
+      // 主链不依赖 ACP），warn 降级。
+      try {
+        const acpApi = await mountAcp(r.ctx, {
+          dshHome,
+          emitLog,
+        });
+        web.acp = acpApi;
+        emitLog("hana", "[dsh web] ACP 内部通道就绪（web.acp）");
+      } catch (e) {
+        web.acp = null;
+        emitLog(
+          "warn",
+          `[dsh web] ACP 挂载失败（降级：指令走 HTTP /api）：${(e && e.message) || e}`,
+        );
+      }
       // 就绪探测必须与 boot 同 try：就绪失败（超时/握手失败）时 web.ctx 仍持有
       // 进程内 cordis 树 + 占用端口——不回收则 g.web 被 ensureWebHost 清掉后引用
       // 丢失，重试必 EADDRINUSE 直到重启 Hana（CodeRabbit Major：spawn 路径可杀子进程

--- a/src/lib/lifecycle.js
+++ b/src/lib/lifecycle.js
@@ -833,6 +833,15 @@ async function waitWebReady(web, port, emitLog, cfg) {
       // provider push 收敛在同一就绪点（connectBus 幂等 + 内部退避重连，失败不阻断）。
       const markReady = () => {
         web.ready = true;
+        // 就绪态广播（CodeRabbit #10）：通知 /webui/events 的当前活动流（readiness 前早已
+        // 打开、处于 pending 的 shell 流）——否则只靠壳页 boot-state 轮询/刷新兑底挂载。
+        // readiness 后打开的新流不受影响（它们开流时已 ready 直推）。g.notifyWebReady 由
+        // routes/webui.js 模块每次加载重挂（同 notifyWebStartFailed 模式）。
+        try {
+          g?.notifyWebReady?.();
+        } catch {
+          /* 广播失败不阻断就绪 */
+        }
         // 新进程就绪：清掉上次退出记录（持久字段只反映最近一次退出）
         g.webLastExit = null;
         // 总线退役（refactor/bus-inproc 修正 B，2026-09-06）：宿主不再连 dshana.bus WS——

--- a/src/lib/protocol.js
+++ b/src/lib/protocol.js
@@ -103,15 +103,27 @@ async function callUnaryBus(method, payload, signal, meta) {
     : payload;
   const payload2 = { args: inner };
   // ACP 内部通道优先（feat/acp-channel，端口只剩 UI 消费）：web.acp.client 就绪时
-  // session.create/prompt 走 ACP（进程内 JSON-RPC，零端口）——session 指令面中与
-  // 任务链直接相关的两个；其余（selectModel/cancel/list）HTTP 兑底（同 DSH 会话，
-  // gateway 层操作与 ACP 建会话兼容）。
-  if (method === "session.create" || method === "session/create") {
-    const acp = acpClient();
-    if (acp) return await acpCreate(acp, method, payload, signal);
-  } else if (method === "session.prompt" || method === "session/prompt") {
-    const acp = acpClient();
-    if (acp) return await acpPrompt(acp, method, payload, signal);
+  // session 指令面全部走 ACP（进程内 JSON-RPC，零端口）：create（new/resume）/
+  // prompt（fire）/ list（run.js resume 查 cwd）/ selectModel（set_config_option）/ cancel
+  //（notification）。HTTP /api 仅剩 respond（审批应答——L4 反向 request 未接前）兑底
+  // 与 WebUI 数据面消费。
+  const acp = acpClient();
+  if (acp) {
+    if (method === "session.create" || method === "session/create") {
+      return await acpCreate(acp, method, payload, signal);
+    }
+    if (method === "session.prompt" || method === "session/prompt") {
+      return await acpPrompt(acp, method, payload, signal);
+    }
+    if (method === "session.list" || method === "session/list") {
+      return await acpList(acp, method, payload, signal);
+    }
+    if (method === "session.selectModel" || method === "session/selectModel") {
+      return await acpSelect(acp, method, payload, signal);
+    }
+    if (method === "session.cancel" || method === "session/cancel") {
+      return await acpCancel(acp, method, payload, signal);
+    }
   }
   return callUnary(base, endpoint, payload2, signal, meta);
 }
@@ -172,6 +184,70 @@ async function acpPrompt(acp, method, payload, signal) {
       } catch { /* 日志失败不阻断 */ }
     },
   );
+  return { accepted: true };
+}
+
+// ACP session.list：ACP list 无 projections——返回全量轻量会话
+//（sessions: [{ sessionId, cwd }]）。映射宿主 items 结构（run.js resume 分支消费
+// item.sessionId/cwd——同字段直通）。
+async function acpList(acp, method, payload, signal) {
+  const client = acp.client;
+  const methods = acp.methods;
+  const res = await client.request(methods.agent.session.list, {}, { signal });
+  const sessions =
+    res && Array.isArray(res.sessions) ? res.sessions : [];
+  return { items: sessions };
+}
+
+// ACP session.selectModel：set_config_option({ configId: "model", value })——ACP 的
+// model option value = JSON.stringify([provider, model])（model-control.ts 的
+// modelValue 编码，无需预枚举）。reasoningEffort 附加 set reasoning_effort（effort id
+// 字符串；模型不支持时失败静默——对齐原 HTTP 的 model-unavailable 降级重试语义，
+// ACP 层内直接降级）。model 真失败（provider/model 不在目录）抛错。
+async function acpSelect(acp, method, payload, signal) {
+  const client = acp.client;
+  const methods = acp.methods;
+  const sid = payload && payload.sessionId;
+  if (!sid) throw new Error("dsh session.selectModel 缺 sessionId");
+  const provider = payload && payload.provider;
+  const model = payload && payload.model;
+  if (!provider || !model)
+    throw new Error("dsh session.selectModel 缺 provider/model");
+  await client.request(
+    methods.agent.session.setConfigOption,
+    { sessionId: sid, configId: "model", value: JSON.stringify([provider, model]) },
+    { signal },
+  );
+  const effort = payload && payload.reasoningEffort;
+  if (effort) {
+    try {
+      await client.request(
+        methods.agent.session.setConfigOption,
+        { sessionId: sid, configId: "reasoning_effort", value: String(effort) },
+        { signal },
+      );
+    } catch (e) {
+      // effort 不被该模型接受：已选模型生效，effort 用模型默认（对齐 HTTP 降级）
+      try {
+        getSingleton()?.appendLog?.(
+          "hana",
+          "[dsh-rpc] ACP reasoning_effort 降级（模型默认）：" +
+            ((e && e.message) || e),
+        );
+      } catch { /* 日志失败不阻断 */ }
+    }
+  }
+  return { ok: true };
+}
+
+// ACP session.cancel：notification（无响应）——投递后即返回（取消请求已送达 DSH）；
+// notify 同步抛错（连接断/序列化失败）时转普通错误（HTTP 兑底由调用方/上层处理）。
+async function acpCancel(acp, method, payload, signal) {
+  const client = acp.client;
+  const methods = acp.methods;
+  const sid = payload && payload.sessionId;
+  if (!sid) throw new Error("dsh session.cancel 缺 sessionId");
+  client.notify(methods.agent.session.cancel, { sessionId: sid });
   return { accepted: true };
 }
 

--- a/src/lib/protocol.js
+++ b/src/lib/protocol.js
@@ -16,8 +16,10 @@
 // （client-response 信封直发 /api/respond，低频面暂留 HTTP）；selectModel/cancel/list
 // 同留 HTTP（同 DSH 会话 gateway 层操作与 ACP 兼容）。
 //
-// 事件流 openMux：进程内 boot 下宿主与 DSH 同 ctx，ctx.on 直订优先（订阅成功即就绪）；
-// ctx 不可用（boot 边缘）回退总线 events（WS 总线退役前兑底保留）。
+// 事件流 openMux：进程内 boot 下宿主与 DSH 同 ctx，ctx.on 直订优先（订阅注册成功 ≠
+// producer 就绪——就绪 = host boot 收敛 g.web.ready 或总线 ready 帧/ctx 首帧，见 openMux
+// 内 ready 判定，CodeRabbit 第二轮 #4）；ctx 不可用（boot 边缘）回退总线 events（WS 总线
+// 退役前兑底保留）；ctx 订阅存在时同样保留总线兜底至 producer 可用确认。
 //
 // textFromChunk / textFromMessageBlocks 是事件帧文本提取面（assistant/chunk、
 // assistant/message 载荷）。消费方：tools/dsh-run.js submitTask + tools/dsh-approve.js
@@ -336,7 +338,8 @@ async function* openMux(base, signal) {
   const g = getSingleton();
   const queue = [];
   const waiters = [];
-  let off = null;
+  let off = null; // ctx 直订退订（off 为空时 = 总线单订退订）
+  let busOff = null; // ctx 订阅存在时的总线 events 兜底退订（producer 可用前保留）
   let ready = false;
   let aborted = false; // abort 已触发标志：唤醒 waiters 后供循环检查（防 abort 后新建 waiter 挂死）
   const onFrame = (payload) => {
@@ -350,7 +353,19 @@ async function* openMux(base, signal) {
   };
   off = subscribeDshCtxEmitEvents(onFrame);
   if (off) {
-    ready = true; // ctx 直订：订阅成功即就绪（无 bridge ready 帧等待）
+    // 订阅注册成功 ≠ producer 可用（CodeRabbit 第二轮 #4）：truthy disposer 只代表 ctx.on
+    // 白名单已挂上，DSH producer（事件真正从 ctx 广播）要到 host boot 收敛（g.web.ready，
+    // 进程内同 ctx 的会话/设置等 producer 随 boot 挂载完成）才保证存在。注册成功后同时
+    // 挂总线 events 兜底（双订不重复：进程内形态总线已退役——connectBus 停调、总线不发
+    // 帧；旧形态宿主无 ctx、走下方 else 单订总线——两源不会同时活）——producer 可用确认
+    // 前/ctx 源失效期间，总线帧（若存在）仍可达。
+    const bus = g?.dshanaBus;
+    if (bus && typeof bus.on === "function") {
+      busOff = bus.on("events", onFrame);
+    }
+    // ready 信号 = host 已就绪（producer 挂载完成）或总线 ready 帧（onFrame）；ctx 首帧
+    // 到达时下方 ready-wait 经 queue 突破，等价证明 ctx producer 可用。
+    ready = !!(g && g.web && g.web.ready === true);
   } else {
     // ctx 不可用（boot 未完成边缘/异常形态）：回退总线 events（bridge 转发）
     const bus = g?.dshanaBus;
@@ -361,7 +376,8 @@ async function* openMux(base, signal) {
   }
   if (signal?.aborted) {
     aborted = true;
-    off();
+    if (typeof off === "function") off();
+    if (typeof busOff === "function") busOff();
     throw Object.assign(new Error("dsh_run 已取消"), { code: "DSH_ABORTED" });
   }
   const onAbort = () => {
@@ -370,7 +386,8 @@ async function* openMux(base, signal) {
   };
   signal?.addEventListener("abort", onAbort, { once: true });
   try {
-    // 就绪等待（总线模式等 bridge 就绪帧；ctx 直订 ready 恒 true 直接跳过）
+    // 就绪等待（总线模式等 bridge 就绪帧；ctx 直订在 host 已就绪时 ready=true 直接
+    // 跳过；boot 未收敛窗口内等队列/超时突破——见上方 ready 判定）
     const readyDeadline = Date.now() + 5000;
     while (!ready) {
       if (queue.length) break;
@@ -394,6 +411,7 @@ async function* openMux(base, signal) {
   } finally {
     signal?.removeEventListener("abort", onAbort);
     if (typeof off === "function") off();
+    if (typeof busOff === "function") busOff();
   }
 }
 

--- a/src/lib/protocol.js
+++ b/src/lib/protocol.js
@@ -240,14 +240,21 @@ async function acpSelect(acp, method, payload, signal) {
   return { ok: true };
 }
 
-// ACP session.cancel：notification（无响应）——投递后即返回（取消请求已送达 DSH）；
-// notify 同步抛错（连接断/序列化失败）时转普通错误（HTTP 兑底由调用方/上层处理）。
+// ACP session.cancel：notification（无响应）——发送到传输后即返回（取消请求已送达 DSH）。
+// CodeRabbit #7 judgement：ACP notify 虽是 fire-and-forget（服务端不回 ack），但 SDK 的
+// notify 返回 promise，其 settle = JSON-RPC notify 帧**写入传输完成**（内存双工 stream 写
+// 失败立即 reject；不依赖服务端响应 → 不会挂起）。因此值得 await：写入/序列化失败时错误
+// 沿 callUnaryBus 的既有错误路径抛出（调用方多为 best-effort 已 catch 忽略——index.js/
+// run.js 兜底捕获——不再静默吞掉「取消未送达」帧错误）。Service sendNotification 语义确认
+//（dist/acp.js AcpContext.notify→sendNotification）。
 async function acpCancel(acp, method, payload, signal) {
   const client = acp.client;
   const methods = acp.methods;
   const sid = payload && payload.sessionId;
   if (!sid) throw new Error("dsh session.cancel 缺 sessionId");
-  client.notify(methods.agent.session.cancel, { sessionId: sid });
+  // await notify：写传输失败（连接断/stream 已 error）→ 此处 reject → callUnaryBus 抛错，
+  // 取消未达不再被误报为 accepted。
+  await client.notify(methods.agent.session.cancel, { sessionId: sid });
   return { accepted: true };
 }
 

--- a/src/lib/protocol.js
+++ b/src/lib/protocol.js
@@ -155,6 +155,47 @@ async function acpCreate(acp, method, payload, signal) {
   try {
     getSingleton()?.appendLog?.("hana", `[dsh-rpc] ACP ${sid ? "resume" : "new"} 会话 ${res.sessionId}`);
   } catch { /* 日志失败不阻断 */ }
+  // effort 默认保持：session 建立后补 set reasoning_effort（ACP 会话 initial selection
+  // 只带 provider/model——settings 的 reasoningEffort 不经 ACP 插件 config 传递，落
+  // model 默认 = Default）。effort = 工具显式传（payload.reasoningEffort）?? boot 读
+  // settings 的默认（g.acpDefaultEffort——acp-mount readDefaultModel）。模型不支持
+  //（effort 枚举不在 efforts 列表）set 抛 AcpModelConfigError——catch 静默降级
+  //（effort 落该模型默认——「有的模型不支持该参数」的兜底）。
+  try {
+    const g0 = getSingleton();
+    const effort =
+      (payload && payload.reasoningEffort) ||
+      (g0 && g0.acpDefaultEffort) ||
+      null;
+    if (effort) {
+      try {
+        await client.request(
+          methods.agent.session.setConfigOption,
+          {
+            sessionId: res.sessionId,
+            configId: "reasoning_effort",
+            value: String(effort),
+          },
+          { signal },
+        );
+        try {
+          getSingleton()?.appendLog?.(
+            "hana",
+            "[dsh-rpc] ACP effort 已设：" + String(effort) +
+              "（session=" + String(res.sessionId).slice(0, 12) + "）",
+          );
+        } catch { /* 日志失败不阻断 */ }
+      } catch (e) {
+        try {
+          getSingleton()?.appendLog?.(
+            "hana",
+            "[dsh-rpc] ACP reasoning_effort 降级（模型默认）：" +
+              ((e && e.message) || e),
+          );
+        } catch { /* 日志失败不阻断 */ }
+      }
+    }
+  } catch { /* effort 读取/设置失败不阻断会话创建 */ }
   return { sessionId: res.sessionId };
 }
 
@@ -218,7 +259,15 @@ async function acpSelect(acp, method, payload, signal) {
     { sessionId: sid, configId: "model", value: JSON.stringify([provider, model]) },
     { signal },
   );
-  const effort = payload && payload.reasoningEffort;
+  // 默认 effort 保持（宿主 set model 会冲掉 DSH settings 的 reasoningEffort——
+  // readDefaultModel 读到存 g.acpDefaultEffort；任务显式传的优先）。模型不支持的
+  // effort（枚举不在 efforts 列表）set 抛 AcpModelConfigError——catch 静默降级
+  //（effort 落该模型默认）——「有的模型不支持该参数」的兜底。
+  const g0 = getSingleton();
+  const effort =
+    (payload && payload.reasoningEffort) ||
+    (g0 && g0.acpDefaultEffort) ||
+    null;
   if (effort) {
     try {
       await client.request(
@@ -226,6 +275,13 @@ async function acpSelect(acp, method, payload, signal) {
         { sessionId: sid, configId: "reasoning_effort", value: String(effort) },
         { signal },
       );
+      try {
+        getSingleton()?.appendLog?.(
+          "hana",
+          "[dsh-rpc] ACP effort 已设：" + String(effort) +
+            "（session=" + String(sid).slice(0, 12) + "）",
+        );
+      } catch { /* 日志失败不阻断 */ }
     } catch (e) {
       // effort 不被该模型接受：已选模型生效，effort 用模型默认（对齐 HTTP 降级）
       try {

--- a/src/lib/protocol.js
+++ b/src/lib/protocol.js
@@ -2,24 +2,26 @@
 // Copyright (c) 2026 Nyasers
 //
 // tools/lib/protocol.js — dsh web /api 网关协议层共用模块（lib 提取）
-// 从 tools/dsh-run.js 剥离的协议/纯函数：总线 RPC 客户端（指令面收敛进 dshana.bus）、
-// HTTP RPC 兜底、事件流（WS mux）、文本提取。dsh-run.js 与 dsh-session.js 静态 import。
+// 从 tools/dsh-run.js 剥离的协议/纯函数：Unary RPC（ACP 优先，HTTP 兑底）、事件流
+// （ctx 直订 + 总线 events 兑底）、文本提取。
 //
-// 归类说明：callUnary / callUnaryBus / nextRpcId / openMux 是 dsh web host /api 网关的
-// 传输协议（Unary RPC + WebSocket 事件流）。v0.23.x 起 Unary RPC 指令面（session.create /
-// prompt / selectModel / cancel + respond 审批应答）经 dshana.bus 总线收发（callUnaryBus，
-// 总线优先、HTTP 兜底）；events.mux 事件流保持直连（流式高吞吐 + 实时审批帧不适合事件
-// 通道，见收敛边界注释）。textFromChunk / textFromMessageBlocks 是同一网关事件帧的
-// 文本提取面（assistant/chunk、assistant/message 的载荷提取）。两者同属"与 dsh web
-// 通信的线上协议"一条线，收敛在一个 protocol.js 里（若拆 format.js 反而让 callUnary
-// 与它消费的事件帧解析分处两文件，语义更散）。
+// 归类说明（feat/acp-channel，2026-09-06）：宿主↔DSH 通讯两条通道——
+//   指令 = ACP 进程内直连（Agent Client Protocol：宿主与 DSH 同进程，boot 时挂
+//   @deepseek-ai/dsh-acp 插件 + 内存双工 Web Streams，宿主侧 client 单例挂 web.acp；
+//   session.create/new/resume 与 prompt 走 ACP——官方 JSON-RPC 面，零端口零 stdio；
+//   ctx 不可用/ACP 未挂载时兑底 HTTP RPC）；
+//   事件 = cordis ctx.on 直订（DSH Host 事件源头，见 dsh-events.js——ACP 只管指令，
+//   事件仍 ctx 直订，与 ACP 插件的 ctx 订阅并存 fan-out）。
+// callUnaryBus 为兼容名（调用方 tools/* 不变）。respond（审批应答）走 respondDirect
+// （client-response 信封直发 /api/respond，低频面暂留 HTTP）；selectModel/cancel/list
+// 同留 HTTP（同 DSH 会话 gateway 层操作与 ACP 兼容）。
 //
-// 消费方：tools/dsh-run.js submitTask（事件循环 / session.create / session.prompt /
-// session.selectModel / session.cancel 全经此层）+ tools/dsh-cancel.js / tools/dsh-approve.js
-// （callUnaryBus）+ tools/dsh-session.js（get 模式 textFromMessageBlocks 提取会话最终结论）。
-// routes/card.js 另有一份独立 openMux 事件流实现，但它不 import 本模块（是独立实现，
-// 见 dsh-run.js 头注释），不在此归并。
-
+// 事件流 openMux：进程内 boot 下宿主与 DSH 同 ctx，ctx.on 直订优先（订阅成功即就绪）；
+// ctx 不可用（boot 边缘）回退总线 events（WS 总线退役前兑底保留）。
+//
+// textFromChunk / textFromMessageBlocks 是事件帧文本提取面（assistant/chunk、
+// assistant/message 载荷）。消费方：tools/dsh-run.js submitTask + tools/dsh-approve.js
+// / dsh-session.js（get 模式）。routes/card.js 另有一份独立 openMux（不 import 本模块）。
 import { getSingleton } from "./state.js";
 import { subscribeDshCtxEmitEvents } from "./dsh-events.js";
 
@@ -30,15 +32,17 @@ function nextRpcId() {
   return `r_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
 }
 
-// HTTP fallback fetch 超时（总线不可用时直连 dsh 的降级路径不能无限挂）：无 caller
-// signal 时用 BUS_RPC_TIMEOUT_MS；有则 AbortSignal.any 合并（任一触发即中止）
+const HTTP_RPC_TIMEOUT_MS = 60000; // HTTP RPC 默认超时（响应丢失兜底，防挂死）
+
+// RPC fetch 超时：无 caller signal 时用 HTTP_RPC_TIMEOUT_MS；有则 AbortSignal.any 合并
 function rpcTimeoutSignal(signal) {
-  const t = AbortSignal.timeout(BUS_RPC_TIMEOUT_MS);
+  const t = AbortSignal.timeout(HTTP_RPC_TIMEOUT_MS);
   return signal ? AbortSignal.any([signal, t]) : t;
 }
 
 async function callUnary(base, method, payload, signal, meta) {
-  const rpcId = nextRpcId();
+  const rpcId =
+    (meta && typeof meta === "object" && meta.rpcId) || nextRpcId();
   // meta.rpcId 回传：rpcId 由宿主生成（client-request 信封），dsh 侧以此写 jsonl
   // user/message 的 data.source.rpcId——生成即有效，提前设置使失败/拒绝路径也能拿到
   //（成功路径同值），供调用方在提交失败时保留 rpcId 关联（sessionId+rpcId 定位轮次）。
@@ -62,129 +66,117 @@ async function callUnary(base, method, payload, signal, meta) {
   return full.result.value;
 }
 
-// ---- 总线 RPC（dshana.bus，Unary RPC 指令面收敛）----
-// v0.23.x 起 Unary RPC 指令面（session.create / prompt / selectModel / cancel + respond 审批
-// 应答）经 dshana.bus 总线收发：宿主 emit rpc.request（payload = { reqId, method, payload }），
-// dsh 进程内 @dsh-hanako/bridge 翻译器自环调 /api/<method> 后回投 rpc.result（payload =
-// { reqId, ok, value? } 或 { reqId, ok:false, error }），宿主按 reqId 配对等待。
-// 总线优先、HTTP 兜底：总线未连接（emit 返回 false 或 dshanaBus 未就绪）时降级回退
-// callUnary（HTTP），保可用性并 appendLog 记录降级（events.mux 事件流仍直连，不进总线）。
-// 收敛边界：数据面（events.mux 流式 chunk/审批帧/终态）与 /api/host.describe 就绪探测
-// （发生在 connectBus 之前的鸡生蛋）保留 HTTP 直连，见 lifecycle.js 注释。
-const BUS_RPC_TIMEOUT_MS = 60000; // 总线 RPC 默认超时（响应丢失/桥接异常兜底，防 pending 挂死）
-
-// callUnaryBus 的 pending 表（reqId → { resolve, reject, timer, method }）与 rpc.result
-// 订阅（模块级惰性接线一次，宿主侧 bus.js 的 on 是裸 EventEmitter 分发，无 ch: 前缀）
-const rpcPending = new Map();
-let rpcResultWired = false;
-
-function wireRpcResult() {
-  if (rpcResultWired) return;
-  const g = getSingleton();
-  const bus = g?.dshanaBus;
-  if (!bus || typeof bus.on !== "function") return;
-  rpcResultWired = true;
-  bus.on("rpc.result", (payload) => {
-    if (!payload || typeof payload !== "object" || typeof payload.reqId !== "string") return;
-    const entry = rpcPending.get(payload.reqId);
-    if (!entry) return; // 未知 reqId（已超时清理/垃圾帧）：忽略
-    // 清理（clearTimeout/delete/移除 abort 监听）统一在 settle 内做——
-    // 不能在 resolve/reject 前先 delete，否则 settle 的 pending 校验会误判已 settle 而跳过。
-    if (payload.ok) {
-      entry.resolve(payload.value);
-    } else {
-      const e = payload.error || {};
-      entry.reject(
-        new Error("dsh " + entry.method + " 失败：" + (e.code || "unknown") + " " + (e.message || "")),
-      );
-    }
-  });
-}
-
-// 降级路径的 base 来源：web host 单例（调用方通常已 ensureWebHost / hostBase 校验就绪）
+// 指令 base 来源：web host 单例（调用方通常已 ensureWebHost / hostBase 校验就绪）
 function rpcBusBase(g) {
   const web = g?.web;
   if (web?.ready && web.port) return "http://127.0.0.1:" + web.port;
   throw new Error("DSH web host 未就绪（callUnaryBus 降级路径）");
 }
 
-// 总线 Unary RPC：method/payload 同 callUnary；signal 支持中止（总线路径下
-// AbortError 语义与 fetch 一致）；meta 成功时回传 rpcId（与 callUnary 同）。
+// Unary RPC 指令面统一入口（feat/acp-channel：ACP 优先，HTTP 信封兑底）——
+// session.create（新建/resume）与 prompt 走 ACP 内部通道（web.acp.client）；其余方法
+// 走 HTTP /api（信封翻译：点号 → 斜杠 endpoint + session/* 的 args 信封
+// request/_request 包装 + requestId 注入——直连缺这层会 404 与 gateway 校验失败）。
 async function callUnaryBus(method, payload, signal, meta) {
+  const base = rpcBusBase(getSingleton());
+  if (method === "respond") {
+    return respondDirect(base, payload, signal);
+  }
   const reqId = nextRpcId();
-  // meta.rpcId 提前回传（同 callUnary 语义：reqId 宿主生成、dsh 侧写 jsonl
-  // data.source.rpcId）——总线路径成功/失败/超时/中止都保留 rpcId 关联；降级路径由
-  // callUnary 内部的 meta.rpcId 覆盖为实际 HTTP rpcId。
   if (meta && typeof meta === "object") meta.rpcId = reqId;
-  const g = getSingleton();
-  const bus = g?.dshanaBus;
-  // 总线优先：dshanaBus 就绪且 emit 送达（bus.js sendFrame 排队成功才 true——
-  // 未连接/未握手返回 false）才走总线；否则降级 HTTP 兜底（保可用性）。
-  let queued = false;
-  if (bus && typeof bus.emit === "function") {
-    try {
-      wireRpcResult(); // 先接线再发（响应经 WS 异步到达，接线必先于回投）
-      queued = bus.emit("rpc.request", { reqId, method, payload });
-    } catch {
-      queued = false;
-    }
+  const endpoint = method.includes(".") ? method.replace(/\./g, "/") : method;
+  const isSession =
+    method.startsWith("session.") || method.startsWith("session/");
+  const isSessionList =
+    method === "session.list" || method === "session/list";
+  // gateway 信封（HTTP 兑底路径）：payload 必须恰含一个 plain-object args 字段
+  //（{ args: <Remote payload> }）——session/* 的 Remote payload 按 descriptor 参数名
+  // 包 request/_request（session.list 用 _request）并注入 requestId（jsonl 定位键）；
+  // 非 session 方法裸 payload 透传（respond 已走 respondDirect 分支）。
+  const inner = isSession
+    ? {
+        [isSessionList ? "_request" : "request"]: {
+          ...(payload || {}),
+          requestId: reqId,
+        },
+      }
+    : payload;
+  const payload2 = { args: inner };
+  // ACP 内部通道优先（feat/acp-channel，端口只剩 UI 消费）：web.acp.client 就绪时
+  // session.create/prompt 走 ACP（进程内 JSON-RPC，零端口）——session 指令面中与
+  // 任务链直接相关的两个；其余（selectModel/cancel/list）HTTP 兑底（同 DSH 会话，
+  // gateway 层操作与 ACP 建会话兼容）。
+  if (method === "session.create" || method === "session/create") {
+    const acp = acpClient();
+    if (acp) return await acpCreate(acp, method, payload, signal);
+  } else if (method === "session.prompt" || method === "session/prompt") {
+    const acp = acpClient();
+    if (acp) return await acpPrompt(acp, method, payload, signal);
   }
-  if (!queued) {
-    // 降级路径：总线未连接/未握手 → 回退现 callUnary（HTTP），错误语义与直连一致
-    try {
-      g?.appendLog?.(
-        "hana",
-        "[dshana.bus] rpc.request 未送达（总线未连接），" + method + " 降级走 HTTP",
-      );
-    } catch {
-      /* 日志失败不阻断 */
-    }
-    if (method === "respond") {
-      // respond 是 client-response 信封（rpcId 路由 web host pending 表，payload 已是
-      // { type:"client-response", rpcId, result } 原样信封）——不能用 callUnary 的
-      // client-request 信封（会再包一层，dsh /api/respond 校验失败）。总线不可用时
-      // 直发 HTTP，信封语义与总线路径（bridge 翻译器 respond 特殊处理）一致。
-      return respondDirect(rpcBusBase(g), payload, signal);
-    }
-    return callUnary(rpcBusBase(g), method, payload, signal, meta);
-  }
-  // 总线路径：pending 配对等待 rpc.result（超时/中止清理防泄漏）
-  return new Promise((resolve, reject) => {
-    const settle = (fn, value) => {
-      if (rpcPending.get(reqId) !== entry) return; // 已 settle：忽略迟到事件
-      clearTimeout(entry.timer);
-      rpcPending.delete(reqId);
-      signal?.removeEventListener("abort", onAbort);
-      fn(value);
-    };
-    const onAbort = () => {
-      settle(
-        reject,
-        Object.assign(new Error("已取消"), { name: "AbortError" }),
-      );
-    };
-    const entry = {
-      method,
-      meta,
-      resolve: (value) => settle(resolve, value),
-      reject: (err) => settle(reject, err),
-      timer: null,
-    };
-    entry.timer = setTimeout(() => {
-      settle(
-        reject,
-        new Error("dsh " + method + " 总线 RPC 超时（" + BUS_RPC_TIMEOUT_MS / 1000 + "s）"),
-      );
-    }, BUS_RPC_TIMEOUT_MS);
-    entry.timer.unref?.();
-    rpcPending.set(reqId, entry);
-    if (signal?.aborted) onAbort();
-    else signal?.addEventListener("abort", onAbort, { once: true });
-  });
+  return callUnary(base, endpoint, payload2, signal, meta);
 }
 
-// respond 审批应答直发（client-response 信封原样 POST /api/respond）：总线不可用时的
-// 降级路径。响应 rpcReceipt { accepted, reason? }，调用方校验 j.accepted 语义不变。
+// 取 ACP client 单例（boot 挂载成功才有；挂载失败/未 boot 返回 null → HTTP 兑底）
+function acpClient() {
+  try {
+    const acp = getSingleton()?.web?.acp;
+    return acp && acp.client && typeof acp.client.request === "function" ? acp : null;
+  } catch {
+    return null;
+  }
+}
+
+// ACP session.create（新建/续会话）：newSession/resumeSession。ACP 返回
+// { sessionId, configOptions }——映射回原接口的 { sessionId }（调用方再取字段）。
+// agentPreset 无 ACP 对应字段（忽略——用 DSH 全局默认 preset）。
+async function acpCreate(acp, method, payload, signal) {
+  const client = acp.client;
+  const methods = acp.methods;
+  const sid = payload && payload.sessionId;
+  const params = {
+    ...(payload && payload.cwd ? { cwd: String(payload.cwd) } : {}),
+    mcpServers: [],
+  };
+  const res = sid
+    ? await client.request(methods.agent.session.resume, { sessionId: sid, ...params }, { signal })
+    : await client.request(methods.agent.session.new, params, { signal });
+  try {
+    getSingleton()?.appendLog?.("hana", `[dsh-rpc] ACP ${sid ? "resume" : "new"} 会话 ${res.sessionId}`);
+  } catch { /* 日志失败不阻断 */ }
+  return { sessionId: res.sessionId };
+}
+
+// ACP session.prompt：ACP 协议是请求-响应（服务端 drain 到 turn 完才回）——宿主提交
+// 语义 = fire-and-forget：发出请求立即返回 { accepted: true }（结果由事件流 openMux
+// 终态判定，run.js 原逻辑复用）；挂起的 request 在 turn 完 resolve，错误吞（事件流
+// 已判终态/超时兜底——admission 失败无事件流时靠 run.js 超时暴露，错误记诊断日志）。
+async function acpPrompt(acp, method, payload, signal) {
+  const client = acp.client;
+  const methods = acp.methods;
+  const content = Array.isArray(payload && payload.content) ? payload.content : [];
+  const params = { sessionId: payload.sessionId, prompt: content };
+  try {
+    getSingleton()?.appendLog?.("hana", `[dsh-rpc] ACP prompt（fire，session=${payload.sessionId}）`);
+  } catch { /* 日志失败不阻断 */ }
+  const pending = client.request(methods.agent.session.prompt, params);
+  pending.then(
+    () => {},
+    (err) => {
+      // 终态错误：正常 turn 完成路径事件流已判终——此处仅诊断；admission 失败
+      //（sessionId 无效/参数错——快 reject）也会落这里，任务由 run.js 超时暴露。
+      try {
+        getSingleton()?.appendLog?.(
+          "hana",
+          "[dsh-rpc] ACP prompt 终态失败：" + ((err && err.message) || err),
+        );
+      } catch { /* 日志失败不阻断 */ }
+    },
+  );
+  return { accepted: true };
+}
+
+// respond 审批应答直发（client-response 信封原样 POST /api/respond）。响应 rpcReceipt
+// { accepted, reason? }，调用方校验 j.accepted 语义不变。
 async function respondDirect(base, payload, signal) {
   const res = await fetch(`${base}/api/respond`, {
     method: "POST",
@@ -196,18 +188,12 @@ async function respondDirect(base, payload, signal) {
   return await res.json();
 }
 
-// ---- 事件流（dsh 0.1.2：宿主不直连 remote.mux，经 dshana.bus 消费）----
-// bridge 在 dsh 进程内订阅 remote.mux + $events（launchToken 在 BrowserAuth，
-// ensureAuthCookie 换发无竞态），经总线 events 频道转发帧：ready（就绪信号）/ emit
-// （api-session/* 广播）/ waterfall（审批等，bridge 已回投 next）。宿主 openMux 纯
-// 总线订阅——无 WS 连接、无 cookie 管理（直连 remote.mux 的 cookie 换发有启动竞态
-// 且宿主侧无 launchToken 源，已废弃）。
+// ---- 事件流（refactor/bus-inproc：ctx.on 直订优先，总线 events 兜底）----
+// DSH Host 事件源头 = cordis ctx（官方 dsh-api-remotes remoteEventSource 即 ctx.on 直订），
+// remote.mux WS / dshana.bus 只是载波。进程内 boot 下宿主 ctx.on 直订同一事件源，
+// 零 WS/总线绕圈；ctx 不可用（boot 边缘）回退总线 events（总线退役前兜底保留）。
 
 async function* openMux(base, signal) {
-  // 事件源：进程内 boot 下宿主与 DSH 同 ctx（g.web.ctx），DSH Host 事件源头 = cordis ctx
-  // （官方 dsh-api-remotes remoteEventSource 即 ctx.on 直订），remote.mux WS / dshana.bus
-  // 只是载波（refactor/bus-inproc：总线内置化第一刀——事件链路 ctx.on 直订优先，免
-  // WS/总线绕圈；ctx 不可用回退总线 events，端口形态零行为差异）。
   const g = getSingleton();
   const queue = [];
   const waiters = [];
@@ -245,8 +231,7 @@ async function* openMux(base, signal) {
   };
   signal?.addEventListener("abort", onAbort, { once: true });
   try {
-    // 等 bridge 事件流就绪（bridge 连 remote.mux 后转发 ready 帧；最多 5s，
-    // 超时不阻塞——帧到达自然流转，bridge 重连期间事件可能晚到）
+    // 就绪等待（总线模式等 bridge 就绪帧；ctx 直订 ready 恒 true 直接跳过）
     const readyDeadline = Date.now() + 5000;
     while (!ready) {
       if (queue.length) break;

--- a/src/lib/protocol.js
+++ b/src/lib/protocol.js
@@ -21,6 +21,7 @@
 // 见 dsh-run.js 头注释），不在此归并。
 
 import { getSingleton } from "./state.js";
+import { subscribeDshCtxEmitEvents } from "./dsh-events.js";
 
 // ---- HTTP RPC 客户端（dsh web /api 网关，fetch 载波）----
 // Unary：POST /api/<method>，body = { type:"client-request", rpcId, method, payload }
@@ -203,13 +204,11 @@ async function respondDirect(base, payload, signal) {
 // 且宿主侧无 launchToken 源，已废弃）。
 
 async function* openMux(base, signal) {
-  // dsh 0.1.2：宿主不直连 remote.mux——bridge 在 dsh 进程内订阅 $events 并经
-  // dshana.bus events 频道转发（ready/emit/waterfall），这里纯总线消费。
+  // 事件源：进程内 boot 下宿主与 DSH 同 ctx（g.web.ctx），DSH Host 事件源头 = cordis ctx
+  // （官方 dsh-api-remotes remoteEventSource 即 ctx.on 直订），remote.mux WS / dshana.bus
+  // 只是载波（refactor/bus-inproc：总线内置化第一刀——事件链路 ctx.on 直订优先，免
+  // WS/总线绕圈；ctx 不可用回退总线 events，端口形态零行为差异）。
   const g = getSingleton();
-  const bus = g?.dshanaBus;
-  if (!bus || typeof bus.on !== "function") {
-    throw new Error("dshana.bus 不可用，无法订阅 DSH 事件流");
-  }
   const queue = [];
   const waiters = [];
   let off = null;
@@ -218,13 +217,23 @@ async function* openMux(base, signal) {
   const onFrame = (payload) => {
     if (!payload || typeof payload.type !== "string") return;
     if (payload.type === "ready") {
-      ready = true; // bridge 事件流就绪信号，不投上层
+      ready = true; // 事件流就绪信号（总线模式 bridge 就绪帧），不投上层
       return;
     }
     if (waiters.length) waiters.shift()(payload);
     else queue.push(payload);
   };
-  off = bus.on("events", onFrame);
+  off = subscribeDshCtxEmitEvents(onFrame);
+  if (off) {
+    ready = true; // ctx 直订：订阅成功即就绪（无 bridge ready 帧等待）
+  } else {
+    // ctx 不可用（boot 未完成边缘/异常形态）：回退总线 events（bridge 转发）
+    const bus = g?.dshanaBus;
+    if (!bus || typeof bus.on !== "function") {
+      throw new Error("dshana.bus 不可用，无法订阅 DSH 事件流");
+    }
+    off = bus.on("events", onFrame);
+  }
   if (signal?.aborted) {
     aborted = true;
     off();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -35,11 +35,6 @@
     "configuration": {
       "title": "DSHana 设置",
       "properties": {
-        "webPort": {
-          "type": "number",
-          "default": 3080,
-          "title": "DSH WebUI 端口"
-        },
         "approvalTimeoutSec": {
           "type": "number",
           "default": 30,

--- a/src/routes/card.js
+++ b/src/routes/card.js
@@ -28,6 +28,7 @@ import cardJs from "../assets/card.js";
 // 卡片页面 HTML 模板（构建期 template-loader 经 doT 编译为自包含渲染函数）
 import { render as cardOpHtml } from "../assets/card-op.jinja2";
 import { render as cardDepHtml } from "../assets/card-dep.jinja2";
+import { subscribeDshCtxEmitEvents } from "../lib/dsh-events.js";
 
 const CARD_ASSETS = { css: cardCss, js: cardJs };
 
@@ -330,8 +331,10 @@ export default function registerCardRoutes(app, ctx) {
   });
 
   // SSE 推送源（卡片主链路）：先推 baseline（jsonl 恢复快照，含全量 output），
-  // 再对每个连接开一条到 DSH events.mux 的 WebSocket（openMux 同款），过滤
-  // frame.sessionId === 本连接 sessionId 的帧，以 event 事件原样转发；连接关闭时关 WS。
+  // 再对每个连接订阅一次 DSH 会话事件（进程内 ctx 直订——ACP 内部通道下会话事件走
+  // session/event 通用广播，DSH WS events.mux 只转 api-session/*（HTTP 网关面），ACP
+  // 会话不在其上——直订同一事件源零 WS/端口绕圈），过滤 sessionId === 本连接会话的帧，
+  // 以 event 事件转译转发；连接关闭时退订。
   app.get("/ops/stream", (c) => {
     const sessionId = String(c.req.query("sessionId") || "");
     const rpcId = String(c.req.query("rpcId") || "");
@@ -341,11 +344,8 @@ export default function registerCardRoutes(app, ctx) {
     const g = globalThis.__dshHanako;
     const baseline = readOp({ sessionId, rpcId, timeoutMs }, true);
     if (!baseline) return c.json({ ok: false, error: "任务记录不存在" }, 404);
-    // web host 端口：单例优先（运行中 dsh web），否则配置兜底
-    const web = g?.web;
-    const port = web?.port || Number(ctx?.config?.webPort) || 3080;
 
-    let ws = null;
+    let offEvents = null; // ctx 进程内订阅退订函数（替代 WS events.mux）
     const stream = new ReadableStream({
       start(controller) {
         const enc = new TextEncoder();
@@ -363,10 +363,13 @@ export default function registerCardRoutes(app, ctx) {
         const closeAll = () => {
           if (closed) return;
           closed = true;
-          try {
-            if (ws) ws.close();
-          } catch {
-            /* 已关 */
+          if (typeof offEvents === "function") {
+            try {
+              offEvents();
+            } catch {
+              /* 已退订 */
+            }
+            offEvents = null;
           }
           try {
             controller.close();
@@ -376,50 +379,47 @@ export default function registerCardRoutes(app, ctx) {
         };
         // a) 基线快照（jsonl 恢复；运行中窗口归一化为 running + 部分输出）
         send("baseline", baseline);
-        // b) 转发 DSH 实时事件：events.mux WebSocket（与 tools/dsh-run.js openMux 同款连接）
+        // b) 转发 DSH 实时事件：进程内 ctx 直订（session/event 通用广播——jsonl 同源，
+        // 含 turn/start、assistant/chunk、assistant/message、turn/end 等；card.js 前端已
+        // 原生消费该帧格式）。emit 帧 {type:"emit",event,args} 的 session/event 参数为
+        // [session, evObj]——转译 {type:"session/event", event: evObj, sessionId: session.id}
+        // 投卡片。
         try {
-          if (typeof WebSocket !== "function")
-            throw new Error("宿主环境无全局 WebSocket，无法订阅 DSH 事件流");
-          ws = new WebSocket(`ws://127.0.0.1:${port}/api/events.mux`);
-          ws.onmessage = (ev) => {
-            let frame = {};
-            let envelope = null;
-            try {
-              envelope = JSON.parse(ev.data);
-              frame = envelope?.payload || envelope || {};
-            } catch {
-              return;
-            }
-            // server-request 信封（approval/requested 等应答类帧）：外层 rpcId 补进 frame
+          offEvents = subscribeDshCtxEmitEvents((frame) => {
             if (
-              envelope &&
-              typeof envelope === "object" &&
-              typeof envelope.rpcId === "string" &&
-              typeof frame.rpcId !== "string"
-            ) {
-              frame.rpcId = envelope.rpcId;
-            }
-            if (!frame || typeof frame.type !== "string") return;
-            if (frame.sessionId && frame.sessionId !== sessionId) return; // 只转发本连接会话的帧
-            send("event", frame);
-          };
-          ws.onerror = () => {
-            /* 错误由 onclose 收尾 */
-          };
-          ws.onclose = () => closeAll();
+              !frame ||
+              frame.type !== "emit" ||
+              frame.event !== "session/event"
+            )
+              return;
+            const args = Array.isArray(frame.args) ? frame.args : [];
+            const [session, evObj] = args;
+            const sid = session && (session.id ?? null);
+            if (!sid || sid !== sessionId) return; // 只转发本连接会话的帧
+            if (!evObj || typeof evObj.type !== "string") return;
+            send("event", {
+              type: "session/event",
+              event: evObj,
+              sessionId: sid,
+            });
+          });
+          if (!offEvents)
+            throw new Error("ctx 未就绪，无法订阅 DSH 会话事件");
         } catch (e) {
-          // WS 建立失败：基线已推送，结束流（卡片侧 EventSource 会自动重连 / 兜底 /ops/status）
+          // ctx 订阅失败（boot 边缘/异常形态）：基线已推送，结束流（卡片侧
+          // EventSource 自动重连 / 兜底 /ops/status jsonl 恢复路径）
           closeAll();
         }
       },
       cancel() {
-        // 卡片断开（EventSource.close / 页面卸载）：关 WS 释放连接
-        if (ws) {
+        // 卡片断开（EventSource.close / 页面卸载）：退订 ctx 事件释放连接
+        if (typeof offEvents === "function") {
           try {
-            ws.close();
+            offEvents();
           } catch {
-            /* 已关 */
+            /* 已退订 */
           }
+          offEvents = null;
         }
       },
     });

--- a/src/routes/card.js
+++ b/src/routes/card.js
@@ -118,8 +118,18 @@ function rebuildOpFromLog(dataDir, sessionId, rpcId) {
     else if (ev.type === "user/message" && ev.data?.source?.kind === "user")
       prompts.push(ev);
   }
-  const idx = prompts.findIndex((u) => u.data?.source?.rpcId === rpcId);
-  if (idx < 0) return null;
+  let idx = prompts.findIndex((u) => u.data?.source?.rpcId === rpcId);
+  if (idx < 0) {
+    // ACP 通道兑底：ACP 会话的 jsonl 里 user/message 无 source.rpcId（ACP 协议无
+    // requestId 概念——rpcId 是 HTTP client-request 信封才注入的宿主侧键）。特征 =
+    // 全部 user prompt 都无 rpcId——此时退化取最后一个 prompt（最近任务，当前任务
+    // 卡片场景即命中）；HTTP 会话（prompt 带 rpcId）匹配失败仍判不存在（原行为）。
+    if (prompts.length && prompts.every((u) => u.data?.source?.rpcId == null)) {
+      idx = prompts.length - 1;
+    } else {
+      return null;
+    }
+  }
   const prompt = prompts[idx];
   const startSeq = prompt.seq;
   const endSeq = idx + 1 < prompts.length ? prompts[idx + 1].seq : Infinity;

--- a/src/routes/webui.js
+++ b/src/routes/webui.js
@@ -368,11 +368,14 @@ export default function registerWebuiRoutes(app, ctx) {
         // （refactor/bus-inproc 修正 B）后宿主不再连 dshana.bus：ready/pending 由下方
         // 初始推（打开时 g.web.ready）+ 壳页 boot-state 刷新兑底驱动；此处订阅仅当
         // 旧形态总线仍存在时挂（兼容残留），不存在即跳过。
-        const g = globalThis.__dshHanako;
         // 打开时已就绪（常态：卡在 boot 完成后打开）→ 立即推 ready，壳页即挂载；
         // 未就绪（自举页场景）不推——壳页靠 boot-state 刷新兑底挂载（applyBoot ready
         // → mountReady，见 webui-shell），事件流仅作 diag-changed/theme-pref 载体。
-        if (busReady()) {
+        // 就绪判定 = web host boot 收敛（g.web.ready，ACP/进程内 boot 形态）或旧形态
+        // 总线已连接（总线退役前兼容残留——退役后恒 false，不影响）。此前仅判
+        // busReady() 导致总线退役后打开壳页收不到 ready 事件（靠轮询兑底慢显示）。
+        const g = globalThis.__dshHanako;
+        if ((g && g.web && g.web.ready === true) || busReady()) {
           send({ type: "ready" });
         }
         // DSH 设置变更转发（theme-pref）：settings/document-updated 的 ui-theme 命名空间

--- a/src/routes/webui.js
+++ b/src/routes/webui.js
@@ -364,8 +364,42 @@ export default function registerWebuiRoutes(app, ctx) {
           if (closed) return;
           send({ type: "diag-changed" });
         };
-        // 订阅总线本机事件（bus.ready / bus.disconnect / events 转发）
+        // 订阅总线本机事件（bus.ready / bus.disconnect / events 转发）——总线退役
+        // （refactor/bus-inproc 修正 B）后宿主不再连 dshana.bus：ready/pending 由下方
+        // 初始推（打开时 g.web.ready）+ 壳页 boot-state 刷新兑底驱动；此处订阅仅当
+        // 旧形态总线仍存在时挂（兼容残留），不存在即跳过。
         const g = globalThis.__dshHanako;
+        // 打开时已就绪（常态：卡在 boot 完成后打开）→ 立即推 ready，壳页即挂载；
+        // 未就绪（自举页场景）不推——壳页靠 boot-state 刷新兑底挂载（applyBoot ready
+        // → mountReady，见 webui-shell），事件流仅作 diag-changed/theme-pref 载体。
+        if (busReady()) {
+          send({ type: "ready" });
+        }
+        // DSH 设置变更转发（theme-pref）：settings/document-updated 的 ui-theme 命名空间
+        // = 主题偏好变更，推给壳页转告注入脚本重读偏好（事件驱动替代 3s 轮询
+        // settings/describe）。事件源：ctx.on 直订优先（DSH Host 事件源头 = cordis ctx）；
+        // ctx 不可用兑底总线 events（旧形态 bridge 转发）。
+        const themeFromFrame = (frame) => {
+          if (closed) return;
+          if (!frame || frame.type !== "emit") return;
+          if (
+            frame.event === "settings/document-updated" &&
+            Array.isArray(frame.args) &&
+            frame.args[0] === "ui-theme"
+          ) {
+            send({
+              type: "theme-pref",
+              ns: "ui-theme",
+              revision: frame.args[1] ?? null,
+            });
+          }
+        };
+        const themeCtxOff = subscribeDshCtxEmitEvents(themeFromFrame);
+        if (themeCtxOff) {
+          unsubs.push(themeCtxOff);
+        } else if (g && g.dshanaBus && typeof g.dshanaBus.on === "function") {
+          unsubs.push(g.dshanaBus.on("events", themeFromFrame));
+        }
         if (g && g.dshanaBus && typeof g.dshanaBus.on === "function") {
           unsubs.push(
             g.dshanaBus.on("bus.ready", () => {
@@ -381,32 +415,6 @@ export default function registerWebuiRoutes(app, ctx) {
               send({ type: "pending" });
             }),
           );
-          // DSH 设置变更转发（theme-pref）：settings/document-updated 的 ui-theme 命名空间
-          // = 主题偏好变更，推给壳页转告注入脚本重读偏好（事件驱动替代 3s 轮询
-          // settings/describe）。事件源：ctx.on 直订优先（refactor/bus-inproc 总线内置化——
-          // DSH Host 事件源头 = cordis ctx，总线只是载波）；ctx 不可用兑底总线 events
-          // （bridge 订阅转发）。
-          const themeFromFrame = (frame) => {
-            if (closed) return;
-            if (!frame || frame.type !== "emit") return;
-            if (
-              frame.event === "settings/document-updated" &&
-              Array.isArray(frame.args) &&
-              frame.args[0] === "ui-theme"
-            ) {
-              send({
-                type: "theme-pref",
-                ns: "ui-theme",
-                revision: frame.args[1] ?? null,
-              });
-            }
-          };
-          const themeCtxOff = subscribeDshCtxEmitEvents(themeFromFrame);
-          if (themeCtxOff) {
-            unsubs.push(themeCtxOff);
-          } else if (g && g.dshanaBus && typeof g.dshanaBus.on === "function") {
-            unsubs.push(g.dshanaBus.on("events", themeFromFrame));
-          }
         }
         // 挂钩 web host 启动失败通知（lifecycle startWebHostFromPlugin catch 调用）。
         // 每次模块加载都重新赋值 notifyWebStartFailed（不设 __webStartFailedHooked 守卫）：

--- a/src/routes/webui.js
+++ b/src/routes/webui.js
@@ -58,6 +58,14 @@ const webStartFailedListeners = new Set();
 // （事件驱动替代面板 5s 周期 tick；安装中进度滚动由壳页 installing 态 tick 承担）。
 const depsChangedListeners = new Set();
 
+// ---- web host 就绪翻转通知订阅者（lifecycle 的 waitWebReady/markReady 调 g.notifyWebReady）----
+// 总线退役后（refactor/bus-inproc）宿主不再连 dshana.bus，/webui/events 在 readiness 前就
+// 打开的常驻流等不到 bus.ready 事件（CodeRabbit #10）。此 Set 接收 g.web.ready→true 翻转，
+// 推 ready 事件给当前活动流；readiness 后打开的新流开流即直推、不依赖本通知。与
+// notifyWebStartFailed/notifyDepsChanged 同模式（同模块每次加载重挂，一次订阅生命周期 =
+// 流存活期，close()/cancel() 移除）。
+const webReadyListeners = new Set();
+
 function esc(v) {
   return String(v)
     .replace(/&/g, "&amp;")
@@ -317,6 +325,7 @@ export default function registerWebuiRoutes(app, ctx) {
     let unsubs = [];
     let onStartFailed = null;
     let onDepsChanged = null;
+    let onWebReady = null;
     const stream = new ReadableStream({
       start(controller) {
         const enc = new TextEncoder();
@@ -344,6 +353,7 @@ export default function registerWebuiRoutes(app, ctx) {
           unsubs.length = 0;
           if (onStartFailed) webStartFailedListeners.delete(onStartFailed);
           if (onDepsChanged) depsChangedListeners.delete(onDepsChanged);
+          if (onWebReady) webReadyListeners.delete(onWebReady);
           try {
             controller.close();
           } catch {
@@ -363,6 +373,14 @@ export default function registerWebuiRoutes(app, ctx) {
         onDepsChanged = () => {
           if (closed) return;
           send({ type: "diag-changed" });
+        };
+        // web host 就绪翻转 → 推 ready 事件（CodeRabbit #10）：总线退役后无 bus.ready 事件，
+        // readiness 前打开的本流收不到 ready → 悬 pending，只靠壳页刷新兑底。markReady
+        // 时 lifecycle 广播 g.notifyWebReady，这里收翻转推 ready（ready 后流的重复 ready 事件
+        // 由壳页 readyReceived 幂等忽略）。
+        onWebReady = () => {
+          if (closed) return;
+          send({ type: "ready" });
         };
         // 订阅总线本机事件（bus.ready / bus.disconnect / events 转发）——总线退役
         // （refactor/bus-inproc 修正 B）后宿主不再连 dshana.bus：ready/pending 由下方
@@ -428,6 +446,7 @@ export default function registerWebuiRoutes(app, ctx) {
         // 幂等无害）。
         webStartFailedListeners.add(onStartFailed);
         depsChangedListeners.add(onDepsChanged);
+        webReadyListeners.add(onWebReady);
         const hookG = globalThis.__dshHanako || (globalThis.__dshHanako = {});
         hookG.notifyWebStartFailed = () => {
           for (const fn of [...webStartFailedListeners]) {
@@ -440,6 +459,17 @@ export default function registerWebuiRoutes(app, ctx) {
         };
         hookG.notifyDepsChanged = () => {
           for (const fn of [...depsChangedListeners]) {
+            try {
+              fn();
+            } catch {
+              /* 通知失败不阻断 */
+            }
+          }
+        };
+        // web host 就绪翻转广播（lifecycle waitWebReady/markReady 在 g.web.ready=true 时调用，
+        // CodeRabbit #10）：通知当前活动流（readiness 前已打开的常驻流）推 ready。
+        hookG.notifyWebReady = () => {
+          for (const fn of [...webReadyListeners]) {
             try {
               fn();
             } catch {

--- a/src/routes/webui.js
+++ b/src/routes/webui.js
@@ -46,6 +46,7 @@
 
 // 插件页 HTML 壳（构建期 template-loader 经 doT 编译为自包含渲染函数，运行时零依赖）
 import { render as webuiShellHtml } from "../assets/webui-shell.jinja2";
+import { subscribeDshCtxEmitEvents } from "../lib/dsh-events.js";
 
 // ---- 就绪事件流订阅者（web host 启动失败通知；lifecycle.js 调 g.notifyWebStartFailed）----
 // 多个壳页 tab 可同时订阅；Set 保存，流关闭时移除。notifyWebStartFailed 每次模块加载
@@ -380,26 +381,32 @@ export default function registerWebuiRoutes(app, ctx) {
               send({ type: "pending" });
             }),
           );
-          // DSH 设置变更转发（bridge $events 订阅 → 总线 events 频道 → 这里过滤）：
-          // settings/document-updated 的 ui-theme 命名空间 = 主题偏好变更，推给壳页
-          // 转告注入脚本重读偏好（事件驱动替代 3s 轮询 settings/describe）。
-          unsubs.push(
-            g.dshanaBus.on("events", (frame) => {
-              if (closed) return;
-              if (!frame || frame.type !== "emit") return;
-              if (
-                frame.event === "settings/document-updated" &&
-                Array.isArray(frame.args) &&
-                frame.args[0] === "ui-theme"
-              ) {
-                send({
-                  type: "theme-pref",
-                  ns: "ui-theme",
-                  revision: frame.args[1] ?? null,
-                });
-              }
-            }),
-          );
+          // DSH 设置变更转发（theme-pref）：settings/document-updated 的 ui-theme 命名空间
+          // = 主题偏好变更，推给壳页转告注入脚本重读偏好（事件驱动替代 3s 轮询
+          // settings/describe）。事件源：ctx.on 直订优先（refactor/bus-inproc 总线内置化——
+          // DSH Host 事件源头 = cordis ctx，总线只是载波）；ctx 不可用兑底总线 events
+          // （bridge 订阅转发）。
+          const themeFromFrame = (frame) => {
+            if (closed) return;
+            if (!frame || frame.type !== "emit") return;
+            if (
+              frame.event === "settings/document-updated" &&
+              Array.isArray(frame.args) &&
+              frame.args[0] === "ui-theme"
+            ) {
+              send({
+                type: "theme-pref",
+                ns: "ui-theme",
+                revision: frame.args[1] ?? null,
+              });
+            }
+          };
+          const themeCtxOff = subscribeDshCtxEmitEvents(themeFromFrame);
+          if (themeCtxOff) {
+            unsubs.push(themeCtxOff);
+          } else if (g && g.dshanaBus && typeof g.dshanaBus.on === "function") {
+            unsubs.push(g.dshanaBus.on("events", themeFromFrame));
+          }
         }
         // 挂钩 web host 启动失败通知（lifecycle startWebHostFromPlugin catch 调用）。
         // 每次模块加载都重新赋值 notifyWebStartFailed（不设 __webStartFailedHooked 守卫）：

--- a/src/routes/webui.js
+++ b/src/routes/webui.js
@@ -244,10 +244,6 @@ function buildShell({
 
 export default function registerWebuiRoutes(app, ctx) {
   const base = "/api/plugins/" + ctx.pluginId;
-  // 端口：manifest 默认 + 用户配置合并后的 ctx.config；非对象容错回退 3080
-  const cfg =
-    ctx && typeof ctx.config === "object" && ctx.config ? ctx.config : {};
-  const port = Number(cfg.webPort) || 3080;
 
   // 页面（父子双卡，见文件头）：主卡 /main 与子卡 /sidebar 共用同一壳页与自举逻辑，仅
   // iframe 的 view 参数不同（/main → main 视图 = 接收端 receive；/sidebar → sidebar 视图
@@ -262,10 +258,14 @@ export default function registerWebuiRoutes(app, ctx) {
   // （dsh 3080）iframe 同源直嵌提供，无浏览器端劫持/改写。
 
   const page = (view) => async (c) => {
-    // 壳页：iframe 直嵌 @dsh-hanako/app 子插件（dsh 3080）serve 的 fork SPA——
+    // 壳页：iframe 直嵌 @dsh-hanako/app 子插件（DSH server）serve 的 fork SPA——
     // iframe 内同源（资源/API/SSE/WS 全由子插件提供，免鉴权，无劫持无 token/PSS）；
     // 宿主只做页面壳：就绪事件化 / 自举状态 / 主题与剪贴板桥（全部在壳页 JS 里）。
     const ready = busReady();
+    // 随机端口（listen 0 语义，2026-09-06）：实际端口 boot 后写 g.web.port；渲染时动态
+    // 解析（ready 后 g.web 必在，port 已读回）。3080 仅为理论兜底（无 webPort 配置项了）。
+    const g = globalThis.__dshHanako;
+    const port = g?.web?.port || 3080;
     const hc = c.req.query("hana-css") || "";
     const th = c.req.query("hana-theme") || "inherit";
     const hcLink = hc ? `<link rel="stylesheet" href="${esc(hc)}">` : "";

--- a/src/routes/webui.js
+++ b/src/routes/webui.js
@@ -415,10 +415,16 @@ export default function registerWebuiRoutes(app, ctx) {
             });
           }
         };
+        // 订阅注册成功 ≠ producer 可用（CodeRabbit 第二轮 #4）：themeCtxOff truthy 只代表
+        // ctx.on 白名单已挂上；settings/document-updated 的 producer 随 host boot 收敛才
+        // 保证挂载，ctx 有效但 producer 未就绪时 ctx 订阅可能永不触发——保留总线 events
+        // 兜底订阅（双订，不重复：进程内形态总线已退役不发帧；旧形态宿主无 ctx 时
+        // themeCtxOff 为 null 也走总线——两源不会同时活）。
         const themeCtxOff = subscribeDshCtxEmitEvents(themeFromFrame);
         if (themeCtxOff) {
           unsubs.push(themeCtxOff);
-        } else if (g && g.dshanaBus && typeof g.dshanaBus.on === "function") {
+        }
+        if (g && g.dshanaBus && typeof g.dshanaBus.on === "function") {
           unsubs.push(g.dshanaBus.on("events", themeFromFrame));
         }
         if (g && g.dshanaBus && typeof g.dshanaBus.on === "function") {

--- a/src/routes/webui.js
+++ b/src/routes/webui.js
@@ -137,7 +137,7 @@ function readBootState() {
       guidance: null,
       lastError: null,
     },
-    web: { ready: false, lastError: null },
+    web: { ready: false, port: null, lastError: null },
   });
   try {
     const g = globalThis.__dshHanako;
@@ -180,6 +180,12 @@ function readBootState() {
       },
       web: {
         ready: webReady,
+        // 实际监听端口（随机端口 listen 0 语义，boot 后读回）：iframe src 客户端拼装用——
+        // 服务端渲染自举页时端口可能未定，端口固进模板会钉死 3080 兑底（attach 错端口）
+        port:
+          g.web && typeof g.web.port === "number" && g.web.port > 0
+            ? g.web.port
+            : null,
         lastError: tail(g.webLastError, 800),
       },
     };

--- a/src/tools/subtool/approve.js
+++ b/src/tools/subtool/approve.js
@@ -87,13 +87,26 @@ async function doExecute(input, ctx) {
     eventId: ap.eventId,
     outcome: { kind: "result", value: outcome },
   };
-  // 经总线 rpc.request method="respond" 发送（bus 翻译器自环 /api/$events/result，
-  // clientId 由总线事件流补齐；回投 { accepted } = ConnectionRpcResult.ok 转译）
-  const j = await callUnaryBus("respond", body);
-  if (!j || !j.accepted) {
-    throw new Error(
-      `审批应答未接受（${(j && j.reason) || "unknown"}）：可能已超时或被其他方处理，任务侧会自行感知`,
-    );
+  if (typeof ap._respond === "function") {
+    // ACP 会话审批（feat/acp-channel L4）：审批请求经 request_permission 反向到宿主
+    // client（acp-mount onRequest handler），本工具应答 = resolve 该挂起（optionId
+    // allow-once/reject-once 映射）——agent 即收决策，不碰 HTTP respond。
+    await ap._respond(outcome);
+    if (typeof ap._cancelTimer === "function") {
+      try {
+        ap._cancelTimer();
+      } catch {
+        /* 超时表清理失败忽略 */
+      }
+    }
+  } else {
+    // HTTP/旧形态会话审批：client-response 信封经 /api/respond（/api/$events/result）
+    const j = await callUnaryBus("respond", body);
+    if (!j || !j.accepted) {
+      throw new Error(
+        `审批应答未接受（${(j && j.reason) || "unknown"}）：可能已超时或被其他方处理，任务侧会自行感知`,
+      );
+    }
   }
 
   ap.status = "answered";

--- a/src/tools/subtool/run.js
+++ b/src/tools/subtool/run.js
@@ -111,13 +111,18 @@ const toolCallCache = new Map();
 // 误判为完成）。前提：同一 sessionId 多轮 prompt（resume 复用会话）时条目被当轮覆盖——
 // dsh 会话串行（上一轮终态 finally 已删条目），当轮条目语义正确。
 
-function createOpEntry(sessionId) {
+function createOpEntry(sessionId, meta) {
   const g = getSingleton();
   // 协调态最小化：task/sessionId/approvalPending 均不再存（task 原文在 jsonl user/message，
-  // sessionId 即键，approvalPending 由 activeApprovals 是否有 pending 项推出）
+  // sessionId 即键，approvalPending 由 activeApprovals 是否有 pending 项推出）。
+  // ACP 审批协调补充（L4）：sessionPath/task/rpcId 供 acp-mount 的 request_permission
+  // handler 投递 interlude 审批通知（notifyApprovalWake 需要宿主会话关联）。
   g.ops.set(sessionId, {
     activeApprovals: [],
     cancelledRequested: false,
+    sessionPath: meta?.sessionPath ?? null,
+    task: meta?.task ?? null,
+    rpcId: meta?.rpcId ?? null,
   });
   return sessionId;
 }
@@ -590,7 +595,11 @@ function submitTask(
       // 同 sessionId 多轮 prompt（resume 复用会话）时条目被当轮覆盖：dsh 会话串行
       // （上一轮终态 finally 已删条目），当轮条目语义正确。
       taskRpcId = promptMeta.rpcId || "";
-      createOpEntry(sessionId);
+      createOpEntry(sessionId, {
+        sessionPath,
+        task: taskText,
+        rpcId: taskRpcId,
+      });
       // 宿主 task 体系接入：任务注册（type: 'dsh'，taskId = sessionId——取消链路经宿主
       // task:abort → handler.abort → session.cancel，Agent 取消统一走宿主 task 能力，
       // dsh_cancel 不再直连）。注册失败不阻断任务（宿主面板不可见，任务照跑；终态同步

--- a/src/tools/subtool/run.js
+++ b/src/tools/subtool/run.js
@@ -370,8 +370,32 @@ function submitTask(
               if (sid !== sessionId) continue;
               if (!evObj || typeof evObj.type !== "string") continue;
               if (evObj.type === "turn/end") {
+                // 终态前先判 reason.kind（CodeRabbit #12）：reason.kind==="error" 的失败回合
+                //（LLM 输出校验失败/内部错误）不得被 finishFromProjection 当正常成功上报。
+                const r = (evObj && evObj.data && evObj.data.reason) || null;
+                const kind = r && r.kind;
+                if (kind === "error") {
+                  // 失败回合：从 reason.error/failure（或 pendingFailure 兜底）取错误消息作
+                  // error outcome。normal 完成/aborted 走既有路径：aborted 由 abortPromise/
+                  // 上层 DSH_ABORTED 判终，这里不把失败回合当成功 end_turn。
+                  const f =
+                    (r && (r.failure || r.error)) ||
+                    pendingFailure ||
+                    { message: "DSH turn 失败（reason.kind=error 无错误详情）" };
+                  outcome = {
+                    stopReason: "error",
+                    failure: {
+                      message: String(
+                        (f && (f.message || "")) ||
+                          (r && r.message) ||
+                          "DSH turn 失败",
+                      ),
+                    },
+                  };
+                  return; // 终态：失败回合（outcome 已判 error）
+                }
                 finishFromProjection();
-                return; // 终态：turn 回合结束（projcache 已写 title/stats）
+                return; // 终态：turn 回合结束（正常/end_turn）
               }
               if (evObj.type === "assistant/message") {
                 // 从事件 data.message.content 提取真正的助手文本（CodeRabbit #11）：不走

--- a/src/tools/subtool/run.js
+++ b/src/tools/subtool/run.js
@@ -318,42 +318,66 @@ function submitTask(
     let pendingFailure = null;
 
     const consume = (async () => {
+      // finishFromProjection：终态统一收尾（HTTP 会话经 api-session/status running=false，
+      // ACP 会话不经 session-controller——经 session/event 的 turn/end 帧）。两者共读会话
+      // 投影（projcache）：title 作为 collected 输出 + tokenUsage 汇总 → outcome。
+      const finishFromProjection = () => {
+        const proj = readSessionProjection(cfg.dataDir, sessionId);
+        if (proj) {
+          const pv = proj.record?.rows;
+          const title = pv?.title?.val ?? null;
+          if (typeof title === "string" && title && !collected) {
+            collected = title;
+            blocksSeq.push({ type: "text", text: title });
+          }
+          const tu = pv?.tokenUsage?.val;
+          if (tu) {
+            usageTotal = usageTotal || {};
+            const totals = tu.totals || {};
+            if (totals.uncachedInputTokens != null)
+              usageTotal.inputTokens = totals.uncachedInputTokens;
+            if (totals.outputTokens != null)
+              usageTotal.outputTokens = totals.outputTokens;
+            if (totals.cacheReadTokens != null)
+              usageTotal.cacheReadTokens = totals.cacheReadTokens;
+          }
+        }
+        outcome = pendingFailure
+          ? { stopReason: "error", failure: pendingFailure }
+          : { stopReason: "end_turn" };
+      };
       try {
         for await (const frame of openMux(base, ac.signal)) {
           // ---- dsh 0.1.2 事件帧适配（openMux 产出 emit/waterfall）----
           // 0.1.2 的 $events 只广播 api-session/*（added/removed/status/error/activity），
           // 无 assistant/chunk/turn 内容事件——内容经会话投影（projcache）读取。
+          // ACP 会话的事件走 session/event 通用广播（不经 session-controller）——
+          // turn/end 即终态（与 api-session/status false 同义，双通道互不冲突先到先收）。
           if (frame.type === "emit") {
             const ev = frame.event;
             const args = Array.isArray(frame.args) ? frame.args : [];
+            if (ev === "session/event") {
+              const [session, evObj] = args;
+              const sid = session && (session.id ?? null);
+              if (sid !== sessionId) continue;
+              if (!evObj || typeof evObj.type !== "string") continue;
+              if (evObj.type === "turn/end") {
+                finishFromProjection();
+                return; // 终态：turn 回合结束（projcache 已写 title/stats）
+              }
+              if (evObj.type === "assistant/message") {
+                // 0.1.2 内容走 projcache（title 已收）——消息帧不重复收集；若 proj 缺
+                // title 可在此兜底（暂无需要，保留分支便于后续扩展）
+                continue;
+              }
+              continue;
+            }
             if (ev === "api-session/status") {
               const [sid, running] = args;
               if (sid !== sessionId) continue;
               if (running !== false) continue; // 运行中：等待终态
               // 终态：agent 回合结束（status false）。结果从会话投影读取。
-              const proj = readSessionProjection(cfg.dataDir, sessionId);
-              if (proj) {
-                const pv = proj.record?.rows;
-                const title = pv?.title?.val ?? null;
-                if (typeof title === "string" && title && !collected) {
-                  collected = title;
-                  blocksSeq.push({ type: "text", text: title });
-                }
-                const tu = pv?.tokenUsage?.val;
-                if (tu) {
-                  usageTotal = usageTotal || {};
-                  const totals = tu.totals || {};
-                  if (totals.uncachedInputTokens != null)
-                    usageTotal.inputTokens = totals.uncachedInputTokens;
-                  if (totals.outputTokens != null)
-                    usageTotal.outputTokens = totals.outputTokens;
-                  if (totals.cacheReadTokens != null)
-                    usageTotal.cacheReadTokens = totals.cacheReadTokens;
-                }
-              }
-              outcome = pendingFailure
-                ? { stopReason: "error", failure: pendingFailure }
-                : { stopReason: "end_turn" };
+              finishFromProjection();
               return; // 0.1.2：status false 即终态
             } else if (ev === "api-session/error") {
               const [sid, message] = args;

--- a/src/tools/subtool/run.js
+++ b/src/tools/subtool/run.js
@@ -314,6 +314,11 @@ function submitTask(
 
     let collected = "";
     let blocksSeq = []; // assistant/message 的 blocks（终态回调输出结构化，reasoning 可折叠）
+    // 最新一条 assistant/message 的纯文本（CodeRabbit #11）：从事件 data.message.content 经
+    // textFromMessageBlocks 提取真助手文本（非会话 title 元数据）。turn/end 时以它为最终
+    // assistant output——覆盖式保留 turn 内最后一条真正的助手答复。
+    let lastAssistantText = "";
+    const seenMsgIds = new Set(); // assistant/message 去重（防事件边界重放）
     let sawChunk = false;
     const seen = new Set();
     let outcome = null; // { stopReason, failure? }
@@ -324,17 +329,15 @@ function submitTask(
 
     const consume = (async () => {
       // finishFromProjection：终态统一收尾（HTTP 会话经 api-session/status running=false，
-      // ACP 会话不经 session-controller——经 session/event 的 turn/end 帧）。两者共读会话
-      // 投影（projcache）：title 作为 collected 输出 + tokenUsage 汇总 → outcome。
+      // ACP 会话不经 session-controller——经 session/event 的 turn/end 帧）。tokenUsage 汇总
+      // 自会话投影（projcache）。assistant output 用事件循环累计的真助手文本（CodeRabbit
+      // #11）——不再拿 projcache 的 title 元数据冒充助手输出（title 是会话标题，不是回答）。
       const finishFromProjection = () => {
+        // 终端前把事件循环累计的最后一条真正的助手答复定为 collected（有正文才覆盖）。
+        if (lastAssistantText) collected = lastAssistantText;
         const proj = readSessionProjection(cfg.dataDir, sessionId);
         if (proj) {
           const pv = proj.record?.rows;
-          const title = pv?.title?.val ?? null;
-          if (typeof title === "string" && title && !collected) {
-            collected = title;
-            blocksSeq.push({ type: "text", text: title });
-          }
           const tu = pv?.tokenUsage?.val;
           if (tu) {
             usageTotal = usageTotal || {};
@@ -371,8 +374,36 @@ function submitTask(
                 return; // 终态：turn 回合结束（projcache 已写 title/stats）
               }
               if (evObj.type === "assistant/message") {
-                // 0.1.2 内容走 projcache（title 已收）——消息帧不重复收集；若 proj 缺
-                // title 可在此兜底（暂无需要，保留分支便于后续扩展）
+                // 从事件 data.message.content 提取真正的助手文本（CodeRabbit #11）：不走
+                // title 元数据冒充输出。text block 拼接为 lastAssistantText（turn 内最后一条
+                // 助手答复即最终 output）；去重防边界重放。blocks 镜像卡片口径累积到 blocksSeq
+                //（text/reasoning/tool-call），供终态结构化重建/下游取用。
+                const msg =
+                  (evObj && evObj.data && evObj.data.message) || null;
+                const id = (msg && typeof msg.id === "string" && msg.id) || "";
+                if (id) {
+                  if (seenMsgIds.has(id)) continue;
+                  seenMsgIds.add(id);
+                }
+                const blocks = Array.isArray(msg && msg.content)
+                  ? msg.content
+                  : [];
+                const msgText = textFromMessageBlocks(blocks);
+                for (const b of blocks) {
+                  if (!b) continue;
+                  if (b.type === "text" && typeof b.text === "string" && b.text) {
+                    blocksSeq.push({ type: "text", text: b.text });
+                  } else if (
+                    b.type === "reasoning" &&
+                    typeof b.text === "string" &&
+                    b.text
+                  ) {
+                    blocksSeq.push({ type: "reasoning", text: b.text });
+                  } else if (b.type === "tool-call" && b.name) {
+                    blocksSeq.push({ type: "tool-call", name: b.name });
+                  }
+                }
+                if (msgText) lastAssistantText = msgText;
                 continue;
               }
               continue;


### PR DESCRIPTION
## 目标

做到让 port 只用于用户界面（cards/WebUI）——DSH 任务通讯（指令 + 事件 + 审批）全链进程内化，零端口。

## 演进路径（15 commits）

**端口演进起步**
- `a6b7719` DSH WebUI 随机端口（listen 0 语义），删 webPort 配置项
- `caca48b` iframe src 随机端口固进模板钉死 3080 兑底

**总线退役（WS → ctx 直订）**
- `efe6675` 事件链路 ctx.on 直订（免 WS/总线绕圈，不依赖端口）
- `fb3efb9` 宿主停连 dshana.bus WS，provider push / 壳页信号 ctx 化
- `b95e1e1` config 下发进程内化（修 DSH 卡「总线配置未就绪」）
- `fea5363` cordis bridge/bus 用 bus-inproc 版（master 版与 dsh 0.1.2 组合 boot 失败修复）

**ACP 进程内内部通讯通道（L1/L2）**
- `43eefa6` L1：boot 挂 dsh-acp + client 单例
- `18153ee` L2 第一刀：session.create/prompt 走 ACP 内部通道（prompt = fire-and-forget，终态由事件流判定）
- `252f370` L2 补全：list/selectModel/cancel 切 ACP

**事件面与卡片修复（L3）**
- `bc153cf` ACP 会话事件面接入 session/event 通用广播（run.js 终态 + 卡片状态流）
- `2194b38` 卡片「任务记录不存在」修复（ACP jsonl 无 rpcId → 退化取最近 prompt）
- `73e5b54` WebUI 壳页 ready 收不到修复（busReady 退役后就绪判定对齐 web.ready）

**审批应答（L4，三轮收敛）**
- `4fbb311` 第一版：ACP request_permission 应答（实证不触发——dsh-acp 无 scope ctx.on 被 agent-scope filter 挡）
- `3159b3e` 第二版：ctx approval/request global listener 认领（实证仍静默）
- `82d5f89` 完成版：**global + prepend** listener 收 agent-scope waterfall——prepend 是 agent-scope 分发的可靠注册形态（仅 global 实证两轮静默）。审批经 deferred 通知宿主 Agent（toolName/args/reason 全带），dsh_approve 应答闭环

## 验证记录

- 事件面通（session/event 终态即时 resolved，旧形态挂 6 分钟）
- 全 ACP 通（create→selectModel→prompt 全 ACP 零 HTTP 噪音，卡片正常）
- 取消通（挂起中 cancel → aborted）
- **审批闭环通**（越界写 → 审批通知 → allowed-once → 文件真写入 → 任务 ok；rejected/超时/无 op 均 fail-closed）

## 当前 HTTP 面

- `/api` 消费者：WebUI（壳页/卡片资源，UI 面）+ respond 兜底（旧形态会话审批应答兼容，ACP 会话已走 ctx 直答不经它）
- DSH Web UI 随机端口（不再配置化，仅 UI 消费）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added faster in-process ACP communication with HTTP fallback.
  - Added automatic agent preset setup and configurable reasoning effort for ACP sessions.
  - Improved session event streaming, operation tracking, approvals, and cancellations.
  - Added direct provider synchronization and event-based updates.
  - Added dynamic web-host ports and iframe updates without remounting.

- **Bug Fixes**
  - Improved readiness checks and fallback behavior.
  - Prevented stale event listeners across reloads.
  - Improved cancellation, approval timeout, and error handling.

- **Configuration**
  - Removed the configurable `webPort` setting; runtime-assigned ports are used automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->