### PR TITLE
fix(app): 工具上下文补齐 runtime/tasks 宿主能力（list/get 与句柄路径）

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,10 +69,14 @@ export function apply(ctx) {
   // 工具名 = dshSession.name（"dshana_session"，全局唯一；v2 不自动加前缀，重名会被宿主
   // 当场拒掉）。action 参数与返回语义见 tools/session.js。
   // 每个 execute 收到一个工具上下文（v2 execute 上下文袋缺省兼容）：log 走宿主 ctx.logger；
-  // dataDir/config 供工具业务读取。
+  // dataDir/config 供工具业务读取；runtime/tasks 是工具面的宿主能力出口——list/get 经
+  // ctx.runtime.fetch 发受管服务请求（lib/controller.js），句柄路径经 ctx.tasks.get 校验
+  // 任务归属（tools/session.js resolveTarget）——缺了它们这两条路在真机上直接失败。
   const makeToolCtx = () => ({
     dataDir,
     config: ctx.config,
+    runtime: ctx.runtime,
+    tasks: ctx.tasks,
     log: {
       debug: (...a) => log("debug", ...a),
       info: (...a) => log("info", ...a),


### PR DESCRIPTION
## 问题

`makeToolCtx`（src/index.ts）构造的工具执行上下文缺 `runtime` / `tasks` 两个成员，而工具链上正好有两处要从工具上下文读宿主能力：

- **list/get**：`subtool/query → lib/controller.ts` 的 `invokeControl` 读 `ctx.runtime.fetch` 发受管服务请求。缺失时真机报 `宿主不支持 ctx.runtime.fetch（受管服务请求）——需要 Hana 0.944+`，读面整体不可用。
- **句柄路径**（get/cancel/approve 传 `taskId`/`approvalId`）：`tools/session.ts` 的 `resolveTarget` 读 `ctx.tasks.get` 校验任务归属。缺失时读回 null，按 fail-closed 拒绝（`宿主任务记录里没有来源会话字段（异常状态），已按 fail-closed 拒绝。`）——即「句柄默认」调用模型在真机上不可用。

create/send 提交链与 cancel/approve 的其余链路走模块级 `appCtx()`（完整宿主 ctx），不受影响，所以此前只有这两条路暴露出来。

## 修正

工具上下文补齐 `runtime: ctx.runtime` 与 `tasks: ctx.tasks`（值即 apply(ctx) 收到的宿主能力对象，与 appCtx() 同源，不引入新的生命周期面）。

## 验证

- 三域类型检查 + 全量构建通过；全量单测 278/279 通过（1 跳过）。
- 装包真机（Hana 0.951.4）：修复前 list/get 复现 `ctx.runtime.fetch` 缺失报错；修复后 `create → 终态 completed → get` 取回本轮结论文本，读面端到端通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool execution can now access managed runtime requests and validate task ownership through the execution context.
* **Documentation**
  * Updated contextual guidance to describe the available runtime and task capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->