### PR TITLE
chore(manifest): minAppVersion 调回 0.520.0

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,7 +5,7 @@
   "version": "1.0.0-beta.5+dsh-0.1.2-rc.1",
   "description": "DSHana: DeepSeek Harness as a subagent for HanaAgent",
   "author": "Nyaser",
-  "minAppVersion": "0.810.0",
+  "minAppVersion": "0.520.0",
   "trust": "full-access",
   "ui": {
     "hostCapabilities": [


### PR DESCRIPTION
## 变更

`src/manifest.json` 的 `minAppVersion` 从 0.810.0 调回 0.520.0。

## 背景

宿主版本门槛调整：0.450.0 以上即内测版宿主，0.520.0 为有意设定的兼容声明。纯 manifest 字段变更，无功能影响。

## 验证

- manifest JSON 结构合法（minAppVersion 为字符串语义版本）
- 不涉及代码/构建/依赖改动，无构建验证需求

## 备注

本分支原包含 pnpm 12.3.4 升级（`chore/deps-pnpm-12`），因 pnpm 12 将 CLI 改为 native binary 形态（主 tarball 不再含 `dist/pnpm.mjs`），与插件运行时 pnpm 自举链路不兼容，已回退（rebase 移除该提交）。本 PR 仅保留 manifest 改动。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Expanded support to include application versions from 0.520.0 onward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->